### PR TITLE
Use a forward slash in the default download path

### DIFF
--- a/src/downloadmanagerwidget.cpp
+++ b/src/downloadmanagerwidget.cpp
@@ -26,7 +26,7 @@ void DownloadManagerWidget::downloadRequested(
   QDir().mkpath(path);
 
   auto proposed_file_name =
-      path + QDir::separator() + download->downloadFileName();
+      path + QLatin1Char('/') + download->downloadFileName();
 
   QFileInfo p_file_info(proposed_file_name);
 
@@ -39,7 +39,7 @@ void DownloadManagerWidget::downloadRequested(
     msgBox.setDefaultButton(QMessageBox::Save);
     switch (msgBox.exec()) {
     case QMessageBox::Save: {
-      QString n_proposed_file_name = path + QDir::separator() +
+      QString n_proposed_file_name = path + QLatin1Char('/') +
                                      Utils::generateRandomId(5) + "_" +
                                      download->downloadFileName();
       download->setDownloadFileName(n_proposed_file_name);
@@ -78,7 +78,7 @@ void DownloadManagerWidget::on_open_download_dir_clicked() {
   Utils::desktopOpenUrl(SettingsManager::instance().settings().value("defaultDownloadLocation",
                                    QStandardPaths::writableLocation(
                                        QStandardPaths::DownloadLocation) +
-                                       QDir::separator() +
+                                       QLatin1Char('/') +
                                        QApplication::applicationDisplayName())
                             .toString());
 }

--- a/src/downloadmanagerwidget.cpp
+++ b/src/downloadmanagerwidget.cpp
@@ -20,7 +20,7 @@ void DownloadManagerWidget::downloadRequested(
       SettingsManager::instance().settings().value("defaultDownloadLocation",
                  QStandardPaths::writableLocation(
                      QStandardPaths::DownloadLocation) +
-                     QDir::separator() + QApplication::applicationDisplayName())
+                     QLatin1Char('/') + QApplication::applicationDisplayName())
           .toString();
 
   QDir().mkpath(path);


### PR DESCRIPTION
On Windows `QDir::separator()` returns a backslash, so the default download location was built with mixed separators — the base (`QStandardPaths::DownloadLocation`) already uses `/`, producing paths like `C:/Users/.../Downloads\Whatly`. Using `QLatin1Char('/')` keeps the whole path consistent and matches Qt's internal convention (Qt uses `/` on every platform). No behavioural change on Linux/macOS.
