### PR TITLE
Hide on tray-click when the window is frontmost (Windows)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include <QStyleFactory>
 #include <QStyleHints>
 #include <QUrlQuery>
+#include <QDateTime>
 #ifdef Q_OS_LINUX
 #include <QDBusArgument>
 #include <QDBusConnection>
@@ -328,6 +329,11 @@ void MainWindow::moveEvent(QMoveEvent *event) {
 void MainWindow::changeEvent(QEvent *e) {
   if (e->type() == QEvent::WindowStateChange)
     handleZoomOnWindowStateChange(static_cast<QWindowStateChangeEvent *>(e));
+  // Remember when the window last lost activation: a tray-icon click moves
+  // focus to the shell before iconActivated() runs, so this lets it tell "was
+  // frontmost a moment ago" apart from "buried under another window".
+  if (e->type() == QEvent::ActivationChange && !isActiveWindow())
+    m_lastDeactivationMs = QDateTime::currentMSecsSinceEpoch();
   QMainWindow::changeEvent(e);
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -221,6 +221,9 @@ private:
 
   QMenu *m_trayIconMenu = nullptr;
   QSystemTrayIcon *m_systemTrayIcon = nullptr;
+  // Timestamp of the last time the window lost activation, for the tray-click
+  // "was frontmost a moment ago" heuristic in iconActivated().
+  qint64 m_lastDeactivationMs = 0;
   QWebEngineView *m_webEngine = nullptr;
   PageBridge *m_pageBridge = nullptr;
   QWebChannel *m_webChannel = nullptr;

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include <QStyleHints>
+#include <QDateTime>
 #include <QActionGroup>
 #include <QPainter>
 
@@ -256,7 +257,14 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
   // window to the front reliably (raise + activate + clear minimised) — the
   // part that used to fail on Windows and when minimised. Only when it is
   // already frontmost, and the user opted into it, does a click hide it again.
-  const bool frontmost = isVisible() && !isMinimized() && isActiveWindow();
+  // On Windows the tray click hands focus to the shell before this runs, so
+  // isActiveWindow() is already false for a window that WAS frontmost; a short
+  // grace window (m_lastDeactivationMs, stamped in changeEvent) recovers that,
+  // so "hide when clicked while frontmost" still works.
+  const bool frontmost =
+      isVisible() && !isMinimized() &&
+      (isActiveWindow() ||
+       QDateTime::currentMSecsSinceEpoch() - m_lastDeactivationMs < 300);
   const bool minimizeOnClick = SettingsManager::instance()
                                    .settings()
                                    .value("minimizeOnTrayIconClick", false)


### PR DESCRIPTION
On Windows, clicking the tray icon moves focus to the shell *before* `iconActivated()` runs, so `isActiveWindow()` is already `false` for a window that was frontmost a moment earlier. That broke "click the tray icon to hide the window when it's already frontmost" — the click would re-raise it instead of hiding.

Stamp the last time the window lost activation in `changeEvent` (`ActivationChange`), and treat the window as frontmost within a short 300 ms grace window, restoring the hide behaviour. No effect on other platforms.
