### PR TITLE
Keep the custom notification popup on-screen (top-right)

### DIFF
--- a/src/notificationpopup.h
+++ b/src/notificationpopup.h
@@ -115,8 +115,12 @@ protected slots:
       }
 
       QRect screenRect = screen->availableGeometry();
-      int x = (screenRect.x() + screenRect.width() - 20) - this->width();
-      int y = 40;
+      // Finalise the size first — otherwise width()/height() are stale here and
+      // the popup lands off the corner with its top and left edges clipped.
+      this->adjustSize();
+      const int margin = 20;  // keep at least a character clear of the screen edge
+      int x = screenRect.x() + screenRect.width() - this->width() - margin;
+      int y = screenRect.y() + margin;
 
       QPropertyAnimation *a = new QPropertyAnimation(this, "pos");
       a->setDuration(200);


### PR DESCRIPTION
The custom notification popup was positioned so its top and left edges could be clipped off the screen. Anchor it to the top-right of the screen's *available* geometry with a small (20px) margin, so it always appears fully on-screen.

Note: this is the non-Linux popup path — on Linux, notifications go through libnotify.
