### PR TITLE
Redesign the settings page: collapsible sections, clearer labels, and translations

### DIFF
--- a/src/i18n/ar_SA.ts
+++ b/src/i18n/ar_SA.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>التبرع عبر PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>التقييم في المتجر</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>تطبيقات أخرى</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>الشيفرة المصدرية</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ينسخ معلومات التصحيح أدناه إلى الحافظة ويفتح متتبّع المشكلات، حتى يمكن لصقها مباشرة في التقرير.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>الإبلاغ عن خطأ</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>معلومات التنقيح</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>الإصدار: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>كانت معلومات التصحيح أطول من أن يحملها المتصفح، لذا نُسخت إلى الحافظة. الصقها في التقرير.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | حول</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>الشروق</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>الغروب</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  تحديث </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>التعطيل والإغلاق</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  التفعيل والإغلاق</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 يرجى المحاولة مرة أخرى.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>مربع حوار</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>أيقونة</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (افتراضي)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>وردي باربي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>وردي باهت</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>خزامى</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>بنفسجي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>أزرق سماوي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>محيط عميق</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>أزرق مخضر</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>نعناعي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>مرجاني</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>خوخي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>ذهبي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>قرمزي</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>غرافيت</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>لوحة الأوامر</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>اكتب أمرًا…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>بحث الأوامر</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>الأوامر المطابقة</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>تصغير</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>تكبير</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>التنزيلات</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>لا توجد تنزيلات</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>مسح قائمة التنزيلات</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>مسح الكل</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>فتح مجلد التنزيلات في مدير الملفات</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>فتح مجلد التنزيلات</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>يوجد ملف بالاسم نفسه بالفعل!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>حفظ الملف باسم جديد؟</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>فتح الملف بتطبيق النظام</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 بايت</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 ك.بايت</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 م.بايت</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 غ.بايت</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - تم تنزيل %1 من %2 - %3/ث</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>حجم غير معروف - تم تنزيل %1 - %2/ث</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>اكتمل - تم تنزيل %1 - %2/ث</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>أُلغي - تم تنزيل %1 - %2/ث</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>توقّف: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>إيقاف التنزيل</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>إزالة من القائمة</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>تعيين رمز القفل</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>أدخل الرمز</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>أدخل الرمز مرة أخرى</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>تعيين الرمز</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>تنبيه: مفتاح Caps Lock مفعّل</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ملاحظة: يجب أن يزيد الرمز عن 3 أحرف وأن يتطابق في الحقلين.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>أدخل رمزك للوصول</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>أدخل رمزك</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;رمز غير صحيح. يُرجى المحاولة مرة أخرى.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>في انتظار الشبكة…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>لا توجد نافذة واتساب مفتوحة</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>تذكير</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>تذكير: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>يتوفر تحديث</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>الإصدار %1 من Whatly متوفر. انقر لفتح صفحة التنزيل.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| خطأ</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>افتح القفل للوصول إلى الإعدادات.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>تعذّر تهيئة وحدة الإعدادات.
 لم تتم تهيئة WebEngine.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | إجراء مطلوب</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>يجب إعادة تحميل الصفحة للمتابعة.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>محادثة جديدة</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>أدخل رقم WhatsApp صالحًا مع رمز الدولة (مثال: ‎+966XXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>تقييم التطبيق</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 هل تريد فتح الإعدادات الآن؟</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>ملء الشاشة</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>التصغير إلى شريط النظام (&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>استعادة (&amp;R)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>إعادة التحميل (&amp;L)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>قفل (&amp;K)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>كتم الصوت</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>تكبير</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>تصغير</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>إعادة تعيين التكبير</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>الإعدادات (&amp;S)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>الرسائل المجدولة…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>تبديل السمة (&amp;T)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>عرض بعلامات تبويب</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>عرض شبكي</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>لوحة الأوامر</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>حول (&amp;A)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>خروج (&amp;Q)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>إعادة التحميل</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>التصغير إلى شريط النظام</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>قفل</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>كتم الصوت</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>محادثة جديدة / فتح URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>تبديل السمة</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>خروج</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>إعادة تسمية…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>إزالة الحساب</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>التبديل إلى الحساب: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>إضافة حساب…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>إدراج: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 غير مقروءة</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>إضافة حساب آخر</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>استعادة</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>رسائل</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>رسالة</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>إضافة حساب</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>اسم الحساب الجديد:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>الحساب %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>إعادة تسمية الحساب</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>اسم الحساب:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>الحساب 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>افتح القفل لإعادة تحميل التطبيق.</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>المصادقة مطلوبة</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>أيقونة</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>معلومات</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>اسم المستخدم:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>كلمة المرور:</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>الميزة</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>الحالة</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>قائمة المحادثات</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>المحادثة المفتوحة</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>قائمة المحادثات والمحادثة</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>كل شيء، بما في ذلك الصور</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>إظهار معلومات التنقيح</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>إخفاء معلومات التنقيح</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>لا يوجد ما يُنقل من &quot;%1&quot; — تم النقل بالفعل، أو لم يُعثر على بيانات.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>سيتم النسخ:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>تم النسخ:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>أعد التشغيل بدون --dry-run لتنفيذ النسخ.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>عميل WhatsApp Web غني بالمزايا ومبني على Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>يعرض المساعدة الخاصة بخيارات سطر الأوامر</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>يفتح الإعدادات في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>يقفل نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>يفتح نافذة «حول» في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>يفتح مربع حوار الرسائل المجدولة في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>يبدّل بين السمة الفاتحة والداكنة في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>يعيد تحميل التطبيق في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>يفتح نافذة محادثة جديدة في نسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;التشغيل كحساب منفصل بجلسته وإعداداته الخاصة، في نافذته الخاصة&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>يعرض النافذة الرئيسية للنسخة قيد التشغيل من </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>انسخ الإعدادات والجلسة المسجّلة من تثبيت سابق (مثل إصدار &quot;whatsie&quot; القديم) إلى هذا، ثم اخرج</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>مع --migrate-from، أبلغ فقط عمّا سيتم نسخه</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>طباعة عدد الرسائل غير المقروءة الحالي ثم الخروج</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>لم يُضبط قفل التطبيق.
 يُرجى ضبط كلمة المرور في الإعدادات أولاً.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>جارٍ إعادة التحميل...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>وضع التثبيت</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>فرع المصدر</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>بصمة الإيداع</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>تاريخ البناء</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>إصدار Qt وقت التشغيل</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>إصدار Qt وقت الترجمة</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>البنية</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>استثناء</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> واجه مشكلة.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> قد يحتاج إلى إعادة التشغيل. يُرجى إبلاغ المطوّر بالخطأ.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>تعذّر تشغيل &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>لا شيء لنسخه احتياطيًا</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>تعذّر إنشاء %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>تعذّر نسخ %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>تعذّر إنشاء دليل مؤقّت</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>تعذّر استعادة ملف الإعدادات</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>تعذّرت الكتابة إلى %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>التبديل إلى السمة الفاتحة</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>التبديل إلى السمة الداكنة</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>إظهار المحادثات</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>تمويه المحادثات</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>قيّم هذا التطبيق</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;إذا أعجبك هذا التطبيق، فهل تمانع في تخصيص لحظة لتقييمه؟&lt;/p&gt;&lt;p&gt;لن يستغرق الأمر أكثر من دقيقة. شكرًا لدعمك!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  التقييم في المتجر</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>أو</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>امنح مستودع GitHub نجمة</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>التبرع عبر PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>التبرع عبر OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>لاحقًا</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  سبق أن فعلت ذلك  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>انتهت المهلة أثناء انتظار إرسال الرسالة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>يوميًا</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>أيام الأسبوع</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>أسبوعيًا</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>مرة واحدة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>أُرسلت</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>فشل</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>قيد الانتظار</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>الرسائل المجدولة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>إلى</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>متى</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>الرسالة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>الحالة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>رقم الهاتف بالصيغة الدولية، مثال: 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>تسمية اختيارية</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>مرة واحدة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>يوميًا</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>أيام الأسبوع</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>أسبوعيًا</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>تكرار</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>ذكّرني بدلاً من الإرسال (تنبيه دون إرسال رسالة)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>الرسالة المراد إرسالها</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>يجب أن يكون التطبيق قيد التشغيل وواتساب مسجّلاً للدخول في الوقت المحدد. إذا كان مغلقًا، تُرسَل الرسالة في المرة التالية التي تفتح فيها التطبيق. الإرسال يفتح محادثة المستلم.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>جدولة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>إزالة المحدد</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>مسح المُرسَلة/الفاشلة</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>أدخل رقم هاتف ورسالة.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>الوقت في الماضي — هل تريد إرسال هذه الرسالة الآن؟</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>حجم خط الواجهة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> نقطة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;حجم النقطة لواجهة التطبيق نفسه — القوائم والإعدادات والحوارات. لا يؤثر ذلك على نص واتساب ويب؛ استخدم التكبير لذلك.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>سمة العرض</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>إعادة التحميل تلقائيًا بعد التعطل</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;إذا تعطلت عملية صفحة واتساب ويب، فأعد تحميلها تلقائيًا بدلاً من السؤال أولاً.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>الإعدادات العامة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>نمط الودجات</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>سمة الودجات</translation>
+        <translation type="vanished">سمة الودجات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;بناءً على المنطقة الزمنية والموقع في نظامك.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>تلقائي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>داكن</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>فاتح</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يطابق تفضيل سطح المكتب الفاتح/الداكن ويتغيّر معه. يتجاوز السمة اليدوية والتبديل التلقائي عند الشروق/الغروب.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>اتّبع سمة النظام الفاتحة/الداكنة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>إشعار النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>إشعار مخصّص</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  تجربة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>نوع الإشعار</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>تعطيل الإشعارات المنبثقة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>مدة عرض الإشعار</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> ث</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>تسليم الإشعارات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>كيفية إرسال الإشعارات الأصلية على Linux. يستخدم الوضع التلقائي بوابة سطح المكتب داخل بيئة Flatpak المعزولة وخدمة النظام في الحالات الأخرى.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>إيقاف النوافذ المنبثقة للإشعارات خلال فترة هدوء يومية. تظل شارات الرسائل غير المقروءة تُحدَّث؛ ويُحجب المنبثق فقط.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>عدم الإزعاج</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>من</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>إلى</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>كلمات مفتاحية مميزة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>كلمات مفصولة بفواصل تُرسل إشعارًا دائمًا، حتى أثناء وضع عدم الإزعاج (غير حساسة لحالة الأحرف).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>مثال: عاجل، المدير، فاتورة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>استخدام مربع حوار الملفات الخاص بالنظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>كتم صوت الصفحة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>تعطيل التشغيل التلقائي للوسائط</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>البدء مصغّرًا في شريط النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>الإظهار/الإخفاء عند النقر على أيقونة شريط النظام (إن كان مدعومًا)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يغلق لوحة الرموز التعبيرية وصور GIF والملصقات عند النقر في مكان آخر. وإلا فإن WhatsApp Web يبقيها مفتوحة حتى يُضغط الزر مجددًا.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>إغلاق لوحة الرموز/الملصقات عند النقر خارجها</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>لغة الواجهة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;لغة واجهة Whatly نفسها. تسري بعد إعادة تشغيل التطبيق. لغة المحادثات تأتي من WhatsApp Web ولا يمكن تغييرها هنا.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يضيف زر فاتح/داكن إلى الشريط الجانبي لـ WhatsApp، فوق صورة ملفك الشخصي مباشرة.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>زر السمة في الشريط الجانبي لـ WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يضيف زرًا إلى الشريط الجانبي لـ WhatsApp يموّه محادثاتك ويكشفها بنقرة واحدة، دون فتح الإعدادات.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>زر التمويه في الشريط الجانبي لـ WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يستخدم أيقونة أحادية اللون في شريط النظام تتناسب مع بقية اللوحة، بدلاً من أيقونة WhatsApp الخضراء. كما تخفت الأيقونة عندما لا يكون WhatsApp متصلاً.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>أيقونة أحادية اللون في شريط النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يجعل التمرير متحركًا بدلًا من القفز سطرًا بسطر.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>تمرير سلس</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS مخصص</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;حمّل ملف .css لإعادة تصميم WhatsApp Web — أوراق أنماط المجتمع (مثل catppuccin) تعمل هنا. تُطبَّق فوق سمة المحادثة.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>اختيار ملف…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>مسح</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يزيل أيقونة شريط النظام بالكامل. بدون شريط للاستعادة منه، يؤدي إغلاق النافذة إلى إنهاء التطبيق بدلاً من إخفائه.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>إخفاء أيقونة شريط النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>عائلة الخط</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;اعرض نص واتساب ويب بخط مثبَّت على نظامك. تُترك الرموز التعبيرية والأيقونات وتنسيق الرسائل أحادي المسافة دون تغيير.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;إخفاء قسم &quot;التحديثات المكتومة&quot; في لوحة الحالة/التحديثات، بحيث لا تظهر حالات جهات الاتصال التي كتمتها إطلاقًا.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>إخفاء تحديثات الحالة المكتومة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يضع خطًا تحت الكلمات الخاطئة أثناء الكتابة ويقترح تصحيحات في قائمة النقر بالزر الأيمن.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>تدقيق الإملاء أثناء الكتابة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;اللغة التي يجري التدقيق وفقها.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>تمويه الخصوصية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يموّه محادثاتك حتى تمرّر المؤشر فوقها، حتى لا يستطيع من يلمح الشاشة قراءتها. تمرير المؤشر فوق صف يكشف ذلك الصف فقط.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>سمة المحادثة</translation>
+        <translation type="vanished">سمة المحادثة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>تدرّج لون المحادثة</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;يعيد تلوين WhatsApp Web نفسه. تحتفظ الصور والصور الرمزية والملصقات بألوانها. يعمل فوق السمة الفاتحة أو الداكنة، أيها كانت نشطة.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>خلفية المحادثة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;استخدم إحدى صورك كخلفية لجزء المحادثة، كما يفعل WhatsApp على Android. تُخزَّن الصورة داخل Whatly، ولا تُرفَع إلى أي مكان، ولا يراها سواك.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>اختيار صورة…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ستظهر عمليات تسجيل الدخول الجديدة في قائمة الأجهزة المرتبطة بهاتفك باسم «Whatly for Linux» (أو المنصة المقابلة) بدلاً من «Google Chrome (Linux)». يُحفظ الاسم في الهاتف عند ربط جهاز، لذا فإن تغيير هذا الخيار يؤثر في عمليات الربط اللاحقة فقط — سجّل الخروج ثم أعد الربط لإعادة تسمية جلسة قائمة.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>التعريف باسم Whatly في الأجهزة المرتبطة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>وكيل المستخدم</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;متقدم — لا تغيّر هذا إلا إذا كنت تعرف تمامًا ما تفعله. قد يؤدي وكيل مستخدم (user agent) غير قياسي إلى منع تحميل واتساب، وقد تؤدي القيم غير المعتادة إلى تمييز حساب واتساب الخاص بك أو إدراجه في القائمة السوداء.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  تطبيق</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>إعادة التعيين إلى الافتراضي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>معامل التكبير في النافذة العادية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>تصغير</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>تكبير</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>إعادة تعيين</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>معامل التكبير عند التكبير/ملء الشاشة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>التصغير إلى شريط النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>خروج</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>الاختصارات العامة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>إجراء زر الإغلاق</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  إظهار الاختصارات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>الأذونات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  إظهار الأذونات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;تفعيل شاشة القفل.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>تفعيل قفل التطبيق عند البدء</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;عند إخفاء النافذة إلى شريط النظام، اقفلها خلف رمز المرور. يتطلب تعيين كلمة مرور.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>القفل عند الإخفاء إلى شريط النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>قفل Whatly أيضًا عند قفل جلسة سطح المكتب. يتطلب تعيين كلمة مرور. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>القفل عند قفل الشاشة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>كلمة المرور الحالية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>تغيير كلمة المرور</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>تفعيل القفل التلقائي بعد</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>إعادة تعيين</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>إظهار كلمة المرور</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>مجلد التنزيل الافتراضي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>تغيير مجلد التنزيل</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>التخزين </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>الخاصية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  مسح (يتطلب إعادة التشغيل)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;تشمل البيانات الدائمة ملفات تعريف الارتباط الدائمة وتخزين HTML5 المحلي والروابط المُزارة.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>البيانات الدائمة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>ذاكرة التخزين المؤقت لـ HTTP والوسائط. مسحها آمن — يُعاد تنزيلها عند الحاجة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>ذاكرة التخزين المؤقت</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  مسح ذاكرة التخزين المؤقت</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>الإجراء</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>نسخ احتياطي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>احفظ هذا الحساب (الإعدادات والجلسة والإضافات) في أرشيف .tar.gz. يحتوي الأرشيف على جلستك المسجَّلة الدخول — حافظ على خصوصيته.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>تصدير الملف الشخصي…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>استعادة حساب من أرشيف .tar.gz. يؤدي هذا إلى استبدال البيانات الحالية ويتطلّب إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>استيراد الملف الشخصي…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>الأداء والخصوصية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>ضبط دقيق لمحرّك العرض. الإعدادات الافتراضية آمنة على معظم الأنظمة؛ إذا كانت النافذة فارغة أو تعطّل التطبيق عند البدء، أو حدث تقطّع، فجرّب تغيير هذه الخيارات. تُطبّق التغييرات بعد إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>العرض بالكامل على المعالج (--disable-gpu). يُصلح النوافذ الفارغة وأعطال البدء في بعض إعدادات GPU/التعريف. الافتراضي على Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>تعطيل تسريع GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>تركيب الصفحة على المعالج (--disable-gpu-compositing). يتجنّب وميض الإطارات القديمة على بعض التعريفات.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>تعطيل تركيب GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>تعطيل مزامنة VSync لوحدة GPU (--disable-gpu-vsync). قد يقلّل تأخّر الإدخال على حساب تمزّق الصورة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>تعطيل مزامنة VSync لوحدة GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>تشغيل عملية GPU داخل العملية الرئيسية (--in-process-gpu). حل بديل لبعض الإعدادات المعزولة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>تشغيل GPU داخل العملية</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>فرض التسريع حتى عندما يكون التعريف في قائمة الحظر (--ignore-gpu-blocklist). جرّب هذا لإعادة تشغيل GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>تجاهل قائمة حظر GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>تشغيل كل شيء في عملية واحدة (--single-process). يستهلك ذاكرة أقل لكنه أقل استقراراً.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>وضع العملية الواحدة (ذاكرة أقل)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>مشاركة عملية عرض واحدة لكل موقع (--process-per-site). يقلّل استهلاك الذاكرة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>عملية واحدة لكل موقع (ذاكرة أقل)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>إخفاء أسماء جهات الاتصال ومعاينات الرسائل في قائمة المحادثات (مرّر المؤشر لإظهار واحدة). مفيد عند مشاركة الشاشة. المحادثة المفتوحة تبقى كما هي.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>وضع التركيز (إخفاء معاينات المحادثات)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>اجعل جودة الصور ومقاطع الفيديو HD افتراضيًا في محرر الوسائط. يعتمد ذلك على تخطيط WhatsApp Web؛ إذا تعطّل بسبب تحديث في واتساب، فأوقف تشغيله.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>إرسال الصور ومقاطع الفيديو بجودة HD افتراضيًا</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>منع WebRTC من كشف عنوان IP المحلي الخاص بك عبر الاتصالات غير الوسيطة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>منع تسرّب عنوان IP عبر WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>حد ذاكرة JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>حدّد سقف كومة JavaScript (V8 --max-old-space-size). 0 = تلقائي. قلّله إذا استهلك التطبيق الكثير من RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>ذاكرة تخزين HTTP المؤقتة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>مكان حفظ ذاكرة تخزين HTTP المؤقتة. الذاكرة تُمسح عند الخروج؛ &quot;بلا&quot; يعطّل التخزين المؤقت.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>الحجم الأقصى</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>الحجم الأقصى للذاكرة المؤقتة على القرص. 0 = تلقائي.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>الشبكة &amp; بدء التشغيل</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>تشغيل Whatly تلقائيًا عند تسجيل الدخول إلى جلسة سطح المكتب.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>تشغيل Whatly عند تسجيل الدخول</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>استبدال حدود نافذة النظام بشريط عنوان Whatly النحيل الخاص. يُطبَّق بعد إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>استخدام إطار نافذة مخصص (يتطلب إعادة التشغيل)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>التحقق من GitHub مرة واحدة يوميًا بحثًا عن إصدار أحدث وإعلامك بذلك. لا يقوم Whatly مطلقًا بتنزيل أو تثبيت أي شيء من تلقاء نفسه.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>التحقق من التحديثات تلقائيًا</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>مقياس الواجهة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>تغيير مقياس النافذة والصفحة بالكامل (QT_SCALE_FACTOR). &quot;تلقائي&quot; يتبع سطح المكتب. يتجاوز هذا متغيّر البيئة QT_SCALE_FACTOR إذا كان مضبوطًا. يُطبَّق بعد إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>الوكيل</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>كيفية اتصال Whatly بالشبكة. &quot;النظام&quot; يتبع نظام التشغيل؛ &quot;بلا&quot; يتصل مباشرةً.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>المضيف</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>المنفذ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>اسم المستخدم</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>اختياري</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>كلمة المرور</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>ملحقات JavaScript المخصّصة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>حمّل ملفات ‎.js‎ لتشغيلها على WhatsApp Web. يعمل كل مُلحق في بيئة معزولة خاصّة به، لذا لا يمكن لمُلحق معطوب أن يُعطّل المُلحقات الأخرى أو الصفحة. أزل التحديد عن مُلحق لتعطيله دون حذفه. تُطبَّق التغييرات بعد إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>إضافة مُلحق…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>إزالة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>الردود المحفوظة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>نصوص قصيرة ترسلها كثيرًا. أدرج واحدًا من لوحة الأوامر (Ctrl+K) — اكتب &quot;إدراج&quot; ثم اخترها؛ يُكتب النص في مربع الرسالة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>إضافة رد…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>اختصارات لوحة المفاتيح</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>انقر فوق حقل واضغط على تركيبة المفاتيح. امسح الحقل لإزالة الاختصار. تُطبَّق التغييرات بعد إعادة التشغيل.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>سيؤدي هذا إلى حذف البيانات الدائمة (بما في ذلك ملفات تعريف الارتباط الدائمة وذاكرة التخزين المؤقت) وإغلاق التطبيق.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>حذف ملفات تعريف الارتباط وإغلاق التطبيق؟</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| خطأ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>لا يمكن تعيين سلسلة User-Agent فارغة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>عُطّل التبديل التلقائي للسمة بسبب تغيير السمة يدويًا.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>لم يتم تكوين قفل التطبيق.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>هل تريد إعداد قفل التطبيق الآن؟</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>أذونات الميزات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>اختر خلفية للمحادثة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>صور (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>تعذّر استخدام تلك الصورة: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>اختر ملف CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>أوراق الأنماط (*.css);;كل الملفات (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>تعذّرت قراءة ذلك الملف: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>القرص</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>بلا (مباشر)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>بوابة سطح المكتب (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>خدمة النظام (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>إضافة رد</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>النص المراد إدراجه</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>اختر ملف JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;كل الملفات (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>تعذّرت إضافة المُلحق</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>إزالة المُلحق</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>إزالة المُلحق &quot;%1&quot;؟ سيؤدّي ذلك إلى حذف ملفه.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>المدقق الإملائي (لا توجد قواميس مثبتة)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>لا شيء</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>الأساسيات</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>المظهر</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>الإشعارات</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>المحادثة</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>الخصوصية والقفل</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>النافذة والتكبير</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>متقدم</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>الاختصار قيد الاستخدام</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>هذا الاختصار مستخدَم بالفعل من قِبل إجراء آخر.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>مسح ذاكرة التخزين المؤقت</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>هل تريد مسح ذاكرة التخزين المؤقت الآن؟ سيُعاد تنزيلها عند الحاجة.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>تصدير الملف الشخصي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>سيحتوي الأرشيف على جلسة WhatsApp المسجَّلة الدخول. حافظ على خصوصيته. هل تريد المتابعة؟</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>الأرشيفات (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>تم تصدير الملف الشخصي.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>استيراد الملف الشخصي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>سيؤدي هذا إلى استبدال بيانات الحساب الحالي بمحتوى الأرشيف، ثم يجب إعادة تشغيل Whatly. هل تريد المتابعة؟</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>تم استيراد الملف الشخصي. يُرجى إعادة تشغيل Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 لغات</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>افتراضي واتساب</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>إعداد النظام الافتراضي</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>ستتغيّر لغة الواجهة عند إعادة تشغيل %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>إعداد قفل التطبيق</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>يرجى إعداد كلمة مرور قفل التطبيق أولاً.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>اختر مجلد التنزيل</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 قد تحتاج أيضًا إلى إعادة تشغيل التطبيق بالكامل!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>هل تريد المتابعة؟</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>مرحبًا بك في Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>عميل WhatsApp Web سريع وأصلي لسطح المكتب. لنُعدّ بعض الأمور — يمكنك تغيير كل هذا لاحقًا من الإعدادات.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>يُبقي Whatly محادثاتك في نافذة سطح مكتب حقيقية، مع أيقونة في شريط المهام، وإشعارات، وسمات، وحسابات متعددة.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>بعض التفضيلات</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>إعدادات افتراضية معقولة؛ عدّلها حسب ذوقك.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>مطابقة سمة النظام الفاتحة/الداكنة</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>تشغيل Whatly عند تسجيل الدخول</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>تسليم الإشعارات:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>تلقائي</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>بوابة سطح المكتب (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>خدمة النظام (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>كل شيء جاهز</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>أنت جاهز للبدء. امسح رمز QR بهاتفك لتسجيل الدخول.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>كل ما هنا موجود في الإعدادات إن غيّرت رأيك.</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>تعذّرت قراءة أحدث إصدار</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>شارك شاشتك</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>اختر ما تريد مشاركته:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>بلا عنوان</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>الشاشة: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>النافذة: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>هل تسمح لـ %1 بالوصول إلى معلومات موقعك؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>هل تسمح لـ %1 بالوصول إلى الميكروفون؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>هل تسمح لـ %1 بالوصول إلى الكاميرا؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>هل تسمح لـ %1 بالوصول إلى الميكروفون والكاميرا؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>هل تسمح لـ %1 بحصر مؤشر الفأرة؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>هل تسمح لـ %1 بتسجيل فيديو سطح مكتبك؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>هل تسمح لـ %1 بتسجيل صوت وفيديو سطح مكتبك؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>هل تسمح لـ %1 بعرض الإشعارات على سطح مكتبك؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>هل تسمح لـ %1 بقراءة الحافظة؟ هذا ضروري للصق الصور في المحادثة.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>هل تسمح لـ %1 بالاطلاع على الخطوط المثبّتة في نظامك؟</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>طلب إذن</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>خطأ في الشهادة</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>أدخل اسم المستخدم وكلمة المرور لـ «%1» على %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>الاتصال بالوكيل «%1» باستخدام:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>هل تسمح لـ %1 بفتح جميع روابط %2؟</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>انتهت عملية العرض بشكل طبيعي</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>انتهت عملية العرض بشكل غير طبيعي</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>تعطّلت عملية العرض</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>أُنهيت عملية العرض</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>انتهت عملية العرض بالرمز: %1

--- a/src/i18n/de_DE.ts
+++ b/src/i18n/de_DE.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Über PayPal spenden</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Im Store bewerten</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Weitere Anwendungen</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Quellcode</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kopiert die untenstehenden Debug-Informationen in die Zwischenablage und öffnet den Issue-Tracker, damit sie direkt in den Bericht eingefügt werden können.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Fehler melden</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Debug-Informationen</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Die Debug-Informationen waren zu lang für den Browser und wurden stattdessen in die Zwischenablage kopiert. Fügen Sie sie in das Issue ein.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Über</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Sonnenaufgang</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Sonnenuntergang</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Aktualisieren </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Deaktivieren und schließen</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Aktivieren und schließen</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Bitte versuchen Sie es erneut.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Symbol</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (Standard)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Barbie-Pink</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Altrosa</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavendel</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Violett</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Himmelblau</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Tiefes Blau</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Petrol</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Mint</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Koralle</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Pfirsich</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Gold</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Karmesinrot</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Graphit</translation>
     </message>
@@ -209,18 +256,22 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Befehlspalette</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Befehl eingeben…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Befehlssuche</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Passende Befehle</translation>
     </message>
@@ -228,14 +279,17 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimieren</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maximieren</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
@@ -243,34 +297,42 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Keine Downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Downloadliste leeren</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Alle leeren</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Downloadordner im Dateimanager öffnen</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Downloadordner öffnen</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Eine Datei mit demselben Namen existiert bereits!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Datei unter einem neuen Namen speichern?</translation>
     </message>
@@ -278,54 +340,68 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Datei mit der Systemanwendung öffnen</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 von %2 heruntergeladen - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>unbekannte Größe - %1 heruntergeladen - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>abgeschlossen - %1 heruntergeladen - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>abgebrochen - %1 heruntergeladen - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>unterbrochen: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Download anhalten</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Aus der Liste entfernen</translation>
     </message>
@@ -333,46 +409,58 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Sperrcode festlegen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>Code eingeben</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>Code erneut eingeben</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Code festlegen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Achtung: Feststelltaste ist aktiv</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hinweis: Der Code muss länger als 3 Zeichen sein und in beiden Feldern übereinstimmen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Geben Sie Ihren Code ein, um Zugriff zu erhalten</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>Code eingeben</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Falscher Code. Bitte erneut versuchen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Möchten Sie die Sicherheitsprüfung übergehen und fortfahren?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Warten auf Netzwerk…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Kein WhatsApp-Fenster ist geöffnet</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Erinnerung</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Erinnerung: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Update verfügbar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 ist verfügbar. Klicke, um die Downloadseite zu öffnen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Fehler</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Entsperren, um auf die Einstellungen zuzugreifen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Einstellungsmodul kann nicht initialisiert werden.
 WebEngine ist nicht initialisiert.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Aktion erforderlich</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>Die Seite muss neu geladen werden, um fortzufahren.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Neuer Chat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Geben Sie eine gültige WhatsApp-Nummer mit Ländervorwahl ein (z. B. +49XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Anwendung bewerten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Bitte legen Sie zuerst das Passwort in den Einstellungen fest.
 Einstellungen jetzt öffnen?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>In den Infobereich mi&amp;nimieren</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Neu &amp;laden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>S&amp;perren</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>Ton &amp;stummschalten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Vergrößern</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Verkleinern</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Zoom zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Einstellungen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>Geplante &amp;Nachrichten…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>&amp;Design wechseln</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Tab-Ansicht</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Befehlspalette</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Über</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Neu laden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>In den Infobereich minimieren</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Sperren</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Ton stummschalten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Neuer Chat / URL öffnen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Design umschalten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Umbenennen…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Konto entfernen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Zu Konto wechseln: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Konto hinzufügen…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Einfügen: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 ungelesen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Weiteres Konto hinzufügen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>Nachrichten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Konto hinzufügen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Name für das neue Konto:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Konto %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Konto umbenennen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Kontoname:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Konto 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Entsperren, um die Anwendung neu zu laden.</translation>
     </message>
@@ -623,10 +779,12 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
@@ -641,22 +800,27 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Authentifizierung erforderlich</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Symbol</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informationen</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Benutzername:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Passwort:</translation>
     </message>
@@ -664,14 +828,17 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Funktion</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
@@ -679,22 +846,27 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Chatliste</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Geöffnete Unterhaltung</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Chatliste und Unterhaltung</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Alles, auch Fotos</translation>
     </message>
@@ -702,10 +874,13 @@ Einstellungen jetzt öffnen?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Debug-Informationen anzeigen</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Einstellungen jetzt öffnen?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Debug-Informationen ausblenden</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Nichts von „%1“ zu migrieren – bereits migriert oder keine Daten gefunden.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Würde kopieren:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Kopiert:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Ohne --dry-run erneut ausführen, um die Kopie durchzuführen.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Funktionsreicher WhatsApp-Web-Client auf Basis von Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Zeigt die Hilfe zu den Befehlszeilenoptionen an</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Öffnet die Einstellungen in einer laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Sperrt eine laufende Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Öffnet den Info-Dialog in einer laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Öffnet den Dialog für geplante Nachrichten in einer laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Wechselt zwischen hellem und dunklem Design in einer laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Lädt die Anwendung in einer laufenden Instanz neu von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Öffnet den Dialog für einen neuen Chat in einer laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Als separates Konto mit eigener Sitzung und eigenen Einstellungen in einem eigenen Fenster ausführen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Zeigt das Hauptfenster der laufenden Instanz von </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Einstellungen und die angemeldete Sitzung aus einer früheren Installation (z. B. der älteren „whatsie“-Version) in diese kopieren und dann beenden</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Mit --migrate-from nur anzeigen, was kopiert würde</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Die aktuelle Anzahl ungelesener Nachrichten ausgeben und beenden</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Die App-Sperre ist nicht eingerichtet.
 Bitte legen Sie zuerst das Passwort in den Einstellungen fest.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Wird neu geladen...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Installationsmodus</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Quell-Branch</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Commit-Hash</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Build-Zeitpunkt</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt-Laufzeitversion</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt-Kompilierversion</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Architektur</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Ausnahme</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> ist auf ein Problem gestoßen.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> muss möglicherweise neu gestartet werden. Bitte melden Sie den Fehler dem Entwickler.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>&apos;tar&apos; konnte nicht ausgeführt werden</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Nichts zu sichern</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>%1 kann nicht erstellt werden</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>%1 kann nicht kopiert werden</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Temporäres Verzeichnis kann nicht erstellt werden</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Die Einstellungsdatei konnte nicht wiederhergestellt werden</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>%1 kann nicht geschrieben werden</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Zum hellen Design wechseln</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Zum dunklen Design wechseln</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Chats anzeigen</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Chats verwischen</translation>
@@ -898,42 +1123,53 @@ Bitte legen Sie zuerst das Passwort in den Einstellungen fest.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Diese Anwendung bewerten</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn Ihnen diese Anwendung gefällt, würden Sie sich einen Moment Zeit nehmen, um sie zu bewerten?&lt;/p&gt;&lt;p&gt;Es dauert nicht länger als eine Minute. Vielen Dank für Ihre Unterstützung!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Im Store bewerten</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Oder</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>GitHub-Repository mit einem Stern versehen</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Über PayPal spenden </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Über OpenCollective spenden</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Später</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Bereits erledigt  </translation>
     </message>
@@ -941,34 +1177,42 @@ Bitte legen Sie zuerst das Passwort in den Einstellungen fest.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Zeitüberschreitung beim Senden der Nachricht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Täglich</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Wochentags</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Wöchentlich</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Einmalig</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Gesendet</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Fehlgeschlagen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Ausstehend</translation>
     </message>
@@ -976,90 +1220,117 @@ Bitte legen Sie zuerst das Passwort in den Einstellungen fest.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Geplante Nachrichten</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>An</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Wann</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Telefonnummer im internationalen Format, z. B. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Optionale Bezeichnung</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Einmalig</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Täglich</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Wochentags</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Wöchentlich</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Mich erinnern statt zu senden (benachrichtigen, nicht senden)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Zu sendende Nachricht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>Die App muss laufen und WhatsApp zum geplanten Zeitpunkt angemeldet sein. Ist sie geschlossen, wird die Nachricht beim nächsten Öffnen der App gesendet. Beim Senden wird der Chat des Empfängers geöffnet.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Planen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Auswahl entfernen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Gesendete/fehlgeschlagene löschen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Geben Sie eine Telefonnummer und eine Nachricht ein.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Der Zeitpunkt liegt in der Vergangenheit – diese Nachricht jetzt senden?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Bitte legen Sie zuerst das Passwort in den Einstellungen fest.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Schriftgröße der Oberfläche</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Punktgröße der App-eigenen Oberfläche – Menüs, Einstellungen und Dialoge. Dies wirkt sich nicht auf den Text von WhatsApp Web aus; verwende dafür den Zoom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Anzeigedesign</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Nach einem Absturz automatisch neu laden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn der Seitenprozess von WhatsApp Web abstürzt, ihn automatisch neu laden, statt vorher zu fragen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Allgemeine Einstellungen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Widget-Stil</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Widget-Design</translation>
+        <translation type="vanished">Widget-Design</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Basierend auf Zeitzone und Standort Ihres Systems.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Dunkel</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Hell</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Übernimmt die Hell/Dunkel-Einstellung des Desktops und ändert sich mit ihr. Überschreibt das manuelle Design und den automatischen Sonnenauf-/-untergangswechsel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>System-Hell/Dunkel-Design folgen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Native Benachrichtigung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Angepasste Benachrichtigung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Testen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Benachrichtigungstyp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Benachrichtigungs-Popup deaktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Popup-Anzeigedauer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> Sek.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Benachrichtigungszustellung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Wie native Benachrichtigungen unter Linux gesendet werden. &quot;Automatisch&quot; verwendet das Desktop-Portal innerhalb einer Flatpak-Sandbox, ansonsten den Systemdienst.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Benachrichtigungs-Popups während einer täglichen Ruhezeit unterdrücken. Ungelesen-Markierungen werden weiterhin aktualisiert; nur das Popup wird zurückgehalten.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Nicht stören</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Von</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>bis</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Schlüsselwörter hervorheben</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Durch Kommas getrennte Wörter, die immer benachrichtigen, auch bei „Nicht stören“ (Groß-/Kleinschreibung wird ignoriert).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>z. B. dringend, Chef, Rechnung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Nativen Dateidialog verwenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Ton der Seite stummschalten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Automatische Medienwiedergabe deaktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Beim Start in den Infobereich minimieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Beim Klick auf das Infobereichssymbol ein-/ausblenden (falls unterstützt)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Schließt das Emoji-, GIF- und Sticker-Panel, wenn Sie woanders klicken. Andernfalls lässt WhatsApp Web es geöffnet, bis die Schaltfläche erneut gedrückt wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Emoji-/Sticker-Panel bei Klick außerhalb schließen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Sprache der Oberfläche</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sprache der Whatly-Oberfläche. Wird nach einem Neustart der App wirksam. Die Sprache der Chats stammt von WhatsApp Web und kann hier nicht geändert werden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fügt eine Hell/Dunkel-Schaltfläche in WhatsApps Seitenleiste hinzu, direkt über deinem Profilbild.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Design-Schaltfläche in WhatsApps Seitenleiste</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fügt WhatsApps Seitenleiste eine Schaltfläche hinzu, die deine Chats mit einem Klick unscharf macht und wieder freigibt, ohne die Einstellungen zu öffnen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Unschärfe-Schaltfläche in WhatsApps Seitenleiste</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verwendet ein einfarbiges Tray-Symbol, das zum Rest deiner Leiste passt, statt des grünen WhatsApp-Symbols. Das Symbol wird auch gedimmt, wenn WhatsApp nicht verbunden ist.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Einfarbiges Tray-Symbol</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animiert das Scrollen, statt Zeile für Zeile zu springen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Weiches Scrollen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>Benutzerdefiniertes CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lade eine .css-Datei, um WhatsApp Web umzugestalten – die Community-Stylesheets (catppuccin und Ähnliches) funktionieren hier. Wird über dem Chat-Design angewendet.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Datei auswählen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Löschen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entfernt das Tray-Symbol vollständig. Ohne Tray zum Wiederherstellen beendet das Schließen des Fensters die App, statt sie auszublenden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Tray-Symbol ausblenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Schriftart</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stellt den Text von WhatsApp Web in einer auf Ihrem System installierten Schrift dar. Emojis, Symbole und die dicktengleiche Nachrichtenformatierung bleiben unverändert.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blendet den Bereich „Stummgeschaltete Updates“ im Status-/Updates-Panel aus, sodass Status von stummgeschalteten Kontakten gar nicht erscheinen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Stummgeschaltete Status-Updates ausblenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unterstreicht falsch geschriebene Wörter während der Eingabe und bietet Korrekturen im Rechtsklickmenü an.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Rechtschreibung während der Eingabe prüfen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Die Sprache, gegen die geprüft wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Datenschutz-Unschärfe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Macht deine Chats unscharf, bis du mit der Maus darüberfährst, sodass ein flüchtiger Blick auf den Bildschirm sie nicht lesen kann. Beim Überfahren einer Zeile wird nur diese sichtbar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Chat-Design</translation>
+        <translation type="vanished">Chat-Design</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Farbton des Chats</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Färbt WhatsApp Web selbst um. Fotos, Avatare und Sticker behalten ihre Farben. Funktioniert über dem hellen oder dunklen Design, je nachdem welches aktiv ist.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Chat-Hintergrund</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verwende eines deiner eigenen Bilder als Hintergrund des Chatbereichs, wie WhatsApp unter Android. Das Bild wird in Whatly gespeichert, nirgendwo hochgeladen und ist nur für dich sichtbar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Bild auswählen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Neue Anmeldungen erscheinen in der Liste der verknüpften Geräte Ihres Telefons als „Whatly für Linux“ (oder die entsprechende Plattform) statt als „Google Chrome (Linux)“. Der Name wird beim Verknüpfen eines Geräts auf dem Telefon gespeichert; eine Änderung wirkt sich daher nur auf künftige Verknüpfungen aus. Melden Sie sich ab und verknüpfen Sie erneut, um eine bestehende Sitzung umzubenennen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>In verknüpften Geräten als Whatly ausweisen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User-Agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erweitert — nur ändern, wenn Sie genau wissen, was Sie tun. Ein nicht standardmäßiger User-Agent kann dazu führen, dass WhatsApp nicht mehr lädt, und ungewöhnliche Werte können dazu führen, dass Ihr WhatsApp-Konto markiert oder auf eine schwarze Liste gesetzt wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Anwenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Auf Standard zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Zoomfaktor im normalen Fenster</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Verkleinern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Vergrößern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Zoomfaktor bei Maximierung/Vollbild</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>In den Infobereich minimieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Globale Tastenkürzel</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Aktion der Schließen-Schaltfläche</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Tastenkürzel anzeigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Berechtigungen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Berechtigungen anzeigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sperrbildschirm aktivieren.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>App-Sperre beim Start aktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn sich das Fenster in den System-Tray ausblendet, hinter dem Passcode sperren. Erfordert ein eingerichtetes Passwort.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Beim Ausblenden in den Tray sperren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Whatly auch sperren, wenn die Desktop-Sitzung gesperrt wird. Erfordert ein eingerichtetes Passwort. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Sperren, wenn der Bildschirm gesperrt wird</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Aktuelles Passwort</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Passwort ändern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Automatische Sperre aktivieren nach</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Standard-Downloadordner</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Downloadordner ändern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Speicher </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Eigenschaft</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Leeren (Neustart erforderlich)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zu den persistenten Daten gehören dauerhafte Cookies, HTML5-Local-Storage und besuchte Links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Persistente Daten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>Der HTTP-/Medien-Cache. Das Leeren ist unbedenklich — er wird bei Bedarf erneut heruntergeladen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Cache leeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Sicherung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Dieses Konto (Einstellungen, Sitzung und Add-ons) in einem .tar.gz-Archiv speichern. Das Archiv enthält deine angemeldete Sitzung — halte es privat.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Profil exportieren…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Ein Konto aus einem .tar.gz-Archiv wiederherstellen. Dies überschreibt die aktuellen Daten und erfordert einen Neustart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Profil importieren…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Leistung &amp; Datenschutz</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Feineinstellung der Rendering-Engine. Die Standardwerte sind auf den meisten Systemen sicher; falls das Fenster leer bleibt, die App beim Start abstürzt oder ruckelt, versuche, diese zu ändern. Änderungen werden nach einem Neustart wirksam.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Vollständig auf der CPU rendern (--disable-gpu). Behebt leere Fenster und Startabstürze bei manchen GPU-/Treiberkonfigurationen. Standard unter Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU-Beschleunigung deaktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Die Seite auf der CPU zusammensetzen (--disable-gpu-compositing). Verhindert Flackern durch veraltete Frames bei manchen Treibern.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU-Compositing deaktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU-VSync deaktivieren (--disable-gpu-vsync). Kann die Eingabeverzögerung verringern, allerdings auf Kosten von Tearing.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU-VSync deaktivieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Den GPU-Prozess innerhalb des Hauptprozesses ausführen (--in-process-gpu). Eine Behelfslösung für manche Sandbox-Konfigurationen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU im selben Prozess ausführen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Beschleunigung auch dann erzwingen, wenn der Treiber auf der Sperrliste steht (--ignore-gpu-blocklist). Versuche dies, um die GPU wieder zu aktivieren.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU-Sperrliste ignorieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Alles in einem einzigen Prozess ausführen (--single-process). Verbraucht weniger Speicher, ist aber weniger stabil.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Einzelprozess-Modus (weniger Speicher)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Einen Renderer-Prozess pro Website gemeinsam nutzen (--process-per-site). Reduziert den Speicherverbrauch.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Ein Prozess pro Website (weniger Speicher)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Kontaktnamen und Nachrichtenvorschauen in der Chatliste ausblenden (zum Anzeigen mit der Maus darüberfahren). Nützlich beim Teilen des Bildschirms. Die geöffnete Unterhaltung bleibt unverändert.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Fokusmodus (Chat-Vorschauen ausblenden)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Fotos und Videos im Medien-Editor standardmäßig in HD-Qualität. Hängt vom Layout von WhatsApp Web ab; falls ein WhatsApp-Update es beeinträchtigt, deaktivieren.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Fotos und Videos standardmäßig in HD senden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Verhindert, dass WebRTC deine lokale IP-Adresse über nicht per Proxy geleitete Verbindungen preisgibt.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC-IP-Leck verhindern</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript-Speicherlimit</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Begrenzt den JavaScript-Heap (V8 --max-old-space-size). 0 = automatisch. Verringere den Wert, wenn die App zu viel RAM verbraucht.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP-Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Speicherort für den HTTP-Cache. „Arbeitsspeicher“ wird beim Beenden geleert; „Keiner“ deaktiviert das Caching.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Maximale Größe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Maximale Cache-Größe auf der Festplatte. 0 = automatisch.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Netzwerk &amp; Start</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Whatly automatisch starten, wenn Sie sich bei Ihrer Desktop-Sitzung anmelden.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Whatly beim Anmelden starten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Ersetzt den Fensterrahmen des Systems durch Whatlys eigene schmale Titelleiste. Wird nach einem Neustart wirksam.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Eigenen Fensterrahmen verwenden (Neustart erforderlich)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Einmal täglich auf GitHub nach einer neueren Version suchen und dich benachrichtigen. Whatly lädt oder installiert niemals etwas von selbst.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Automatisch nach Updates suchen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Oberflächenskalierung</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Das gesamte Fenster und die Seite skalieren (QT_SCALE_FACTOR). &quot;Automatisch&quot; folgt dem Desktop. Eine gesetzte Umgebungsvariable QT_SCALE_FACTOR hat Vorrang. Wird nach einem Neustart wirksam.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Wie Whatly sich mit dem Netzwerk verbindet. &quot;System&quot; folgt dem Betriebssystem; &quot;Kein&quot; verbindet direkt.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Benutzername</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Optional</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Eigene JavaScript-Add-ons</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>.js-Dateien laden, die auf WhatsApp Web ausgeführt werden. Jedes Add-on läuft in einer eigenen Sandbox, sodass ein fehlerhaftes Add-on weder die anderen noch die Seite beeinträchtigen kann. Deaktivieren Sie das Häkchen bei einem Add-on, um es abzuschalten, ohne es zu entfernen. Änderungen werden nach einem Neustart wirksam.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Add-on hinzufügen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Gespeicherte Antworten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Kurze Texte, die Sie häufig senden. Fügen Sie einen über die Befehlspalette (Ctrl+K) ein — geben Sie &quot;Einfügen&quot; ein und wählen Sie ihn aus; der Text wird in das Nachrichtenfeld geschrieben.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Antwort hinzufügen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Tastenkürzel</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Klicken Sie in ein Feld und drücken Sie die Tastenkombination. Leeren Sie ein Feld, um das Tastenkürzel zu entfernen. Änderungen werden nach einem Neustart wirksam.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Dies löscht die persistenten Daten (einschließlich persistenter Cookies und Cache) und beendet die Anwendung.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Cookies löschen und Anwendung beenden?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Fehler</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Es kann keine leere User-Agent-Zeichenkette gesetzt werden.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Der automatische Designwechsel wurde durch den manuellen Wechsel deaktiviert.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Die App-Sperre ist nicht eingerichtet.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Möchten Sie die App-Sperre jetzt einrichten?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Funktionsberechtigungen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Chat-Hintergrund auswählen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Bilder (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Dieses Bild konnte nicht verwendet werden: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>CSS-Datei auswählen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Stylesheets (*.css);;Alle Dateien (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Diese Datei konnte nicht gelesen werden: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Festplatte</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Arbeitsspeicher</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Kein (direkt)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Desktop-Portal (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Systemdienst (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Antwort hinzufügen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Einzufügender Text</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>JavaScript-Datei auswählen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Alle Dateien (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Add-on konnte nicht hinzugefügt werden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Add-on entfernen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Das Add-on &quot;%1&quot; entfernen? Dadurch wird seine Datei gelöscht.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Rechtschreibprüfung (keine Wörterbücher installiert)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Erscheinungsbild</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Benachrichtigungen</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Chat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privatsphäre und Sperre</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Fenster und Zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Erweitert</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Tastenkürzel bereits belegt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Dieses Tastenkürzel wird bereits von einer anderen Aktion verwendet.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Cache leeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Cache jetzt leeren? Er wird bei Bedarf erneut heruntergeladen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Profil exportieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Das Archiv enthält deine angemeldete WhatsApp-Sitzung. Halte es privat. Fortfahren?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archive (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profil exportiert.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Profil importieren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Dies überschreibt die Daten des aktuellen Kontos mit dem Archiv, danach muss Whatly neu gestartet werden. Fortfahren?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profil importiert. Bitte starte Whatly neu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 Sprachen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp-Standard</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Systemstandard</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>Die Oberflächensprache ändert sich beim Neustart von %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>App-Sperre einrichten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Richten Sie zuerst das App-Sperrpasswort ein.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Downloadordner auswählen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Dadurch wird Ihre aktuelle Sitzung abgemeldet.
 Möglicherweise ist auch ein vollständiger Neustart der Anwendung erforderlich!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Möchten Sie fortfahren?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Möglicherweise ist auch ein vollständiger Neustart der Anwendung erforderlich!
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Willkommen bei Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Ein schneller, nativer WhatsApp Web-Client für den Desktop. Lass uns ein paar Dinge einrichten — du kannst das alles später in den Einstellungen ändern.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly hält deine Chats in einem richtigen Desktop-Fenster bereit — mit Symbol im Infobereich, Benachrichtigungen, Designs und mehreren Konten.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Ein paar Einstellungen</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Sinnvolle Voreinstellungen; nach Belieben anpassen.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>An das helle/dunkle Systemdesign anpassen</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Whatly beim Anmelden starten</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Benachrichtigungszustellung:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Desktop-Portal (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Systemdienst (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Fertig</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Alles bereit. Scanne den QR-Code mit deinem Handy, um dich anzumelden.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Alles hier findest du in den Einstellungen, falls du es dir anders überlegst.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Möglicherweise ist auch ein vollständiger Neustart der Anwendung erforderlich!
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Neueste Version konnte nicht gelesen werden</translation>
     </message>
@@ -2038,82 +2626,104 @@ Möglicherweise ist auch ein vollständiger Neustart der Anwendung erforderlich!
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Bildschirm teilen</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Was möchten Sie teilen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Ohne Titel</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Bildschirm: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Fenster: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>%1 den Zugriff auf Ihre Standortdaten erlauben?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>%1 den Zugriff auf Ihr Mikrofon erlauben?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>%1 den Zugriff auf Ihre Kamera erlauben?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>%1 den Zugriff auf Mikrofon und Kamera erlauben?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>%1 erlauben, Ihren Mauszeiger zu fixieren?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>%1 erlauben, Video Ihres Bildschirms aufzuzeichnen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>%1 erlauben, Audio und Video Ihres Bildschirms aufzuzeichnen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>%1 erlauben, Benachrichtigungen auf Ihrem Desktop anzuzeigen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>%1 erlauben, Ihre Zwischenablage zu lesen? Das ist nötig, um Bilder in einen Chat einzufügen.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>%1 erlauben, die auf Ihrem System installierten Schriftarten zu sehen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Berechtigungsanfrage</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Zertifikatsfehler</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Geben Sie Benutzername und Passwort für „%1“ auf %2 ein</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Mit Proxy „%1“ verbinden über:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>%1 erlauben, alle %2-Links zu öffnen?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Möglicherweise ist auch ein vollständiger Neustart der Anwendung erforderlich!
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Render-Prozess normal beendet</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Render-Prozess unerwartet beendet</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Render-Prozess abgestürzt</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Render-Prozess abgebrochen</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Render-Prozess mit Code %1 beendet

--- a/src/i18n/es_ES.ts
+++ b/src/i18n/es_ES.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Donar con PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Valorar en la tienda</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Más aplicaciones</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Código fuente</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copia al portapapeles la información de depuración de abajo y abre el gestor de incidencias, para pegarla directamente en el informe.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Informar de un fallo</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Versión: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>La información de depuración era demasiado larga para el navegador, así que se ha copiado al portapapeles. Pégala en el informe.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Acerca de</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Amanecer</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Atardecer</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Actualizar </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Desactivar y cerrar</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Activar y cerrar</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Inténtalo de nuevo.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Inténtalo de nuevo.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Diálogo</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Icono</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (predeterminado)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Rosa Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Rosa palo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavanda</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Violeta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Azul cielo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Océano profundo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Verde azulado</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Menta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Coral</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Melocotón</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Oro</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Carmesí</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafito</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Paleta de comandos</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Escribe un comando…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Búsqueda de comandos</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Comandos coincidentes</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimizar</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maximizar</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Descargas</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Sin descargas</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Vaciar la lista de descargas</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Vaciar todo</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Abrir la carpeta de descargas en el gestor de archivos</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Abrir la carpeta de descargas</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>¡Ya existe un archivo con el mismo nombre!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>¿Guardar el archivo con un nombre nuevo?</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Abrir el archivo con la aplicación del sistema</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 de %2 descargado - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>tamaño desconocido - %1 descargado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>completado - %1 descargado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>cancelado - %1 descargado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>interrumpido: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Detener la descarga</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Quitar de la lista</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Establecer código de bloqueo</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>introduzca el código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>repita el código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Establecer código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Aviso: el bloqueo de mayúsculas está activado</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nota: el código debe tener más de 3 caracteres y coincidir en ambos campos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Introduzca su código para acceder</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>introduzca su código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Código incorrecto. Inténtelo de nuevo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Esperando a la red…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>No hay ninguna ventana de WhatsApp abierta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Recordatorio</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Recordatorio: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Actualización disponible</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 ya está disponible. Haz clic para abrir la página de descarga.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Error</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Desbloquee para acceder a los ajustes.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>No se puede inicializar el módulo de ajustes.
 WebEngine no está inicializado.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Acción requerida</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>La página debe recargarse para continuar.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nuevo chat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Introduzca un número de WhatsApp válido con prefijo de país (ej. +34XXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Valorar la aplicación</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Configure primero la contraseña en los ajustes.
 ¿Abrir los ajustes ahora?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimizar a la bandeja</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Restaurar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Re&amp;cargar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Blo&amp;quear</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Silenciar audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Acercar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Alejar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Restablecer zoom</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ajustes</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>&amp;Mensajes programados…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Cambiar &amp;tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Vista por pestañas</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Vista en cuadrícula</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Paleta de comandos</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Acerca de</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Recargar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Minimizar a la bandeja</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Bloquear</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Silenciar audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nuevo chat / abrir URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Cambiar tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Renombrar…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Eliminar cuenta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Cambiar a la cuenta: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Añadir cuenta…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Insertar: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 sin leer</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Añadir otra cuenta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>mensajes</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>mensaje</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Añadir cuenta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nombre de la nueva cuenta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Cuenta %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Renombrar cuenta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nombre de la cuenta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Cuenta 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Desbloquee para recargar la aplicación.</translation>
     </message>
@@ -623,10 +779,12 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
@@ -641,22 +800,27 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Autenticación requerida</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Icono</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Información</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Usuario:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Contraseña:</translation>
     </message>
@@ -664,14 +828,17 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Función</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -679,22 +846,27 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Lista de chats</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Conversación abierta</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Lista de chats y conversación</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Todo, incluidas las fotos</translation>
     </message>
@@ -702,10 +874,13 @@ Configure primero la contraseña en los ajustes.
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Mostrar información de depuración</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Configure primero la contraseña en los ajustes.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Ocultar información de depuración</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>No hay nada que migrar desde «%1»: ya se migró, o no se encontraron datos ahí.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Se copiaría:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Copiado:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Ejecútalo de nuevo sin --dry-run para realizar la copia.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Cliente de WhatsApp Web con múltiples funciones, basado en Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Muestra la ayuda de las opciones de línea de comandos</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Abre los ajustes en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Bloquea una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Abre el diálogo «Acerca de» en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Abre el diálogo de mensajes programados en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Alterna entre tema claro y oscuro en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Recarga la aplicación en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Abre el diálogo de chat nuevo en una instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ejecutar como una cuenta separada con su propia sesión y ajustes, en su propia ventana&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Muestra la ventana principal de la instancia en ejecución de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Copia los ajustes y la sesión iniciada de una instalación anterior (p. ej. la versión «whatsie» antigua) a esta y luego sale</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Con --migrate-from, solo informa de lo que se copiaría</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Muestra el número actual de mensajes sin leer y sale</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>El bloqueo de la aplicación no está configurado.
 Configure primero la contraseña en los ajustes.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Recargando...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Modo de instalación</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Rama de origen</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Hash del commit</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Fecha de compilación</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Versión de Qt en ejecución</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Versión de Qt de compilación</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Arquitectura</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Excepción</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> ha encontrado un problema.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> puede necesitar reiniciarse. Informe del error al desarrollador.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>No se pudo ejecutar &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>No hay nada que copiar</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>No se puede crear %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>No se puede copiar %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>No se puede crear un directorio temporal</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>No se pudo restaurar el archivo de configuración</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>No se puede escribir %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Cambiar al tema claro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Cambiar al tema oscuro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Mostrar los chats</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Desenfocar los chats</translation>
@@ -898,42 +1123,53 @@ Configure primero la contraseña en los ajustes.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Valorar esta aplicación</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si le gusta esta aplicación, ¿le importaría dedicar un momento a valorarla?&lt;/p&gt;&lt;p&gt;No le llevará más de un minuto. ¡Gracias por su apoyo!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Valorar en la tienda</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>O</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Dar una estrella al repositorio de GitHub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Donar con PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Donar con OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Más tarde</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Ya lo he hecho  </translation>
     </message>
@@ -941,34 +1177,42 @@ Configure primero la contraseña en los ajustes.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Se agotó el tiempo de espera para enviar el mensaje</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Diariamente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Días laborables</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Semanalmente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Una vez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Enviado</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Falló</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Pendiente</translation>
     </message>
@@ -976,90 +1220,117 @@ Configure primero la contraseña en los ajustes.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Mensajes programados</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Cuándo</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Número de teléfono en formato internacional, p. ej. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Etiqueta opcional</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Una vez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Diariamente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Días laborables</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Semanalmente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Repetir</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Recordármelo en lugar de enviar (avisar, no enviar mensaje)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Mensaje a enviar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>La aplicación debe estar en ejecución y WhatsApp con sesión iniciada a la hora programada. Si está cerrada, el mensaje se envía la próxima vez que abras la aplicación. Al enviar se abre el chat del destinatario.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Programar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Eliminar seleccionado</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Borrar enviados/fallidos</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Introduce un número de teléfono y un mensaje.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>La hora ya pasó: ¿enviar este mensaje ahora?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Configure primero la contraseña en los ajustes.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Tamaño de fuente de la interfaz</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tamaño en puntos de la interfaz de la aplicación: menús, ajustes y diálogos. No afecta al texto de WhatsApp Web; para eso usa el zoom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Tema de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Recargar automáticamente tras un fallo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si el proceso de la página de WhatsApp Web falla, recargarlo automáticamente en lugar de preguntar primero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Ajustes generales</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Estilo de los widgets</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Tema de los widgets</translation>
+        <translation type="vanished">Tema de los widgets</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Según la zona horaria y la ubicación de su sistema.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Oscuro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Coincide con la preferencia claro/oscuro del escritorio y cambia con ella. Anula el tema manual y el cambio automático por amanecer/atardecer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Seguir el tema claro/oscuro del sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Notificación nativa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Notificación personalizada</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Probar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Tipo de notificación</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Desactivar el aviso emergente de notificaciones</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Tiempo del aviso emergente</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> s</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Envío de notificaciones</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Cómo se envían las notificaciones nativas en Linux. El modo automático usa el portal de escritorio dentro de un espacio aislado de Flatpak y el servicio del sistema en los demás casos.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Silencia las notificaciones emergentes durante un periodo de silencio diario. Los distintivos de mensajes sin leer siguen actualizándose; solo se retiene la ventana emergente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>No molestar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Desde</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>hasta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Resaltar palabras clave</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Palabras separadas por comas que siempre notifican, incluso durante «No molestar» (no distingue mayúsculas de minúsculas).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>p. ej. urgente, jefe, factura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Usar el diálogo de archivos nativo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Silenciar el audio de la página</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Desactivar la reproducción automática de medios</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Iniciar minimizado en la bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Mostrar/ocultar al pulsar el icono de la bandeja (si se admite)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cierra el panel de emojis, GIF y stickers al pulsar en otro sitio. De lo contrario, WhatsApp Web lo mantiene abierto hasta que se pulsa el botón de nuevo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Cerrar el panel de emojis/stickers al pulsar fuera</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Idioma de la interfaz</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma de la interfaz de Whatly. Se aplica al reiniciar la app. El idioma de los chats viene de WhatsApp Web y no se cambia aquí.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Añade un botón claro/oscuro a la barra lateral de WhatsApp, justo encima de tu foto de perfil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Botón de tema en la barra lateral de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Añade a la barra lateral de WhatsApp un botón que desenfoca y revela tus chats con un clic, sin abrir Ajustes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Botón de desenfoque en la barra lateral de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usa un icono de bandeja de un solo color que combine con el resto de tu panel, en lugar del verde de WhatsApp. El icono también se atenúa cuando WhatsApp no está conectado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Icono de bandeja monocromo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Anima el desplazamiento en lugar de saltar línea por línea.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Desplazamiento suave</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS personalizado</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carga un archivo .css para reestilizar WhatsApp Web; las hojas de estilo de la comunidad (catppuccin y similares) funcionan aquí. Se aplica sobre el tema del chat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Elegir archivo…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Borrar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Elimina por completo el icono de la bandeja del sistema. Sin bandeja desde la que restaurar, al cerrar la ventana la app se cierra en lugar de ocultarse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Ocultar icono de bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Familia de fuente</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Muestra el texto de WhatsApp Web con una fuente instalada en tu sistema. Los emojis, los iconos y el formato monoespaciado de los mensajes no se modifican.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Oculta la sección «Estados silenciados» del panel de Estados/Novedades, de modo que los estados de los contactos que has silenciado no aparezcan en absoluto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Ocultar estados silenciados</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subraya las palabras mal escritas mientras escribes y ofrece correcciones en el menú del clic derecho.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Corregir ortografía mientras escribo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El idioma con el que se comprueba.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Desenfoque de privacidad</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Desenfoca tus chats hasta que pasas el ratón por encima, para que nadie que mire la pantalla pueda leerlos. Al pasar sobre una fila se revela solo esa fila.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Tema del chat</translation>
+        <translation type="vanished">Tema del chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Tinte de color del chat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolorea WhatsApp Web en sí. Las fotos, los avatares y los stickers mantienen sus colores. Funciona sobre el tema claro u oscuro, el que esté activo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Fondo de chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usa una de tus propias imágenes como fondo del panel de chat, como hace WhatsApp en Android. La imagen se guarda dentro de Whatly, no se sube a ningún sitio y solo la ves tú.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Elegir imagen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Los inicios de sesión nuevos aparecerán como «Whatly para Linux» (o la plataforma correspondiente) en la lista de dispositivos vinculados de su teléfono, en lugar de «Google Chrome (Linux)». El nombre se guarda en el teléfono al vincular un dispositivo, así que cambiar esto solo afecta a vinculaciones futuras: cierre la sesión y vuelva a vincularla para renombrar una sesión existente.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Identificarse como Whatly en los dispositivos vinculados</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>Agente de usuario</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avanzado — no cambie esto a menos que sepa exactamente lo que hace. Un user agent no estándar puede impedir que WhatsApp cargue, y los valores inusuales pueden hacer que su cuenta de WhatsApp sea marcada o incluida en listas negras.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Aplicar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Restablecer valores por defecto</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Factor de zoom en ventana normal</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Reducir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Ampliar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>restablecer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Factor de zoom en maximizado/pantalla completa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimizar a la bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Atajos globales</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Acción del botón de cerrar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Mostrar atajos</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Permisos</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Mostrar permisos</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Activar la pantalla de bloqueo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Activar el bloqueo al iniciar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cuando la ventana se oculta en la bandeja del sistema, bloquéala tras el código. Requiere tener una contraseña configurada.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Bloquear al ocultar en la bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Bloquear también Whatly cuando se bloquee la sesión del escritorio. Requiere tener una contraseña configurada. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Bloquear cuando se bloquee la pantalla</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Contraseña actual</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Cambiar contraseña</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Activar el bloqueo automático tras</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Restablecer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Ver contraseña</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Carpeta de descargas por defecto</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Cambiar la carpeta de descargas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Almacenamiento </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Propiedad</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Vaciar (requiere reiniciar)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Los datos persistentes incluyen cookies persistentes, almacenamiento local HTML5 y enlaces visitados.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Datos persistentes</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>La caché HTTP y de contenido multimedia. Borrarla es seguro — se vuelve a descargar cuando sea necesario.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Caché</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Borrar caché</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Copia de seguridad</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Guarda esta cuenta (ajustes, sesión y complementos) en un archivo .tar.gz. El archivo contiene tu sesión iniciada — mantenlo privado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Exportar perfil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Restaura una cuenta desde un archivo .tar.gz. Esto sobrescribe los datos actuales y requiere reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Importar perfil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Rendimiento y privacidad</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Ajusta con precisión el motor de renderizado. Los valores predeterminados son seguros en la mayoría de los sistemas; si la ventana aparece en blanco, la aplicación se bloquea al arrancar o va a tirones, prueba a cambiarlos. Los cambios se aplican tras reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Renderiza por completo en la CPU (--disable-gpu). Corrige ventanas en blanco y bloqueos al arrancar en algunas configuraciones de GPU/controlador. Predeterminado en Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Desactivar la aceleración por GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Compone la página en la CPU (--disable-gpu-compositing). Evita el parpadeo de fotogramas obsoletos en algunos controladores.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Desactivar la composición por GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Desactiva el VSync de la GPU (--disable-gpu-vsync). Puede reducir la latencia de entrada a costa de tearing.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Desactivar VSync de la GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Ejecuta el proceso de la GPU dentro del proceso principal (--in-process-gpu). Una solución alternativa para algunas configuraciones con espacio aislado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Ejecutar la GPU en el mismo proceso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Fuerza la aceleración incluso cuando el controlador está en la lista de bloqueo (--ignore-gpu-blocklist). Prueba esto para volver a activar la GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Ignorar la lista de bloqueo de la GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Ejecuta todo en un único proceso (--single-process). Usa menos memoria, pero es menos estable.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Modo de proceso único (menos memoria)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Comparte un proceso de renderizado por sitio (--process-per-site). Reduce el uso de memoria.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Un proceso por sitio (menos memoria)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Oculta los nombres de contacto y las vistas previas de mensajes en la lista de chats (pasa el ratón para revelar uno). Útil al compartir pantalla. La conversación abierta no se altera.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Modo concentración (ocultar vistas previas)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Usar la calidad HD de forma predeterminada para fotos y vídeos en el editor multimedia. Depende del diseño de WhatsApp Web; si una actualización de WhatsApp lo estropea, desactívalo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Enviar fotos y vídeos en HD de forma predeterminada</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Impide que WebRTC revele tu dirección IP local en conexiones sin proxy.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Evitar la fuga de IP de WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Límite de memoria de JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Limita el montículo de JavaScript (V8 --max-old-space-size). 0 = automático. Redúcelo si la aplicación usa demasiada RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Caché HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Dónde guardar la caché HTTP. La memoria se borra al salir; «Ninguna» desactiva la caché.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Tamaño máximo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Tamaño máximo de la caché en disco. 0 = automático.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Red e inicio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Iniciar Whatly automáticamente al iniciar sesión en tu escritorio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Iniciar Whatly al iniciar sesión</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Sustituir el borde de ventana del sistema por la barra de título fina de Whatly. Se aplica tras reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Usar un marco de ventana personalizado (requiere reiniciar)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Comprueba GitHub una vez al día para ver si hay una versión más reciente y te avisa. Whatly nunca descarga ni instala nada por su cuenta.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Buscar actualizaciones automáticamente</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Escala de la interfaz</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Escala toda la ventana y la página (QT_SCALE_FACTOR). Automático sigue la configuración del escritorio. La variable de entorno QT_SCALE_FACTOR, si está definida, tiene prioridad sobre esta opción. Se aplica tras reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Cómo se conecta Whatly a la red. Sistema sigue la configuración del sistema operativo; Ninguno se conecta directamente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nombre de usuario</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Opcional</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Complementos de JavaScript personalizados</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Carga archivos .js para ejecutarlos en WhatsApp Web. Cada complemento se ejecuta en su propio entorno aislado, de modo que uno defectuoso no puede afectar a los demás ni a la página. Desmarca un complemento para desactivarlo sin eliminarlo. Los cambios se aplican tras reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Añadir complemento…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Respuestas guardadas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Textos breves que envías a menudo. Inserta uno desde la paleta de comandos (Ctrl+K) — escribe &quot;Insertar&quot; y elígelo; el texto se escribe en el cuadro de mensaje.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Añadir respuesta…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Atajos de teclado</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Haz clic en un campo y pulsa la combinación de teclas. Borra un campo para eliminar el atajo. Los cambios se aplican tras reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Esto eliminará los datos persistentes (incluidas las cookies persistentes y la caché) y cerrará la aplicación.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>¿Eliminar las cookies y cerrar la aplicación?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Error</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>No se puede establecer una cadena de User-Agent vacía.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>El cambio automático de tema se desactivó al cambiar el tema manualmente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>El bloqueo de la aplicación no está configurado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>¿Quieres configurar el bloqueo de la aplicación ahora?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Permisos de funciones</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Elegir un fondo de chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Imágenes (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>No se pudo usar esa imagen: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Elegir un archivo CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Hojas de estilo (*.css);;Todos los archivos (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>No se pudo leer ese archivo: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disco</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Ninguno (directo)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal de escritorio (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Servicio del sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Añadir respuesta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Texto a insertar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Elegir un archivo JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Todos los archivos (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>No se pudo añadir el complemento</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Eliminar complemento</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>¿Eliminar el complemento &quot;%1&quot;? Esto borra su archivo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Corrector ortográfico (sin diccionarios instalados)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Básico</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Apariencia</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Notificaciones</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Mensajería</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privacidad y bloqueo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Ventana y zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Avanzado</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Atajo en uso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Ese atajo ya lo utiliza otra acción.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Borrar caché</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>¿Borrar la caché ahora? Se volverá a descargar cuando sea necesario.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Exportar perfil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>El archivo contendrá tu sesión de WhatsApp iniciada. Mantenlo privado. ¿Continuar?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archivos comprimidos (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Perfil exportado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Importar perfil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Esto sobrescribe los datos de la cuenta actual con el archivo y luego habrá que reiniciar Whatly. ¿Continuar?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Perfil importado. Reinicia Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 idiomas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Predeterminada de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Predeterminado del sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>El idioma de la interfaz cambiará cuando reinicies %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Configuración del bloqueo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Configura primero la contraseña del bloqueo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Seleccionar la carpeta de descargas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Esto cerrará tu sesión actual.
 ¡También podría requerir reiniciar por completo la aplicación!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>¿Quieres continuar?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Esto cerrará tu sesión actual.
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Te damos la bienvenida a Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Un cliente de WhatsApp Web nativo y rápido para el escritorio. Vamos a configurar algunas cosas — podrás cambiarlas todas más tarde en los Ajustes.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly mantiene tus chats en una ventana de escritorio como es debido, con icono en la bandeja, notificaciones, temas y varias cuentas.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Algunas preferencias</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Valores predeterminados sensatos; ajústalos a tu gusto.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Seguir el tema claro/oscuro del sistema</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Iniciar Whatly al iniciar sesión</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Entrega de notificaciones:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal de escritorio (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Servicio del sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Todo listo</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Ya está todo listo. Escanea el código QR con tu teléfono para iniciar sesión.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Si cambias de opinión, todo esto está en los Ajustes.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Esto cerrará tu sesión actual.
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>No se pudo leer la última versión</translation>
     </message>
@@ -2038,82 +2626,104 @@ Esto cerrará tu sesión actual.
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Compartir pantalla</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Elige qué compartir:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Sin título</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Pantalla: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Ventana: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>¿Permitir que %1 acceda a su información de ubicación?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>¿Permitir que %1 acceda a su micrófono?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>¿Permitir que %1 acceda a su cámara?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>¿Permitir que %1 acceda a su micrófono y su cámara?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>¿Permitir que %1 capture el cursor del ratón?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>¿Permitir que %1 grabe el vídeo de su escritorio?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>¿Permitir que %1 grabe el audio y el vídeo de su escritorio?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>¿Permitir que %1 muestre notificaciones en su escritorio?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>¿Permitir que %1 lea su portapapeles? Es necesario para pegar imágenes en un chat.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>¿Permitir que %1 vea las fuentes instaladas en su sistema?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Solicitud de permiso</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Error de certificado</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Introduzca el usuario y la contraseña de «%1» en %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Conectar al proxy «%1» usando:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>¿Permitir que %1 abra todos los enlaces %2?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Esto cerrará tu sesión actual.
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>El proceso de renderizado terminó con normalidad</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>El proceso de renderizado terminó de forma anómala</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>El proceso de renderizado se bloqueó</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>El proceso de renderizado fue terminado</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>El proceso de renderizado terminó con el código: %1

--- a/src/i18n/fr_FR.ts
+++ b/src/i18n/fr_FR.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Faire un don via PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Noter sur la boutique</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Plus d&apos;applications</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Code source</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copie les informations de débogage ci-dessous dans le presse-papiers et ouvre le suivi des tickets, pour les coller directement dans le rapport.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Signaler un bug</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Informations de débogage</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Version : </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Les informations de débogage étaient trop longues pour le navigateur ; elles ont été copiées dans le presse-papiers. Collez-les dans le ticket.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | À propos</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Lever du soleil</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Coucher du soleil</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Actualiser </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Désactiver et fermer</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Activer et fermer</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Veuillez réessayer.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Veuillez réessayer.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Boîte de dialogue</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Icône</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (par défaut)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Rose Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Vieux rose</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavande</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Violet</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Bleu ciel</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Océan profond</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Sarcelle</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Menthe</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Corail</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Pêche</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Or</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Cramoisi</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Graphite</translation>
     </message>
@@ -209,18 +256,22 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Palette de commandes</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Saisissez une commande…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Recherche de commandes</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Commandes correspondantes</translation>
     </message>
@@ -228,14 +279,17 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Réduire</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Agrandir</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
@@ -243,34 +297,42 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Téléchargements</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Aucun téléchargement</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Vider la liste des téléchargements</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Tout vider</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Ouvrir le dossier des téléchargements dans le gestionnaire de fichiers</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Ouvrir le dossier des téléchargements</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Un fichier du même nom existe déjà !</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Enregistrer le fichier sous un nouveau nom ?</translation>
     </message>
@@ -278,54 +340,68 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Ouvrir le fichier avec l&apos;application du système</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 o</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 Kio</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 Mio</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 Gio</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 sur %2 téléchargé - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>taille inconnue - %1 téléchargé - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>terminé - %1 téléchargé - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>annulé - %1 téléchargé - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>interrompu : %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Arrêter le téléchargement</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Retirer de la liste</translation>
     </message>
@@ -333,46 +409,58 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Définir le code de verrouillage</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>saisir le code</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>saisir le code à nouveau</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Définir le code</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Attention : le verrouillage majuscules est activé</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note : le code doit comporter plus de 3 caractères et être identique dans les deux champs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Saisissez votre code pour accéder</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>saisissez votre code</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Code incorrect. Veuillez réessayer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Voulez-vous ignorer le contrôle de sécurité et continuer ?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>En attente du réseau…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Aucune fenêtre WhatsApp n&apos;est ouverte</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Rappel</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Rappel : %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Mise à jour disponible</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 est disponible. Cliquez pour ouvrir la page de téléchargement.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Erreur</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Déverrouillez pour accéder aux paramètres.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Impossible d&apos;initialiser le module de paramètres.
 WebEngine n&apos;est pas initialisé.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Action requise</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>La page doit être rechargée pour continuer.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nouvelle discussion</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Saisissez un numéro WhatsApp valide avec l&apos;indicatif du pays (ex. +33XXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Noter l&apos;application</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Définissez d&apos;abord le mot de passe dans les paramètres.
 Ouvrir les paramètres maintenant ?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Réduire dans la zone de &amp;notification</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Restaurer</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Re&amp;charger</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Ve&amp;rrouiller</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Couper le son</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Réinitialiser le zoom</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Paramètres</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>&amp;Messages programmés…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Changer de &amp;thème</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Vue par onglets</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Vue en grille</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Palette de commandes</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>À &amp;propos</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Recharger</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Réduire dans la zone de notification</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Verrouiller</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Couper le son</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nouvelle discussion / ouvrir une URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Changer de thème</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Renommer…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Supprimer le compte</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Basculer vers le compte : %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Ajouter un compte…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Insérer : %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 non lus</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Ajouter un autre compte</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Restaurer</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>messages</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>message</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Ajouter un compte</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nom du nouveau compte :</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Compte %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Renommer le compte</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nom du compte :</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Compte 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Déverrouillez pour recharger l&apos;application.</translation>
     </message>
@@ -623,10 +779,12 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
@@ -641,22 +800,27 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Authentification requise</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Icône</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informations</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Nom d&apos;utilisateur :</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Mot de passe :</translation>
     </message>
@@ -664,14 +828,17 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Fonctionnalité</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
@@ -679,22 +846,27 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Désactivé</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Liste des discussions</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Conversation ouverte</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Liste des discussions et conversation</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Tout, photos comprises</translation>
     </message>
@@ -702,10 +874,13 @@ Ouvrir les paramètres maintenant ?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Afficher les informations de débogage</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Ouvrir les paramètres maintenant ?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Masquer les informations de débogage</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Rien à migrer depuis « %1 » — déjà migré, ou aucune donnée trouvée.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Copierait :</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Copié :</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Relancez sans --dry-run pour effectuer la copie.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Client WhatsApp Web complet basé sur Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Affiche l&apos;aide des options de ligne de commande</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Ouvre les paramètres dans une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Verrouille une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Ouvre la fenêtre « À propos » dans une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Ouvre la boîte de dialogue des messages programmés dans une instance en cours d&apos;exécution de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Bascule entre le thème clair et sombre dans une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Recharge l&apos;application dans une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Ouvre la fenêtre de nouvelle discussion dans une instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exécuter comme un compte distinct avec sa propre session et ses propres paramètres, dans sa propre fenêtre&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Affiche la fenêtre principale de l&apos;instance en cours de </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Copier les paramètres et la session connectée d’une installation précédente (par ex. l’ancienne version « whatsie ») vers celle-ci, puis quitter</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Avec --migrate-from, indiquer seulement ce qui serait copié</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Afficher le nombre de messages non lus et quitter</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Le verrouillage de l&apos;application n&apos;est pas configuré.
 Définissez d&apos;abord le mot de passe dans les paramètres.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Rechargement...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Mode d&apos;installation</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Branche source</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Empreinte du commit</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Date de compilation</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Version de Qt à l&apos;exécution</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Version de Qt à la compilation</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Architecture</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Exception</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> a rencontré un problème.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> devra peut-être redémarrer. Veuillez signaler l&apos;erreur au développeur.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Impossible d&apos;exécuter &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Rien à sauvegarder</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Impossible de créer %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Impossible de copier %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Impossible de créer un répertoire temporaire</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Impossible de restaurer le fichier de configuration</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Impossible d&apos;écrire %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Passer au thème clair</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Passer au thème sombre</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Afficher les discussions</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Flouter les discussions</translation>
@@ -898,42 +1123,53 @@ Définissez d&apos;abord le mot de passe dans les paramètres.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Noter cette application</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si cette application vous plaît, accepteriez-vous de prendre un instant pour la noter ?&lt;/p&gt;&lt;p&gt;Cela ne prendra pas plus d&apos;une minute. Merci de votre soutien !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Noter sur la boutique</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Ou</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Mettre une étoile au dépôt GitHub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Faire un don via PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Faire un don via OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Plus tard</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Déjà fait  </translation>
     </message>
@@ -941,34 +1177,42 @@ Définissez d&apos;abord le mot de passe dans les paramètres.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Délai dépassé en attendant l&apos;envoi du message</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Quotidien</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Jours de semaine</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Hebdomadaire</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Une fois</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Envoyé</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Échec</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>En attente</translation>
     </message>
@@ -976,90 +1220,117 @@ Définissez d&apos;abord le mot de passe dans les paramètres.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Messages programmés</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>À</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Quand</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Numéro de téléphone au format international, par ex. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Libellé facultatif</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Une fois</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Quotidien</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Jours de semaine</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Hebdomadaire</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Répéter</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Me rappeler au lieu d&apos;envoyer (notifier, ne pas envoyer)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Message à envoyer</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>L&apos;application doit être en cours d&apos;exécution et WhatsApp connecté à l&apos;heure programmée. Si elle est fermée, le message est envoyé à la prochaine ouverture de l&apos;application. L&apos;envoi ouvre la conversation du destinataire.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Programmer</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Supprimer la sélection</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Effacer envoyés/échoués</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Saisissez un numéro de téléphone et un message.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>L&apos;heure est déjà passée — envoyer ce message maintenant ?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Définissez d&apos;abord le mot de passe dans les paramètres.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Taille de police de l&apos;interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Taille en points de l&apos;interface de l&apos;application — menus, paramètres et boîtes de dialogue. Cela n&apos;affecte pas le texte de WhatsApp Web ; utilisez le zoom pour cela.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Thème d'affichage</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Recharger automatiquement après un plantage</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si le processus de la page WhatsApp Web plante, le recharger automatiquement au lieu de demander d&apos;abord.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Paramètres généraux</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Style des widgets</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Thème des widgets</translation>
+        <translation type="vanished">Thème des widgets</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;D&apos;après le fuseau horaire et la position de votre système.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automatique</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Sombre</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Clair</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reprend la préférence clair/sombre du bureau et change avec elle. Remplace le thème manuel et le changement automatique lever/coucher du soleil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Suivre le thème clair/sombre du système</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Notification native</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Notification personnalisée</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Essayer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Type de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Désactiver la fenêtre de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Délai de la fenêtre</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> s</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Envoi des notifications</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Mode d&apos;envoi des notifications natives sous Linux. Le mode automatique utilise le portail de bureau dans un bac à sable Flatpak, et le service système dans les autres cas.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Masque les fenêtres de notification pendant une période de silence quotidienne. Les badges de messages non lus continuent de se mettre à jour ; seule la fenêtre contextuelle est retenue.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Ne pas déranger</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>à</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Surligner les mots-clés</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Mots séparés par des virgules qui déclenchent toujours une notification, même en mode Ne pas déranger (insensible à la casse).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>p. ex. urgent, patron, facture</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Utiliser la fenêtre de fichiers native</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Couper le son de la page</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Désactiver la lecture automatique des médias</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Démarrer réduit dans la zone de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Afficher/masquer en cliquant sur l&apos;icône de notification (si pris en charge)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ferme le panneau d&apos;émojis, de GIF et d&apos;autocollants lorsque vous cliquez ailleurs. Sinon, WhatsApp Web le laisse ouvert jusqu&apos;à ce que le bouton soit pressé à nouveau.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Fermer le panneau d&apos;émojis/autocollants en cliquant à côté</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Langue de l&apos;interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Langue de l&apos;interface de Whatly. Prend effet après le redémarrage de l&apos;application. La langue des discussions provient de WhatsApp Web et ne peut pas être modifiée ici.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ajoute un bouton clair/sombre dans la barre latérale de WhatsApp, juste au-dessus de votre photo de profil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Bouton de thème dans la barre latérale de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ajoute à la barre latérale de WhatsApp un bouton qui floute et défloute vos discussions en un clic, sans ouvrir les paramètres.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Bouton de flou dans la barre latérale de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Utilise une icône de barre d&apos;état d&apos;une seule couleur, assortie au reste de votre panneau, au lieu de celle verte de WhatsApp. L&apos;icône est aussi atténuée lorsque WhatsApp n&apos;est pas connecté.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Icône de barre d&apos;état monochrome</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Anime le défilement au lieu de sauter ligne par ligne.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Défilement fluide</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS personnalisé</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Chargez un fichier .css pour restyler WhatsApp Web ; les feuilles de style de la communauté (catppuccin et compagnie) fonctionnent ici. Appliqué par-dessus le thème de discussion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Choisir un fichier…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Supprime entièrement l&apos;icône de la zone de notification. Sans zone pour restaurer, fermer la fenêtre quitte l&apos;application au lieu de la masquer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Masquer l&apos;icône de la zone de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Police de caractères</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Affiche le texte de WhatsApp Web avec une police installée sur votre système. Les emojis, les icônes et la mise en forme à chasse fixe des messages restent inchangés.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Masque la section « Statuts en sourdine » du panneau Statuts/Actus, afin que les statuts des contacts que vous avez mis en sourdine n&apos;apparaissent pas du tout.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Masquer les statuts en sourdine</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Souligne les mots mal orthographiés pendant la saisie et propose des corrections dans le menu contextuel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Vérifier l&apos;orthographe pendant la saisie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;La langue de référence pour la vérification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Flou de confidentialité</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Floute vos discussions jusqu&apos;à ce que vous les surviez, pour qu&apos;un regard sur l&apos;écran ne puisse pas les lire. Survoler une ligne ne révèle que cette ligne.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Thème de discussion</translation>
+        <translation type="vanished">Thème de discussion</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Teinte de couleur du chat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolore WhatsApp Web lui-même. Les photos, avatars et autocollants gardent leurs couleurs. Fonctionne par-dessus le thème clair ou sombre, selon celui qui est actif.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Fond d&apos;écran de discussion</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Utilisez l&apos;une de vos propres images comme fond du volet de discussion, comme WhatsApp sur Android. L&apos;image est stockée dans Whatly, n&apos;est envoyée nulle part et n&apos;est visible que par vous.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Choisir une image…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Les nouvelles connexions apparaissent comme « Whatly pour Linux » (ou la plateforme correspondante) dans la liste des appareils connectés de votre téléphone, au lieu de « Google Chrome (Linux) ». Le nom est enregistré sur le téléphone lors de la connexion d&apos;un appareil : modifier ceci n&apos;affecte donc que les connexions futures. Déconnectez-vous et reconnectez-vous pour renommer une session existante.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>S&apos;identifier comme Whatly dans les appareils connectés</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>Agent utilisateur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avancé — n'y touchez pas à moins de savoir exactement ce que vous faites. Un user agent non standard peut empêcher WhatsApp de se charger, et des valeurs inhabituelles risquent de faire signaler ou blacklister votre compte WhatsApp.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Appliquer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Réinitialiser par défaut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Facteur de zoom en fenêtre normale</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Dézoomer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Zoomer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>réinitialiser</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Facteur de zoom en maximisé/plein écran</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Réduire dans la zone de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Raccourcis globaux</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Action du bouton de fermeture</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Afficher les raccourcis</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Autorisations</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Afficher les autorisations</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Activer l&apos;écran de verrouillage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Activer le verrouillage au démarrage</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quand la fenêtre se masque dans la zone de notification, la verrouiller derrière le code. Nécessite un mot de passe défini.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Verrouiller une fois masqué dans la zone de notification</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Verrouiller aussi Whatly lorsque la session de bureau se verrouille. Nécessite un mot de passe défini. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Verrouiller quand l’écran se verrouille</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Mot de passe actuel</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Changer le mot de passe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Changer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Activer le verrouillage automatique après</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Réinitialiser</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Afficher le mot de passe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Dossier de téléchargement par défaut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Changer le dossier de téléchargement</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Stockage </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Propriété</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Vider (nécessite un redémarrage)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Les données persistantes comprennent les cookies persistants, le stockage local HTML5 et les liens visités.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Données persistantes</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>Le cache HTTP et multimédia. Le vider est sans risque — il est de nouveau téléchargé au besoin.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Vider le cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Sauvegarde</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Enregistrer ce compte (paramètres, session et modules) dans une archive .tar.gz. L&apos;archive contient votre session connectée — gardez-la privée.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Exporter le profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Restaurer un compte depuis une archive .tar.gz. Cela écrase les données actuelles et nécessite un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Importer le profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Performances &amp; confidentialité</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Ajustez le moteur de rendu. Les valeurs par défaut conviennent à la plupart des systèmes ; si la fenêtre est vide, si l&apos;application plante au démarrage ou si elle saccade, essayez de les modifier. Les modifications s&apos;appliquent après un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Effectue tout le rendu sur le CPU (--disable-gpu). Corrige les fenêtres vides et les plantages au démarrage sur certaines configurations GPU/pilote. Par défaut sous Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Désactiver l&apos;accélération GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Composite la page sur le CPU (--disable-gpu-compositing). Évite le scintillement d&apos;images figées sur certains pilotes.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Désactiver la composition GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Désactive la VSync du GPU (--disable-gpu-vsync). Peut réduire la latence des entrées au prix d&apos;un déchirement de l&apos;image.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Désactiver la VSync du GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Exécute le processus GPU au sein du processus principal (--in-process-gpu). Une solution de contournement pour certaines configurations en bac à sable.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Exécuter le GPU dans le processus principal</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Force l&apos;accélération même lorsque le pilote figure sur la liste de blocage (--ignore-gpu-blocklist). Essayez ceci pour réactiver le GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Ignorer la liste de blocage du GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Exécute tout dans un seul processus (--single-process). Utilise moins de mémoire mais est moins stable.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Mode processus unique (moins de mémoire)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Partage un processus de rendu par site (--process-per-site). Réduit l&apos;utilisation de la mémoire.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Un processus par site (moins de mémoire)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Masque les noms de contacts et les aperçus de messages dans la liste des discussions (survolez pour en révéler un). Utile lors du partage d’écran. La conversation ouverte reste intacte.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Mode concentration (masquer les aperçus)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Utiliser par défaut la qualité HD pour les photos et vidéos dans l&apos;éditeur multimédia. Dépend de la mise en page de WhatsApp Web ; si une mise à jour de WhatsApp le casse, désactivez-le.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Envoyer les photos et vidéos en HD par défaut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Empêche WebRTC de révéler votre adresse IP locale sur les connexions non relayées par un proxy.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Empêcher la fuite d&apos;IP via WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Limite de mémoire JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Limite le tas JavaScript (V8 --max-old-space-size). 0 = automatique. Réduisez-la si l&apos;application utilise trop de RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> Mo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Cache HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Emplacement de conservation du cache HTTP. La mémoire est vidée à la fermeture ; « Aucun » désactive la mise en cache.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Taille maximale</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Taille maximale du cache sur disque. 0 = automatique.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Réseau &amp; Démarrage</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Lancer Whatly automatiquement à l&apos;ouverture de votre session de bureau.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Démarrer Whatly à l&apos;ouverture de ma session</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Remplacer la bordure de fenêtre du système par la barre de titre fine de Whatly. Prend effet après un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Utiliser un cadre de fenêtre personnalisé (redémarrage requis)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Vérifier GitHub une fois par jour pour détecter une nouvelle version et vous prévenir. Whatly ne télécharge ni n&apos;installe jamais rien de lui-même.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Rechercher les mises à jour automatiquement</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Échelle de l&apos;interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Mettre à l&apos;échelle toute la fenêtre et la page (QT_SCALE_FACTOR). Automatique suit le bureau. Une variable d&apos;environnement QT_SCALE_FACTOR, si elle est définie, a priorité sur ce réglage. Prend effet après un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Mode de connexion de Whatly au réseau. Système suit le système d&apos;exploitation ; Aucun se connecte directement.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Hôte</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Facultatif</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Modules JavaScript personnalisés</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Chargez des fichiers .js à exécuter sur WhatsApp Web. Chaque module s&apos;exécute dans son propre bac à sable, de sorte qu&apos;un module défectueux ne peut pas affecter les autres ni la page. Décochez un module pour le désactiver sans le supprimer. Les modifications prennent effet après un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Ajouter un module…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Réponses enregistrées</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Textes courts que vous envoyez souvent. Insérez-en un depuis la palette de commandes (Ctrl+K) — tapez &quot;Insérer&quot; et choisissez-le ; le texte est saisi dans la zone de message.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Ajouter une réponse…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Raccourcis clavier</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Cliquez sur un champ et appuyez sur la combinaison de touches. Videz un champ pour supprimer le raccourci. Les modifications s&apos;appliquent après un redémarrage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Ceci supprimera les données persistantes (y compris les cookies persistants et le cache) et fermera l&apos;application.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Supprimer les cookies et quitter l&apos;application ?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Erreur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Impossible de définir une chaîne User-Agent vide.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Le changement automatique de thème a été désactivé suite à un changement manuel.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Le verrouillage de l&apos;application n&apos;est pas configuré.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Voulez-vous configurer le verrouillage de l&apos;application maintenant ?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Autorisations des fonctionnalités</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Choisir un fond d&apos;écran de discussion</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Images (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Impossible d&apos;utiliser cette image : %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Choisir un fichier CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Feuilles de style (*.css);;Tous les fichiers (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Impossible de lire ce fichier : %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disque</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Aucun (direct)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portail de bureau (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Service système (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Ajouter une réponse</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Texte à insérer</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Choisir un fichier JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Tous les fichiers (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Impossible d&apos;ajouter le module</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Supprimer le module</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Supprimer le module &quot;%1&quot; ? Cela supprime son fichier.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Correcteur orthographique (aucun dictionnaire installé)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Aucune</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Général</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Apparence</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Notifications</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Discussions</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Confidentialité et verrouillage</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Fenêtre et zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Raccourci déjà utilisé</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Ce raccourci est déjà utilisé par une autre action.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Vider le cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Vider le cache maintenant ? Il sera de nouveau téléchargé au besoin.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Exporter le profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>L&apos;archive contiendra votre session WhatsApp connectée. Gardez-la privée. Continuer ?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archives (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profil exporté.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Importer le profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Cela écrase les données du compte actuel avec l&apos;archive, puis Whatly doit être redémarré. Continuer ?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profil importé. Veuillez redémarrer Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 langues</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Par défaut de WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Par défaut du système</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>La langue de l&apos;interface changera au redémarrage de %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Configuration du verrouillage</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Veuillez d&apos;abord configurer le mot de passe de verrouillage.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Choisir le dossier de téléchargement</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Cela déconnectera votre session actuelle.
 Un redémarrage complet de l&apos;application peut aussi être nécessaire !</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Voulez-vous continuer ?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Un redémarrage complet de l&apos;application peut aussi être nécessaire !</tr
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Bienvenue dans Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Un client WhatsApp Web rapide et natif pour votre bureau. Configurons quelques points ensemble — vous pourrez tout modifier plus tard dans les Paramètres.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly garde vos conversations dans une véritable fenêtre de bureau, avec une icône dans la zone de notification, des notifications, des thèmes et la prise en charge de plusieurs comptes.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Quelques préférences</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Des réglages par défaut judicieux ; ajustez-les à votre goût.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Suivre le thème clair/sombre du système</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Démarrer Whatly à l&apos;ouverture de ma session</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Diffusion des notifications :</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automatique</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portail de bureau (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Service système (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Tout est prêt</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Vous êtes prêt. Scannez le QR code avec votre téléphone pour vous connecter.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Tout se trouve dans les Paramètres si vous changez d&apos;avis.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Un redémarrage complet de l&apos;application peut aussi être nécessaire !</tr
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Impossible de lire la dernière version</translation>
     </message>
@@ -2038,82 +2626,104 @@ Un redémarrage complet de l&apos;application peut aussi être nécessaire !</tr
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Partager votre écran</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Choisissez ce que vous partagez :</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Sans titre</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Écran : </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Fenêtre : </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Autoriser %1 à accéder à vos informations de localisation ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Autoriser %1 à accéder à votre microphone ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Autoriser %1 à accéder à votre caméra ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Autoriser %1 à accéder à votre microphone et à votre caméra ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Autoriser %1 à verrouiller le curseur de votre souris ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Autoriser %1 à capturer la vidéo de votre bureau ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Autoriser %1 à capturer l&apos;audio et la vidéo de votre bureau ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Autoriser %1 à afficher des notifications sur votre bureau ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Autoriser %1 à lire votre presse-papiers ? C&apos;est nécessaire pour coller des images dans une discussion.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Autoriser %1 à voir les polices installées sur votre système ?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Demande d&apos;autorisation</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Erreur de certificat</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Saisissez le nom d&apos;utilisateur et le mot de passe pour « %1 » sur %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Se connecter au proxy « %1 » en utilisant :</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Autoriser %1 à ouvrir tous les liens %2 ?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Un redémarrage complet de l&apos;application peut aussi être nécessaire !</tr
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Le processus de rendu s&apos;est arrêté normalement</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Le processus de rendu s&apos;est arrêté anormalement</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Le processus de rendu a planté</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Le processus de rendu a été arrêté</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Le processus de rendu s&apos;est arrêté avec le code : %1

--- a/src/i18n/hi_IN.ts
+++ b/src/i18n/hi_IN.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>PayPal से दान करें</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>स्टोर में रेटिंग दें</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>अन्य ऐप्लिकेशन</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>स्रोत कोड</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;नीचे दी गई डिबग जानकारी को क्लिपबोर्ड पर कॉपी करता है और इश्यू ट्रैकर खोलता है, ताकि इसे सीधे रिपोर्ट में पेस्ट किया जा सके।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>बग की रिपोर्ट करें</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>डीबग जानकारी</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>संस्करण: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>डिबग जानकारी ब्राउज़र के लिए बहुत लंबी थी, इसलिए इसे क्लिपबोर्ड पर कॉपी कर दिया गया है। इसे इश्यू में पेस्ट करें।</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | परिचय</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>सूर्योदय</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>सूर्यास्त</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  ताज़ा करें </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>बंद करें और निष्क्रिय करें</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  सक्रिय करें और बंद करें</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>त्रुटि</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 कृपया पुनः प्रयास करें।</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>संवाद</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>आइकन</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>त्रुटि</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (डिफ़ॉल्ट)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>बार्बी गुलाबी</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>धूसर गुलाबी</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>लैवेंडर</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>बैंगनी</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>आसमानी नीला</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>गहरा समुद्र</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>टील</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>मिंट</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>कोरल</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>पीच</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>सुनहरा</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>क्रिमसन</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>ग्रेफ़ाइट</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>कमांड पैलेट</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>कोई कमांड टाइप करें…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>कमांड खोज</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>मेल खाने वाले कमांड</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>छोटा करें</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>बड़ा करें</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>डाउनलोड</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>कोई डाउनलोड नहीं</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>डाउनलोड सूची साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>सब साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>फ़ाइल प्रबंधक में डाउनलोड फ़ोल्डर खोलें</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>डाउनलोड फ़ोल्डर खोलें</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>इसी नाम की फ़ाइल पहले से मौजूद है!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>फ़ाइल को नए नाम से सहेजें?</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>सिस्टम ऐप्लिकेशन से फ़ाइल खोलें</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %2 में से %1 डाउनलोड हुआ - %3/से॰</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>अज्ञात आकार - %1 डाउनलोड हुआ - %2/से॰</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>पूर्ण - %1 डाउनलोड हुआ - %2/से॰</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>रद्द - %1 डाउनलोड हुआ - %2/से॰</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>बाधित: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>डाउनलोड रोकें</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>सूची से हटाएँ</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>लॉक पासकोड सेट करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>पासकोड दर्ज करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>पासकोड फिर से दर्ज करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>पासकोड सेट करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>चेतावनी: Caps Lock चालू है</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ध्यान दें: पासकोड 3 वर्ण से लंबा होना चाहिए और दोनों फ़ील्ड में समान होना चाहिए।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>पहुँच के लिए अपना पासकोड दर्ज करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>अपना पासकोड दर्ज करें</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ग़लत पासकोड। कृपया फिर से प्रयास करें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>नेटवर्क की प्रतीक्षा…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>कोई WhatsApp विंडो खुली नहीं है</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>अनुस्मारक</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>अनुस्मारक: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>अपडेट उपलब्ध है</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 उपलब्ध है। डाउनलोड पेज खोलने के लिए क्लिक करें।</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| त्रुटि</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>सेटिंग्स तक पहुँचने के लिए अनलॉक करें।</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>सेटिंग्स मॉड्यूल आरंभ नहीं किया जा सका।
 WebEngine आरंभ नहीं हुआ है।</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | कार्रवाई आवश्यक</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>जारी रखने के लिए पृष्ठ को पुनः लोड करना होगा।</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>नई चैट</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>देश कोड सहित मान्य WhatsApp नंबर दर्ज करें (उदा॰ +91XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>ऐप्लिकेशन को रेटिंग दें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 अभी सेटिंग्स खोलें?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>ट्रे में छोटा करें (&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>पुनर्स्थापित करें (&amp;R)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>पुनः लोड करें (&amp;L)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>लॉक करें (&amp;K)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>ऑडियो &amp;म्यूट करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>ज़ूम इन</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>ज़ूम आउट</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>ज़ूम रीसेट करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>सेटिंग्स (&amp;S)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>शेड्यूल किए गए संदेश…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>थीम बदलें (&amp;T)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>टैब दृश्य</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>कमांड पैलेट</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>परिचय (&amp;A)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>बाहर निकलें (&amp;Q)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>पुनः लोड करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>ट्रे में छोटा करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>लॉक करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>ऑडियो म्यूट करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>नई चैट / URL खोलें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>थीम टॉगल करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>बाहर निकलें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>नाम बदलें…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>खाता हटाएँ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>इस खाते पर स्विच करें: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>खाता जोड़ें…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>सम्मिलित करें: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 अपठित</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>एक और खाता जोड़ें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>पुनर्स्थापित करें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>संदेश</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>संदेश</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>खाता जोड़ें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>नए खाते का नाम:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>खाता %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>खाते का नाम बदलें</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>खाते का नाम:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>खाता 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>ऐप्लिकेशन पुनः लोड करने के लिए अनलॉक करें।</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>प्रमाणीकरण आवश्यक</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>आइकन</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>जानकारी</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>उपयोगकर्ता नाम:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>पासवर्ड:</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>सुविधा</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>स्थिति</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>चैट सूची</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>खुली बातचीत</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>चैट सूची और बातचीत</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>सब कुछ, तस्वीरों सहित</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>डीबग जानकारी दिखाएँ</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>डीबग जानकारी छिपाएँ</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>&quot;%1&quot; से माइग्रेट करने के लिए कुछ नहीं — पहले ही माइग्रेट हो चुका, या कोई डेटा नहीं मिला।</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>कॉपी करेगा:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>कॉपी किया गया:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>कॉपी करने के लिए --dry-run के बिना फिर से चलाएँ।</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Qt WebEngine पर आधारित सुविधा-संपन्न WhatsApp Web क्लाइंट</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>कमांड-लाइन विकल्पों की सहायता दिखाता है</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>चल रहे इंस्टेंस में सेटिंग्स खोलता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>चल रहे इंस्टेंस को लॉक करता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>चल रहे इंस्टेंस में «परिचय» विंडो खोलता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>चल रहे इंस्टेंस में शेड्यूल किए गए संदेश संवाद खोलता है </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>चल रहे इंस्टेंस में हल्की और गहरी थीम के बीच बदलता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>चल रहे इंस्टेंस में ऐप्लिकेशन पुनः लोड करता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>चल रहे इंस्टेंस में नई चैट विंडो खोलता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;अपने स्वयं के सत्र और सेटिंग्स के साथ, अपनी अलग विंडो में एक अलग खाते के रूप में चलाएँ&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>चल रहे इंस्टेंस की मुख्य विंडो दिखाता है: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>पिछली इंस्टॉल (उदा. पुराना &quot;whatsie&quot; बिल्ड) से सेटिंग्स और लॉग-इन सत्र को इसमें कॉपी करें, फिर बाहर निकलें</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>--migrate-from के साथ, केवल यह बताएँ कि क्या कॉपी किया जाएगा</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>मौजूदा अपठित संदेशों की संख्या दिखाकर बाहर निकलें</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>ऐप लॉक कॉन्फ़िगर नहीं है।
 कृपया पहले सेटिंग्स में पासवर्ड सेट करें।</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>पुनः लोड हो रहा है...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>इंस्टॉल मोड</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>स्रोत ब्रांच</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>कमिट हैश</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>बिल्ड तिथि</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt रनटाइम संस्करण</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt कंपाइल संस्करण</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>सिस्टम</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>आर्किटेक्चर</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>अपवाद</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> में समस्या आई है।</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> को पुनः आरंभ करना पड़ सकता है। कृपया त्रुटि की सूचना डेवलपर को दें।</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>&apos;tar&apos; नहीं चलाया जा सका</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>बैकअप के लिए कुछ नहीं है</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>%1 नहीं बनाया जा सका</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>%1 कॉपी नहीं की जा सकी</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>अस्थायी डायरेक्टरी नहीं बनाई जा सकी</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>सेटिंग्स फ़ाइल पुनर्स्थापित नहीं की जा सकी</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>%1 नहीं लिखा जा सका</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>लाइट थीम पर स्विच करें</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>डार्क थीम पर स्विच करें</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>चैट दिखाएँ</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>चैट धुंधली करें</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>इस ऐप को रेटिंग दें</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;यदि आपको यह ऐप पसंद आया, तो क्या आप इसे रेटिंग देने के लिए थोड़ा समय निकालेंगे?&lt;/p&gt;&lt;p&gt;इसमें एक मिनट से अधिक नहीं लगेगा। आपके सहयोग के लिए धन्यवाद!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  स्टोर में रेटिंग दें</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>अथवा</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>GitHub रिपॉज़िटरी को स्टार दें</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>PayPal से दान करें </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>OpenCollective से दान करें</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>बाद में</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  पहले ही कर चुका हूँ  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>संदेश भेजने की प्रतीक्षा में समय समाप्त हो गया</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>दैनिक</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>कार्यदिवस</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>साप्ताहिक</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>एक बार</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>भेजा गया</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>विफल</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>लंबित</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>शेड्यूल किए गए संदेश</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>प्रति</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>कब</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>संदेश</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>स्थिति</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>अंतरराष्ट्रीय प्रारूप में फ़ोन नंबर, उदा. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>वैकल्पिक लेबल</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>एक बार</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>दैनिक</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>कार्यदिवस</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>साप्ताहिक</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>दोहराएँ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>भेजने के बजाय मुझे याद दिलाएँ (सूचित करें, संदेश न भेजें)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>भेजने के लिए संदेश</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>निर्धारित समय पर ऐप चालू और WhatsApp में लॉग इन होना चाहिए। यदि यह बंद है, तो संदेश अगली बार ऐप खोलने पर भेजा जाता है। भेजने पर प्राप्तकर्ता की चैट खुल जाती है।</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>शेड्यूल करें</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>चयनित हटाएँ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>भेजे गए/विफल साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>एक फ़ोन नंबर और एक संदेश दर्ज करें।</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>समय बीत चुका है — क्या यह संदेश अभी भेजें?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>इंटरफ़ेस फ़ॉन्ट आकार</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ऐप के अपने इंटरफ़ेस — मेन्यू, सेटिंग्स और डायलॉग — का पॉइंट आकार। यह WhatsApp Web के टेक्स्ट को प्रभावित नहीं करता; उसके लिए ज़ूम का उपयोग करें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>डिस्प्ले थीम</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>क्रैश के बाद स्वचालित रूप से पुनः लोड करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;यदि WhatsApp Web की पेज प्रक्रिया क्रैश हो जाए, तो पहले पूछने के बजाय उसे स्वचालित रूप से पुनः लोड करें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>सामान्य सेटिंग्स</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>विजेट शैली</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>विजेट थीम</translation>
+        <translation type="vanished">विजेट थीम</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;आपके सिस्टम के समय क्षेत्र और स्थान के आधार पर।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>गहरा</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>हल्का</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;डेस्कटॉप की लाइट/डार्क वरीयता से मेल खाता है और उसी के साथ बदलता है। मैनुअल थीम और स्वचालित सूर्योदय/सूर्यास्त स्विच को ओवरराइड करता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>सिस्टम की लाइट/डार्क थीम का अनुसरण करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>सिस्टम सूचना</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>अनुकूलित सूचना</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  आज़माएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>सूचना का प्रकार</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>सूचना पॉपअप निष्क्रिय करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>पॉपअप का समय</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> से॰</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>सूचना वितरण</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Linux पर नेटिव सूचनाएँ कैसे भेजी जाती हैं। स्वचालित मोड Flatpak सैंडबॉक्स के भीतर डेस्कटॉप पोर्टल का और अन्यथा सिस्टम सेवा का उपयोग करता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>दैनिक शांत अवधि के दौरान सूचना पॉपअप को रोकें। अपठित बैज फिर भी अपडेट होते रहेंगे; केवल पॉपअप रोका जाता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>परेशान न करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>से</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>तक</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>मुख्य शब्द हाइलाइट करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>अल्पविराम से अलग किए गए शब्द जो हमेशा सूचित करते हैं, यहाँ तक कि परेशान न करें के दौरान भी (अक्षर-आकार असंवेदनशील)।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>जैसे अत्यावश्यक, बॉस, बिल</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>सिस्टम फ़ाइल संवाद का उपयोग करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>पृष्ठ की ध्वनि म्यूट करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>मीडिया का स्वतः चलना निष्क्रिय करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>प्रारंभ पर ट्रे में छोटा करके चलाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>ट्रे आइकन पर क्लिक करने पर दिखाएँ/छिपाएँ (यदि समर्थित हो)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;कहीं और क्लिक करने पर इमोजी, GIF और स्टिकर पैनल बंद कर देता है। अन्यथा WhatsApp Web उसे तब तक खुला रखता है जब तक बटन दोबारा न दबाया जाए।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>बाहर क्लिक करने पर इमोजी/स्टिकर पैनल बंद करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>इंटरफ़ेस भाषा</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whatly के अपने इंटरफ़ेस की भाषा। ऐप पुनः आरंभ करने पर लागू होती है। चैट की भाषा WhatsApp Web से आती है और यहाँ नहीं बदली जा सकती।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp के साइडबार में, आपकी प्रोफ़ाइल तस्वीर के ठीक ऊपर एक लाइट/डार्क बटन जोड़ता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp के साइडबार में थीम बटन</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp के साइडबार में एक बटन जोड़ता है जो सेटिंग्स खोले बिना एक क्लिक में आपकी चैट को ब्लर और अनब्लर करता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp के साइडबार में ब्लर बटन</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp के हरे आइकन के बजाय, आपके पैनल के बाकी हिस्से से मेल खाता एकल-रंग ट्रे आइकन उपयोग करता है। WhatsApp कनेक्ट न होने पर आइकन मंद भी हो जाता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>मोनोक्रोम ट्रे आइकन</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;पंक्ति दर पंक्ति कूदने के बजाय स्क्रॉलिंग को एनिमेट करता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>स्मूद स्क्रॉलिंग</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>कस्टम CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web को फिर से स्टाइल करने के लिए एक .css फ़ाइल लोड करें — कम्युनिटी स्टाइलशीट (catppuccin आदि) यहाँ काम करती हैं। चैट थीम के ऊपर लागू होती है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>फ़ाइल चुनें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;सिस्टम ट्रे आइकन को पूरी तरह हटा देता है। पुनर्स्थापित करने के लिए ट्रे न होने पर, विंडो बंद करने से ऐप छिपने के बजाय बंद हो जाता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>ट्रे आइकन छिपाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>फ़ॉन्ट परिवार</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web के टेक्स्ट को आपके सिस्टम पर इंस्टॉल किए गए फ़ॉन्ट में दिखाएँ। इमोजी, आइकन और मोनोस्पेस संदेश फ़ॉर्मेटिंग अपरिवर्तित रहती है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;स्टेटस/अपडेट पैनल में &quot;म्यूट किए गए अपडेट&quot; अनुभाग छिपाएँ, ताकि आपने जिन संपर्कों को म्यूट किया है उनके स्टेटस बिल्कुल न दिखें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>म्यूट किए गए स्टेटस अपडेट छिपाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;टाइप करते समय गलत वर्तनी वाले शब्दों को रेखांकित करता है और राइट-क्लिक मेनू में सुधार सुझाता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>टाइप करते समय वर्तनी जाँचें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;जिस भाषा के विरुद्ध जाँच की जाए।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>गोपनीयता ब्लर</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;जब तक आप उन पर होवर नहीं करते तब तक आपकी चैट को ब्लर रखता है, ताकि स्क्रीन पर नज़र डालने वाला उन्हें न पढ़ सके। किसी पंक्ति पर होवर करने से केवल वही पंक्ति दिखती है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>चैट थीम</translation>
+        <translation type="vanished">चैट थीम</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>चैट रंग टिंट</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web को ही फिर से रंगता है। तस्वीरें, अवतार और स्टिकर अपने रंग बनाए रखते हैं। जो भी सक्रिय हो, लाइट या डार्क थीम के ऊपर काम करता है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>चैट वॉलपेपर</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;चैट फलक की पृष्ठभूमि के रूप में अपनी कोई छवि उपयोग करें, जैसे WhatsApp Android पर करता है। छवि Whatly के भीतर संग्रहीत होती है, कहीं अपलोड नहीं होती, और केवल आपको दिखती है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>छवि चुनें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;नए लॉगिन आपके फ़ोन की लिंक किए गए डिवाइस सूची में «Google Chrome (Linux)» के बजाय «Whatly for Linux» (या संबंधित प्लेटफ़ॉर्म) के रूप में दिखेंगे। यह नाम डिवाइस लिंक करते समय फ़ोन पर सहेजा जाता है, इसलिए इसे बदलने का असर केवल आगे के लिंक पर पड़ेगा — किसी मौजूदा सत्र का नाम बदलने के लिए लॉग आउट कर के फिर से लिंक करें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>लिंक किए गए डिवाइस में Whatly के रूप में पहचानें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>यूज़र एजेंट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;उन्नत — इसे तब तक न बदलें जब तक आपको ठीक-ठीक पता न हो कि आप क्या कर रहे हैं। ग़ैर-मानक user agent के कारण WhatsApp लोड होने से मना कर सकता है, और असामान्य मान आपके WhatsApp खाते को फ़्लैग किए जाने या ब्लैकलिस्ट में डाले जाने का जोखिम पैदा करते हैं।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  लागू करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>डिफ़ॉल्ट पर रीसेट करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>सामान्य विंडो में ज़ूम कारक</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>छोटा करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>बड़ा करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>रीसेट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>अधिकतम/पूर्ण स्क्रीन में ज़ूम कारक</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>ट्रे में छोटा करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>बाहर निकलें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>वैश्विक शॉर्टकट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>बंद करें बटन की क्रिया</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  शॉर्टकट दिखाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>अनुमतियाँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  अनुमतियाँ दिखाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;लॉक स्क्रीन सक्रिय करें।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>प्रारंभ पर ऐप लॉक सक्रिय करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;जब विंडो सिस्टम ट्रे में छिपती है, तो उसे पासकोड के पीछे लॉक करें। पासवर्ड सेट होना आवश्यक है।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>ट्रे में छिपाने पर लॉक करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>डेस्कटॉप सत्र लॉक होने पर Whatly को भी लॉक करें। पासवर्ड सेट होना आवश्यक है। (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>स्क्रीन लॉक होने पर लॉक करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>वर्तमान पासवर्ड</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>पासवर्ड बदलें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>इतने समय बाद स्वतः लॉक करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>रीसेट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>पासवर्ड देखें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>डिफ़ॉल्ट डाउनलोड स्थान</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>डाउनलोड स्थान बदलें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>संग्रहण </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>गुण</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  साफ़ करें (पुनः आरंभ आवश्यक)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;स्थायी डेटा में स्थायी कुकीज़, HTML5 लोकल स्टोरेज और देखे गए लिंक शामिल हैं।&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>स्थायी डेटा</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>HTTP/मीडिया कैश। इसे साफ़ करना सुरक्षित है — आवश्यकता होने पर इसे फिर से डाउनलोड कर लिया जाता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>कैश</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  कैश साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>क्रिया</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>बैकअप</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>इस खाते (सेटिंग्स, सत्र और ऐडऑन) को .tar.gz आर्काइव में सहेजें। आर्काइव में आपका लॉग-इन सत्र होता है — इसे निजी रखें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>प्रोफ़ाइल निर्यात करें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>.tar.gz आर्काइव से किसी खाते को पुनर्स्थापित करें। यह मौजूदा डेटा को अधिलेखित करता है और पुनः आरंभ करने की आवश्यकता होती है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>प्रोफ़ाइल आयात करें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>प्रदर्शन &amp; गोपनीयता</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>रेंडरिंग इंजन को बारीकी से समायोजित करें। अधिकांश सिस्टम पर डिफ़ॉल्ट सुरक्षित हैं; अगर विंडो खाली हो या ऐप शुरू होते ही क्रैश हो जाए, या रुक-रुक कर चले, तो इन्हें बदलकर देखें। परिवर्तन पुनः आरंभ के बाद लागू होते हैं।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>पूरी तरह CPU पर रेंडर करें (--disable-gpu)। कुछ GPU/ड्राइवर सेटअप पर खाली विंडो और शुरुआती क्रैश ठीक करता है। Linux पर डिफ़ॉल्ट।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU त्वरण अक्षम करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>पेज को CPU पर कंपोज़िट करें (--disable-gpu-compositing)। कुछ ड्राइवरों पर पुराने-फ्रेम की झिलमिलाहट से बचाता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU कंपोज़िटिंग अक्षम करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU VSync अक्षम करें (--disable-gpu-vsync)। टियरिंग की कीमत पर इनपुट लैग कम कर सकता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU VSync अक्षम करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>GPU प्रक्रिया को मुख्य प्रक्रिया के भीतर चलाएँ (--in-process-gpu)। कुछ सैंडबॉक्स्ड सेटअप के लिए एक उपाय।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU को प्रक्रिया के भीतर चलाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>ड्राइवर के ब्लॉकलिस्ट में होने पर भी त्वरण को बाध्य करें (--ignore-gpu-blocklist)। GPU फिर से चालू करने के लिए यह आज़माएँ।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU ब्लॉकलिस्ट अनदेखा करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>सब कुछ एक ही प्रक्रिया में चलाएँ (--single-process)। कम मेमोरी उपयोग करता है पर कम स्थिर है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>एकल-प्रक्रिया मोड (कम मेमोरी)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>प्रति साइट एक रेंडरर प्रक्रिया साझा करें (--process-per-site)। मेमोरी उपयोग घटाता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>प्रति साइट एक प्रक्रिया (कम मेमोरी)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>चैट सूची में संपर्क नाम और संदेश पूर्वावलोकन छिपाएँ (एक दिखाने के लिए होवर करें)। स्क्रीन साझा करते समय उपयोगी। खुली बातचीत अपरिवर्तित रहती है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>फ़ोकस मोड (चैट सूची पूर्वावलोकन छिपाएँ)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>मीडिया एडिटर में फ़ोटो और वीडियो को डिफ़ॉल्ट रूप से HD गुणवत्ता में रखें। यह WhatsApp Web के लेआउट पर निर्भर करता है; यदि किसी WhatsApp अपडेट से यह काम करना बंद कर दे, तो इसे बंद कर दें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>फ़ोटो और वीडियो डिफ़ॉल्ट रूप से HD में भेजें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>WebRTC को गैर-प्रॉक्सी कनेक्शनों पर आपका स्थानीय IP पता उजागर करने से रोकें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC IP लीक रोकें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript मेमोरी सीमा</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>JavaScript हीप को सीमित करें (V8 --max-old-space-size)। 0 = स्वचालित। अगर ऐप बहुत अधिक RAM उपयोग करे तो इसे कम करें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP कैश</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>HTTP कैश कहाँ रखें। मेमोरी बाहर निकलने पर साफ़ हो जाती है; None कैशिंग अक्षम करता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>अधिकतम आकार</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>डिस्क पर अधिकतम कैश आकार। 0 = स्वचालित।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>नेटवर्क &amp; स्टार्टअप</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>जब आप अपने डेस्कटॉप सत्र में लॉग इन करें तो Whatly को स्वचालित रूप से प्रारंभ करें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>लॉग इन करने पर Whatly प्रारंभ करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>सिस्टम के विंडो बॉर्डर को Whatly की अपनी पतली टाइटल बार से बदलें। पुनरारंभ के बाद लागू होगा।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>कस्टम विंडो फ्रेम का उपयोग करें (पुनरारंभ आवश्यक)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>नए रिलीज़ के लिए दिन में एक बार GitHub जाँचें और आपको सूचित करें। Whatly अपने आप कभी कुछ भी डाउनलोड या इंस्टॉल नहीं करता।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>अपडेट अपने आप जाँचें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>इंटरफ़ेस स्केल</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>पूरी विंडो और पेज को स्केल करें (QT_SCALE_FACTOR)। Automatic डेस्कटॉप का अनुसरण करता है। यदि QT_SCALE_FACTOR एनवायरनमेंट वेरिएबल सेट है, तो वह इसे ओवरराइड करता है। पुनः प्रारंभ के बाद लागू होता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>प्रॉक्सी</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Whatly नेटवर्क से कैसे जुड़ता है। System ऑपरेटिंग सिस्टम का अनुसरण करता है; None सीधे जुड़ता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>होस्ट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>पोर्ट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>उपयोगकर्ता नाम</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>वैकल्पिक</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>पासवर्ड</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>कस्टम JavaScript ऐडऑन</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>WhatsApp Web पर चलाने के लिए .js फ़ाइलें लोड करें। प्रत्येक ऐडऑन अपने सैंडबॉक्स में चलता है, इसलिए एक खराब ऐडऑन दूसरों या पेज को बंद नहीं कर सकता। किसी ऐडऑन को हटाए बिना अक्षम करने के लिए उसका चेक हटाएँ। परिवर्तन पुनः आरंभ के बाद लागू होते हैं।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>ऐडऑन जोड़ें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>हटाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>सहेजे गए उत्तर</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>छोटे संदेश जिन्हें आप अक्सर भेजते हैं। कमांड पैलेट (Ctrl+K) से कोई एक सम्मिलित करें — &quot;सम्मिलित करें&quot; टाइप करें और उसे चुनें; टेक्स्ट संदेश बॉक्स में लिख दिया जाता है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>उत्तर जोड़ें…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>कीबोर्ड शॉर्टकट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>किसी फ़ील्ड पर क्लिक करें और कुंजी संयोजन दबाएँ। शॉर्टकट हटाने के लिए फ़ील्ड साफ़ करें। परिवर्तन पुनरारंभ के बाद लागू होते हैं।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>यह स्थायी डेटा (स्थायी कुकीज़ और कैश सहित) हटा देगा और एप्लिकेशन बंद कर देगा।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>कुकीज़ हटाएँ और एप्लिकेशन बंद करें?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| त्रुटि</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>खाली User-Agent स्ट्रिंग सेट नहीं की जा सकती।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>थीम मैन्युअल रूप से बदलने के कारण स्वचालित थीम परिवर्तन निष्क्रिय कर दिया गया।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>ऐप लॉक कॉन्फ़िगर नहीं है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>क्या आप अभी ऐप लॉक सेट करना चाहते हैं?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>सुविधा अनुमतियाँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>चैट वॉलपेपर चुनें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>छवियाँ (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>वह छवि उपयोग नहीं की जा सकी: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>एक CSS फ़ाइल चुनें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>स्टाइलशीट (*.css);;सभी फ़ाइलें (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>वह फ़ाइल नहीं पढ़ी जा सकी: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>डिस्क</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>मेमोरी</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>सिस्टम</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>कोई नहीं (सीधा)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>डेस्कटॉप पोर्टल (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>सिस्टम सेवा (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>उत्तर जोड़ें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>सम्मिलित किया जाने वाला टेक्स्ट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>एक JavaScript फ़ाइल चुनें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;सभी फ़ाइलें (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>ऐडऑन नहीं जोड़ा जा सका</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>ऐडऑन हटाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>ऐडऑन &quot;%1&quot; हटाएँ? इससे इसकी फ़ाइल हट जाती है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>वर्तनी परीक्षक (कोई शब्दकोश स्थापित नहीं)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>कोई नहीं</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>मूल बातें</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>दिखावट</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>सूचनाएँ</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>बातचीत</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>गोपनीयता और लॉक</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>विंडो और ज़ूम</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>उन्नत</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>शॉर्टकट उपयोग में है</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>यह शॉर्टकट पहले से किसी अन्य क्रिया द्वारा उपयोग किया जा रहा है।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>कैश साफ़ करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>अभी कैश साफ़ करें? आवश्यकता होने पर इसे फिर से डाउनलोड कर लिया जाएगा।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>प्रोफ़ाइल निर्यात करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>आर्काइव में आपका लॉग-इन WhatsApp सत्र होगा। इसे निजी रखें। जारी रखें?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>आर्काइव (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>प्रोफ़ाइल निर्यात की गई।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>प्रोफ़ाइल आयात करें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>यह मौजूदा खाते के डेटा को आर्काइव से अधिलेखित करता है, फिर Whatly को पुनः आरंभ करना होगा। जारी रखें?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>प्रोफ़ाइल आयात की गई। कृपया Whatly को पुनः आरंभ करें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 भाषाएँ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp डिफ़ॉल्ट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>सिस्टम डिफ़ॉल्ट</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>%1 को पुनः आरंभ करने पर इंटरफ़ेस भाषा बदल जाएगी।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>ऐप लॉक सेटअप</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>कृपया पहले ऐप लॉक पासवर्ड सेट करें।</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>डाउनलोड फ़ोल्डर चुनें</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 आपको एप्लिकेशन को पूरी तरह पुनः आरंभ करने की भी आवश्यकता हो सकती है!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>क्या आप आगे बढ़ना चाहते हैं?</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Whatly में आपका स्वागत है</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>डेस्कटॉप के लिए एक तेज़, नेटिव WhatsApp Web क्लाइंट। चलिए कुछ चीज़ें सेट कर लेते हैं — यह सब आप बाद में सेटिंग्स में बदल सकते हैं।</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly आपकी चैट्स को एक सही डेस्कटॉप विंडो में रखता है — ट्रे आइकन, सूचनाओं, थीम्स और कई खातों के साथ।</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>कुछ प्राथमिकताएँ</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>समझदार डिफ़ॉल्ट; अपने अनुसार बदलें।</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>सिस्टम की लाइट/डार्क थीम से मिलाएँ</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>लॉग इन करने पर Whatly प्रारंभ करें</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>सूचना डिलीवरी:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>डेस्कटॉप पोर्टल (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>सिस्टम सेवा (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>सब तैयार है</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>आप तैयार हैं। साइन इन करने के लिए अपने फ़ोन से QR कोड स्कैन करें।</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>अगर आपका मन बदले, तो यहाँ की हर चीज़ सेटिंग्स में मौजूद है।</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>नवीनतम रिलीज़ नहीं पढ़ी जा सकी</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>अपनी स्क्रीन साझा करें</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>चुनें कि क्या साझा करना है:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>बिना शीर्षक</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>स्क्रीन: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>विंडो: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>क्या %1 को आपकी स्थान जानकारी तक पहुँच की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>क्या %1 को आपके माइक्रोफ़ोन तक पहुँच की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>क्या %1 को आपके कैमरे तक पहुँच की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>क्या %1 को आपके माइक्रोफ़ोन और कैमरे तक पहुँच की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>क्या %1 को आपका माउस कर्सर लॉक करने की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>क्या %1 को आपके डेस्कटॉप का वीडियो रिकॉर्ड करने की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>क्या %1 को आपके डेस्कटॉप का ऑडियो और वीडियो रिकॉर्ड करने की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>क्या %1 को आपके डेस्कटॉप पर सूचनाएँ दिखाने की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>क्या %1 को आपका क्लिपबोर्ड पढ़ने की अनुमति दें? चैट में चित्र चिपकाने के लिए यह आवश्यक है।</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>क्या %1 को आपके सिस्टम में स्थापित फ़ॉन्ट देखने की अनुमति दें?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>अनुमति अनुरोध</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>प्रमाणपत्र त्रुटि</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>%2 पर «%1» के लिए उपयोगकर्ता नाम और पासवर्ड दर्ज करें</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>«%1» प्रॉक्सी से इसके द्वारा कनेक्ट करें:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>क्या %1 को सभी %2 लिंक खोलने की अनुमति दें?</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>रेंडर प्रक्रिया सामान्य रूप से समाप्त हुई</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>रेंडर प्रक्रिया असामान्य रूप से समाप्त हुई</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>रेंडर प्रक्रिया क्रैश हो गई</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>रेंडर प्रक्रिया समाप्त कर दी गई</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>रेंडर प्रक्रिया इस कोड के साथ समाप्त हुई: %1

--- a/src/i18n/id_ID.ts
+++ b/src/i18n/id_ID.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Donasi via PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Beri nilai di toko</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Aplikasi lainnya</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Kode sumber</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menyalin informasi debug di bawah ke papan klip dan membuka pelacak masalah, sehingga dapat langsung ditempelkan ke laporan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Laporkan bug</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Informasi debug</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Versi: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Informasi debug terlalu panjang untuk peramban, jadi telah disalin ke papan klip. Tempelkan ke laporan.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Tentang</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Matahari terbit</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Matahari terbenam</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Segarkan </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Nonaktifkan dan tutup</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Aktifkan dan tutup</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Silakan coba lagi.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Silakan coba lagi.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (bawaan)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Merah muda Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Merah jambu pudar</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavender</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Ungu</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Biru langit</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Samudra dalam</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Hijau kebiruan</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Mint</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Koral</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Persik</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Emas</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Merah tua</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafit</translation>
     </message>
@@ -209,18 +256,22 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Palet perintah</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Ketik perintah…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Pencarian perintah</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Perintah yang cocok</translation>
     </message>
@@ -228,14 +279,17 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimalkan</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maksimalkan</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
@@ -243,34 +297,42 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Unduhan</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Tidak ada unduhan</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Bersihkan daftar unduhan</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Bersihkan semua</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Buka folder unduhan di pengelola berkas</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Buka folder unduhan</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Berkas dengan nama yang sama sudah ada!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Simpan berkas dengan nama baru?</translation>
     </message>
@@ -278,54 +340,68 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Buka berkas dengan aplikasi sistem</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 dari %2 terunduh - %3/dtk</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>ukuran tidak diketahui - %1 terunduh - %2/dtk</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>selesai - %1 terunduh - %2/dtk</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>dibatalkan - %1 terunduh - %2/dtk</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>terputus: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Hentikan unduhan</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Hapus dari daftar</translation>
     </message>
@@ -333,46 +409,58 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Atur kode kunci</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>masukkan kode</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>masukkan kode lagi</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Atur kode</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Peringatan: Caps Lock aktif</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Catatan: kode harus lebih dari 3 karakter dan sama pada kedua kolom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Masukkan kode Anda untuk mengakses</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>masukkan kode Anda</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kode salah. Silakan coba lagi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Apakah Anda ingin melewati pemeriksaan keamanan dan melanjutkan?   </translation
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Menunggu jaringan…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Tidak ada jendela WhatsApp yang terbuka</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Pengingat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Pengingat: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Pembaruan tersedia</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 telah tersedia. Klik untuk membuka halaman unduhan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Kesalahan</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Buka kunci untuk mengakses pengaturan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Tidak dapat menginisialisasi modul pengaturan.
 WebEngine belum diinisialisasi.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Tindakan diperlukan</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>Halaman perlu dimuat ulang untuk melanjutkan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Obrolan baru</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Masukkan nomor WhatsApp yang valid dengan kode negara (mis. +62XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Beri nilai aplikasi</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Silakan atur kata sandi di pengaturan terlebih dahulu.
 Buka pengaturan sekarang?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Layar penuh</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimalkan ke baki sistem</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Pulihkan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Muat &amp;ulang</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>&amp;Kunci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Bisukan audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Perbesar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Perkecil</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Atur ulang zoom</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Pengaturan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>&amp;Pesan terjadwal…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Ganti &amp;tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Tampilan tab</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Tampilan kisi</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Palet perintah</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Tentang</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Keluar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Muat ulang</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Kecilkan ke baki</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Kunci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Bisukan audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Obrolan baru / buka URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Alihkan tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Keluar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Ganti nama…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Hapus akun</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Beralih ke akun: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Tambah akun…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Sisipkan: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 belum dibaca</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Tambah akun lain</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Pulihkan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>pesan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>pesan</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Tambah akun</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nama untuk akun baru:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Akun %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Ganti nama akun</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nama akun:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Akun 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Buka kunci untuk memuat ulang aplikasi.</translation>
     </message>
@@ -623,10 +779,12 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
@@ -641,22 +800,27 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Autentikasi diperlukan</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informasi</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Nama pengguna:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Kata sandi:</translation>
     </message>
@@ -664,14 +828,17 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Fitur</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
@@ -679,22 +846,27 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Mati</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Daftar obrolan</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Percakapan terbuka</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Daftar obrolan dan percakapan</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Semuanya, termasuk foto</translation>
     </message>
@@ -702,10 +874,13 @@ Buka pengaturan sekarang?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Tampilkan informasi debug</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Buka pengaturan sekarang?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Sembunyikan informasi debug</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Tidak ada yang bisa dimigrasikan dari &quot;%1&quot; — sudah dimigrasikan, atau tidak ada data.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Akan menyalin:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Disalin:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Jalankan lagi tanpa --dry-run untuk melakukan penyalinan.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Klien WhatsApp Web berfitur lengkap berbasis Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Menampilkan bantuan untuk opsi baris perintah</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Membuka pengaturan pada instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Mengunci instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Membuka jendela «Tentang» pada instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Membuka dialog pesan terjadwal di instans yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Beralih antara tema terang dan gelap pada instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Memuat ulang aplikasi pada instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Membuka jendela obrolan baru pada instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jalankan sebagai akun terpisah dengan sesi dan pengaturannya sendiri, di jendelanya sendiri&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Menampilkan jendela utama dari instansi yang sedang berjalan dari </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Salin pengaturan dan sesi yang masuk dari instalasi sebelumnya (mis. versi &quot;whatsie&quot; lama) ke sini, lalu keluar</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Dengan --migrate-from, hanya laporkan apa yang akan disalin</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Cetak jumlah pesan belum dibaca saat ini lalu keluar</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Kunci aplikasi belum dikonfigurasi.
 Silakan atur kata sandi di pengaturan terlebih dahulu.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Memuat ulang...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Mode pemasangan</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Cabang sumber</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Hash commit</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Waktu build</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Versi Qt saat berjalan</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Versi Qt saat kompilasi</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Arsitektur</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Pengecualian</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> mengalami masalah.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> mungkin perlu dimulai ulang. Silakan laporkan kesalahan ini kepada pengembang.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Tidak dapat menjalankan &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Tidak ada yang perlu dicadangkan</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Tidak dapat membuat %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Tidak dapat menyalin %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Tidak dapat membuat direktori sementara</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Tidak dapat memulihkan berkas pengaturan</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Tidak dapat menulis %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Beralih ke tema terang</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Beralih ke tema gelap</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Tampilkan obrolan</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Buramkan obrolan</translation>
@@ -898,42 +1123,53 @@ Silakan atur kata sandi di pengaturan terlebih dahulu.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Beri nilai aplikasi ini</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jika Anda menikmati aplikasi ini, maukah Anda meluangkan waktu sejenak untuk memberi nilai?&lt;/p&gt;&lt;p&gt;Tidak akan memakan waktu lebih dari satu menit. Terima kasih atas dukungan Anda!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Beri nilai di toko</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Atau</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Beri bintang pada repositori GitHub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Donasi via PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Donasi via OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Nanti</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Sudah dilakukan  </translation>
     </message>
@@ -941,34 +1177,42 @@ Silakan atur kata sandi di pengaturan terlebih dahulu.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Waktu habis menunggu pesan terkirim</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Harian</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Hari kerja</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Mingguan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Sekali</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Terkirim</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Gagal</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Menunggu</translation>
     </message>
@@ -976,90 +1220,117 @@ Silakan atur kata sandi di pengaturan terlebih dahulu.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Pesan terjadwal</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Kepada</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Kapan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Pesan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Nomor telepon dalam format internasional, mis. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Label opsional</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Sekali</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Harian</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Hari kerja</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Mingguan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Ulangi</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Ingatkan saya alih-alih mengirim (beri tahu, jangan kirim pesan)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Pesan untuk dikirim</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>Aplikasi harus berjalan dan WhatsApp masuk pada waktu yang dijadwalkan. Jika ditutup, pesan dikirim saat Anda membuka aplikasi berikutnya. Mengirim akan membuka obrolan penerima.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Jadwalkan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Hapus yang dipilih</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Bersihkan terkirim/gagal</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Masukkan nomor telepon dan pesan.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Waktunya sudah lewat — kirim pesan ini sekarang?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Silakan atur kata sandi di pengaturan terlebih dahulu.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Ukuran font antarmuka</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukuran titik antarmuka aplikasi sendiri — menu, pengaturan, dan dialog. Ini tidak memengaruhi teks WhatsApp Web; gunakan zoom untuk itu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Tema tampilan</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Muat ulang otomatis setelah crash</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jika proses halaman WhatsApp Web crash, muat ulang secara otomatis alih-alih bertanya dahulu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Pengaturan umum</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Gaya widget</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Tema widget</translation>
+        <translation type="vanished">Tema widget</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Berdasarkan zona waktu dan lokasi sistem Anda.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Otomatis</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Gelap</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Terang</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mengikuti preferensi terang/gelap desktop dan berubah bersamanya. Menggantikan tema manual dan peralihan otomatis matahari terbit/terbenam.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Ikuti tema terang/gelap sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Notifikasi bawaan sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Notifikasi khusus</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Coba</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Jenis notifikasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Nonaktifkan pop-up notifikasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Durasi pop-up</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> dtk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Pengiriman notifikasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Cara notifikasi native dikirim di Linux. Otomatis menggunakan portal desktop di dalam sandbox Flatpak dan layanan sistem jika tidak.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Tahan pop-up notifikasi selama periode tenang harian. Lencana belum dibaca tetap diperbarui; hanya pop-up yang ditahan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Jangan Ganggu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Dari</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>hingga</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Sorot kata kunci</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Kata-kata yang dipisahkan koma yang selalu memberi notifikasi, bahkan saat Jangan Ganggu (tidak peka huruf besar/kecil).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>mis. mendesak, bos, faktur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Gunakan dialog berkas bawaan sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Bisukan audio halaman</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Nonaktifkan pemutaran media otomatis</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Mulai terminimalkan di baki sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Tampilkan/sembunyikan saat mengeklik ikon baki (jika didukung)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menutup panel emoji, GIF, dan stiker saat Anda mengeklik di tempat lain. Jika tidak, WhatsApp Web membiarkannya terbuka sampai tombolnya ditekan lagi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Tutup panel emoji/stiker saat mengeklik di luar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Bahasa antarmuka</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bahasa antarmuka Whatly sendiri. Berlaku setelah memulai ulang aplikasi. Bahasa obrolan berasal dari WhatsApp Web dan tidak dapat diubah di sini.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menambahkan tombol terang/gelap ke bilah sisi WhatsApp, tepat di atas foto profil Anda.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Tombol tema di bilah sisi WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menambahkan tombol ke bilah sisi WhatsApp yang memburamkan dan menampilkan obrolan Anda dengan satu klik, tanpa membuka Pengaturan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Tombol buram di bilah sisi WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menggunakan ikon baki satu warna yang serasi dengan panel Anda, alih-alih ikon hijau WhatsApp. Ikon juga meredup saat WhatsApp tidak terhubung.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Ikon baki monokrom</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menganimasikan guliran alih-alih melompat baris demi baris.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Guliran mulus</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS khusus</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Muat berkas .css untuk mengubah gaya WhatsApp Web — lembar gaya komunitas (catppuccin dan sejenisnya) berfungsi di sini. Diterapkan di atas tema obrolan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Pilih berkas…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Bersihkan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menghapus ikon baki sistem sepenuhnya. Tanpa baki untuk memulihkan, menutup jendela akan menutup aplikasi alih-alih menyembunyikannya.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Sembunyikan ikon baki</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Jenis font</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan teks WhatsApp Web dengan font yang terpasang di sistem Anda. Emoji, ikon, dan pemformatan pesan monospace tidak diubah.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sembunyikan bagian &quot;Pembaruan dibisukan&quot; di panel Status/Pembaruan, sehingga status dari kontak yang Anda bisukan tidak muncul sama sekali.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Sembunyikan pembaruan status yang dibisukan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Menggarisbawahi kata yang salah eja saat Anda mengetik, dan menawarkan koreksi di menu klik kanan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Periksa ejaan saat mengetik</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bahasa yang digunakan untuk pemeriksaan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Buram privasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Memburamkan obrolan Anda hingga Anda mengarahkan kursor ke atasnya, sehingga orang yang melirik layar tidak dapat membacanya. Mengarahkan kursor ke satu baris hanya menampilkan baris itu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Tema obrolan</translation>
+        <translation type="vanished">Tema obrolan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Rona warna obrolan</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mewarnai ulang WhatsApp Web itu sendiri. Foto, avatar, dan stiker mempertahankan warnanya. Bekerja di atas tema terang atau gelap, mana pun yang aktif.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Wallpaper obrolan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gunakan salah satu gambar Anda sendiri sebagai latar panel obrolan, seperti yang dilakukan WhatsApp di Android. Gambar disimpan di dalam Whatly, tidak diunggah ke mana pun, dan hanya terlihat oleh Anda.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Pilih gambar…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Login baru akan muncul sebagai «Whatly for Linux» (atau platform yang sesuai) di daftar perangkat tertaut di ponsel Anda, bukan «Google Chrome (Linux)». Nama tersebut disimpan di ponsel saat perangkat ditautkan, jadi mengubah ini hanya memengaruhi penautan berikutnya — keluar dan tautkan ulang untuk mengganti nama sesi yang sudah ada.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Identifikasi sebagai Whatly di perangkat tertaut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User Agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lanjutan — jangan ubah ini kecuali Anda benar-benar tahu apa yang Anda lakukan. User agent yang tidak standar dapat membuat WhatsApp gagal dimuat, dan nilai yang tidak biasa berisiko membuat akun WhatsApp Anda ditandai atau masuk daftar hitam.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Terapkan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Kembalikan ke bawaan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Faktor zoom pada jendela normal</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Perkecil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Perbesar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>atur ulang</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Faktor zoom saat dimaksimalkan/layar penuh</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimalkan ke baki sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Keluar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Pintasan global</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Aksi tombol tutup</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Tampilkan pintasan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Izin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Tampilkan izin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aktifkan layar kunci.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Aktifkan kunci aplikasi saat mulai</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saat jendela disembunyikan ke baki sistem, kunci di balik kode sandi. Memerlukan kata sandi yang telah diatur.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Kunci saat disembunyikan ke baki</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Kunci juga Whatly saat sesi desktop terkunci. Memerlukan kata sandi yang telah diatur. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Kunci saat layar terkunci</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Kata sandi saat ini</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Ubah kata sandi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Ubah</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Aktifkan kunci otomatis setelah</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Atur ulang</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Lihat kata sandi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Lokasi unduhan bawaan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Ubah lokasi unduhan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Penyimpanan </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Properti</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Bersihkan (perlu mulai ulang)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Data persisten mencakup kuki persisten, penyimpanan lokal HTML5, dan tautan yang telah dikunjungi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Data persisten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>Cache HTTP/media. Menghapusnya aman — akan diunduh ulang saat diperlukan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Hapus cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Ukuran</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Aksi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Cadangan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Simpan akun ini (pengaturan, sesi, dan pengaya) ke arsip .tar.gz. Arsip berisi sesi login Anda — jaga kerahasiaannya.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Ekspor profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Pulihkan akun dari arsip .tar.gz. Ini menimpa data saat ini dan memerlukan mulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Impor profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Performa &amp; Privasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Sempurnakan mesin rendering. Pengaturan bawaan aman pada sebagian besar sistem; jika jendela kosong atau aplikasi mogok saat mulai, atau jika tersendat, coba ubah pengaturan ini. Perubahan berlaku setelah memulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Render sepenuhnya pada CPU (--disable-gpu). Memperbaiki jendela kosong dan kemogokan saat mulai pada beberapa konfigurasi GPU/driver. Bawaan pada Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Nonaktifkan akselerasi GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Komposit halaman pada CPU (--disable-gpu-compositing). Menghindari kedipan bingkai usang pada beberapa driver.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Nonaktifkan kompositing GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Nonaktifkan GPU VSync (--disable-gpu-vsync). Dapat mengurangi jeda masukan dengan risiko tearing.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Nonaktifkan GPU VSync</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Jalankan proses GPU di dalam proses utama (--in-process-gpu). Solusi sementara untuk beberapa konfigurasi sandbox.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Jalankan GPU dalam proses</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Paksa akselerasi meski driver masuk daftar blokir (--ignore-gpu-blocklist). Coba ini untuk mengaktifkan kembali GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Abaikan daftar blokir GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Jalankan semuanya dalam satu proses (--single-process). Menggunakan lebih sedikit memori tetapi kurang stabil.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Mode proses tunggal (memori lebih rendah)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Bagikan satu proses perender per situs (--process-per-site). Mengurangi penggunaan memori.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Satu proses per situs (memori lebih rendah)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Sembunyikan nama kontak dan pratinjau pesan di daftar obrolan (arahkan kursor untuk menampilkan satu). Berguna saat berbagi layar. Percakapan yang terbuka tidak berubah.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Mode fokus (sembunyikan pratinjau obrolan)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Jadikan foto dan video berkualitas HD secara default di editor media. Bergantung pada tata letak WhatsApp Web; jika pembaruan WhatsApp membuatnya rusak, matikan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Kirim foto dan video dalam HD secara default</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Cegah WebRTC mengungkapkan alamat IP lokal Anda melalui koneksi tanpa proksi.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Cegah kebocoran IP WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Batas memori JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Batasi heap JavaScript (V8 --max-old-space-size). 0 = otomatis. Turunkan jika aplikasi menggunakan terlalu banyak RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Cache HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Tempat menyimpan cache HTTP. Memory dihapus saat keluar; None menonaktifkan caching.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Ukuran maks</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Ukuran cache maksimum pada disk. 0 = otomatis.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Jaringan &amp; Mulai</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Jalankan Whatly secara otomatis saat Anda masuk ke sesi desktop.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Mulai Whatly saat saya masuk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Ganti bingkai jendela sistem dengan bilah judul ramping milik Whatly. Berlaku setelah memulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Gunakan bingkai jendela kustom (perlu memulai ulang)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Memeriksa GitHub sekali sehari untuk rilis terbaru dan memberi tahu Anda. Whatly tidak pernah mengunduh atau memasang apa pun sendiri.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Periksa pembaruan secara otomatis</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Skala antarmuka</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Skalakan seluruh jendela dan halaman (QT_SCALE_FACTOR). Otomatis mengikuti desktop. Variabel lingkungan QT_SCALE_FACTOR, jika disetel, akan menggantikan pengaturan ini. Berlaku setelah dimulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proksi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Cara Whatly terhubung ke jaringan. Sistem mengikuti sistem operasi; Tidak ada terhubung langsung.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nama pengguna</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Opsional</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Kata sandi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Addon JavaScript khusus</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Muat berkas .js untuk dijalankan di WhatsApp Web. Setiap addon berjalan di sandbox-nya sendiri, sehingga addon yang rusak tidak akan mematikan addon lain atau halaman. Hapus centang pada addon untuk menonaktifkannya tanpa menghapusnya. Perubahan berlaku setelah dimulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Tambah addon…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Hapus</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Balasan tersimpan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Teks singkat yang sering Anda kirim. Sisipkan salah satunya dari palet perintah (Ctrl+K) — ketik &quot;Sisipkan&quot; lalu pilih; teksnya diketikkan ke kotak pesan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Tambah balasan…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Pintasan keyboard</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Klik sebuah bidang dan tekan kombinasi tombol. Kosongkan bidang untuk menghapus pintasan. Perubahan berlaku setelah dimulai ulang.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Ini akan menghapus data persisten (termasuk cookie persisten dan cache) dan menutup aplikasi.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Hapus cookie dan tutup aplikasi?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Kesalahan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Tidak dapat menetapkan string User-Agent kosong.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Peralihan tema otomatis dinonaktifkan karena tema diubah secara manual.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Kunci aplikasi belum dikonfigurasi.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Apakah Anda ingin menyiapkan kunci aplikasi sekarang?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Izin fitur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Pilih wallpaper obrolan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Gambar (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Tidak dapat menggunakan gambar itu: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Pilih berkas CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Lembar gaya (*.css);;Semua berkas (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Tidak dapat membaca berkas itu: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Memori</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Tidak ada (langsung)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Layanan sistem (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Tambah balasan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Teks yang akan disisipkan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Pilih berkas JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Semua berkas (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Tidak dapat menambahkan addon</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Hapus addon</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Hapus addon &quot;%1&quot;? Tindakan ini menghapus berkasnya.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Pemeriksa ejaan (tidak ada kamus terpasang)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Tidak ada</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Dasar</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Notifikasi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Obrolan</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privasi dan kunci</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Jendela dan zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Lanjutan</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Pintasan sedang digunakan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Pintasan itu sudah digunakan oleh tindakan lain.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Hapus cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Hapus cache sekarang? Cache akan diunduh ulang saat diperlukan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Ekspor profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Arsip akan berisi sesi WhatsApp login Anda. Jaga kerahasiaannya. Lanjutkan?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Arsip (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profil diekspor.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Impor profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Ini menimpa data akun saat ini dengan arsip, lalu Whatly harus dimulai ulang. Lanjutkan?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profil diimpor. Silakan mulai ulang Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 bahasa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Bawaan WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Bawaan sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>Bahasa antarmuka akan berubah saat Anda memulai ulang %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Penyiapan Kunci Aplikasi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Silakan siapkan kata sandi kunci aplikasi terlebih dahulu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Pilih folder unduhan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Ini akan mengeluarkan sesi Anda saat ini.
 Anda mungkin juga perlu memulai ulang aplikasi sepenuhnya!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Apakah Anda ingin melanjutkan?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Anda mungkin juga perlu memulai ulang aplikasi sepenuhnya!</translation>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Selamat datang di Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Klien WhatsApp Web yang cepat dan native untuk desktop. Mari atur beberapa hal — Anda bisa mengubah semuanya nanti di Pengaturan.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly menyimpan obrolan Anda dalam jendela desktop yang semestinya, lengkap dengan ikon baki, notifikasi, tema, dan banyak akun.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Beberapa preferensi</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Pengaturan default yang masuk akal; sesuaikan sesuai selera.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Sesuaikan dengan tema terang/gelap sistem</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Mulai Whatly saat saya masuk</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Pengiriman notifikasi:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Otomatis</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Layanan sistem (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Semua siap</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Anda sudah siap. Pindai kode QR dengan ponsel Anda untuk masuk.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Semua yang ada di sini tersedia di Pengaturan jika Anda berubah pikiran.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Anda mungkin juga perlu memulai ulang aplikasi sepenuhnya!</translation>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Tidak dapat membaca rilis terbaru</translation>
     </message>
@@ -2038,82 +2626,104 @@ Anda mungkin juga perlu memulai ulang aplikasi sepenuhnya!</translation>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Bagikan layar Anda</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Pilih yang akan dibagikan:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Tanpa judul</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Layar: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Jendela: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Izinkan %1 mengakses informasi lokasi Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Izinkan %1 mengakses mikrofon Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Izinkan %1 mengakses kamera Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Izinkan %1 mengakses mikrofon dan kamera Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Izinkan %1 mengunci kursor tetikus Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Izinkan %1 merekam video desktop Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Izinkan %1 merekam audio dan video desktop Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Izinkan %1 menampilkan notifikasi di desktop Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Izinkan %1 membaca papan klip Anda? Ini diperlukan untuk menempelkan gambar ke obrolan.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Izinkan %1 melihat fon yang terpasang di sistem Anda?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Permintaan izin</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Kesalahan sertifikat</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Masukkan nama pengguna dan kata sandi untuk «%1» di %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Sambungkan ke proxy «%1» menggunakan:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Izinkan %1 membuka semua tautan %2?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Anda mungkin juga perlu memulai ulang aplikasi sepenuhnya!</translation>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Proses render berakhir normal</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Proses render berakhir tidak normal</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Proses render mengalami crash</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Proses render dihentikan</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Proses render berakhir dengan kode: %1

--- a/src/i18n/it_IT.ts
+++ b/src/i18n/it_IT.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -22,58 +24,73 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Client WhatsApp Web per Desktop Linux.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Progettato &amp;amp; Sviluppato da:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Sito Web:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Dona via PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Lascia una Recensione</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Altre Applicazioni</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Codice Sorgente</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copia negli appunti le informazioni di debug qui sotto e apre il tracker delle segnalazioni, così da incollarle direttamente nel report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Segnala un bug</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Dettagli Debug</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Versione: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Le informazioni di debug erano troppo lunghe per il browser, quindi sono state copiate negli appunti. Incollale nella segnalazione.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Informazioni</translation>
     </message>
@@ -81,36 +98,47 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Alba</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Tramonto</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>Aggiorna</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translatorcomment>Disabilita e Chiudi</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translatorcomment>Abilita e Chiudi</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -119,6 +147,7 @@ Please try again.</source>
 Riprova.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -134,18 +163,22 @@ Riprova.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Icon</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -156,58 +189,72 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (predefinito)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Rosa Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Rosa antico</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavanda</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Viola</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Azzurro cielo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Oceano profondo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Verde acqua</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Menta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Corallo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Pesca</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Oro</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Cremisi</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafite</translation>
     </message>
@@ -215,18 +262,22 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Tavolozza comandi</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Digita un comando…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Ricerca comandi</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Comandi corrispondenti</translation>
     </message>
@@ -234,14 +285,17 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Riduci a icona</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Ingrandisci</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
@@ -249,34 +303,42 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Scaricati</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Nessun download</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Svuota l&apos;elenco dei download</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Svuota tutto</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Apri la cartella dei download nel gestore file</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Apri cartella Scaricati</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Esiste già un file con lo stesso nome!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Salvare il file con un nuovo nome?</translation>
     </message>
@@ -284,54 +346,68 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Apri il file con l&apos;applicazione di sistema</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 di %2 scaricati - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>dimensione sconosciuta - %1 scaricato - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>completato - %1 scaricato - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>annullato - %1 scaricato - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>interrotto: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Ferma scaricamento</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Rimuovi dalla lista</translation>
     </message>
@@ -339,46 +415,58 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Imposta codice di blocco per l&apos;applicazione</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>Inserisci codice di blocco</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>Ripeti codice di blocco</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Imposta Codice di Blocco</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Attenzione: Blocco Maiusc Attivo</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nota: Il codice di blocco deve contenere più di 4 caratteri e deve corrispondere in entrambi i campi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Inserisci il codice per accedere</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>Inserisci codice di blocco</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Codice di Blocco Errato, Riprova.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -386,14 +474,17 @@ Desideri ignorare il controllo di sicurezza e continuare?</translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>In attesa della rete…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Lascia una Recensione</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -404,224 +495,289 @@ Imposta la password nelle Impostazioni.
 Aprire le Impostazioni ora?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Sblocca per aprire le Impostazioni.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Schermo Intero</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimizza nella barra</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Ripristina</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Ricarica</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Blocca</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Disattiva audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Ingrandisci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Riduci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Reimposta zoom</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>Impo&amp;stazioni</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>&amp;Messaggi programmati…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Al&amp;terna tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Vista a schede</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Vista a griglia</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Tavolozza comandi</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>Info</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Ricarica</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Riduci a icona nell&apos;area di notifica</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Blocca</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Disattiva audio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nuova chat / apri URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Cambia tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Rinomina…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Rimuovi account</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Passa all&apos;account: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Aggiungi account…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Inserisci: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 non letti</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Aggiungi un altro account</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>messaggi</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>messaggio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Aggiungi account</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nome del nuovo account:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Account %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Rinomina account</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nome account:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Account 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Ripristina</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Nessuna finestra di WhatsApp è aperta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Promemoria</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Promemoria: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Aggiornamento disponibile</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 è disponibile. Fai clic per aprire la pagina di download.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Errore</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Impossibile inizializzare il modulo impostazioni.
 WebEngine non è inizializzato.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Azione richiesta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>La pagina deve essere ricaricata per continuare.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nuova Chat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Inserisci un numero WhatsApp valido con prefisso internazionale (es- +39XXXXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Sblocca per Ricaricare l&apos;App.</translation>
     </message>
@@ -629,10 +785,12 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -640,6 +798,7 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
@@ -647,22 +806,27 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Autenticazione Richiesta</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Icona</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Nome Utente:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Password:</translation>
     </message>
@@ -670,14 +834,17 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
@@ -685,22 +852,27 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Elenco chat</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Conversazione aperta</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Elenco chat e conversazione</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Tutto, foto incluse</translation>
     </message>
@@ -708,10 +880,13 @@ WebEngine non è inizializzato.</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Mostra Dettagli Debug</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -719,183 +894,233 @@ WebEngine non è inizializzato.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Nascondi Dettagli Debug</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Modalità di installazione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Ramo Sorgente</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Commit</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Data Compilazione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Versione Qt di Esecuzione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Versione Qt di Compilazione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Architettura</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Eccezione</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation>ha riscontrato un problema.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation>potrebbe essere necessario riavviare. Segnala l&apos;errore allo sviluppatore.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Niente da migrare da &quot;%1&quot; — già migrato, o nessun dato trovato.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Copierebbe:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Copiato:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Esegui di nuovo senza --dry-run per eseguire la copia.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Client WhatsApp Web ricco di funzionalità basato su Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Visualizza la guida sulle opzioni della riga di comando</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Apre la finestra di Impostazioni in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Blocca un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Apre la finestra Info in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Apre la finestra dei messaggi programmati in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Passa dal tema scuro a quello chiaro in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Ricarica l&apos;app in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Apri una nuova chat in un&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esegui come account separato con sessione e impostazioni proprie, in una finestra dedicata&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Mostra la finestra principale dell&apos;istanza in esecuzione di </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Copia le impostazioni e la sessione connessa da un’installazione precedente (es. la vecchia versione &quot;whatsie&quot;) in questa, poi esci</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Con --migrate-from, mostra solo ciò che verrebbe copiato</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Stampa il numero di messaggi non letti ed esce</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Blocco non configurato, 
 Imposta la password nelle Impostazioni.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Caricamento...</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Impossibile eseguire &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Nulla di cui fare il backup</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Impossibile creare %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Impossibile copiare %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Impossibile creare una directory temporanea</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Impossibile ripristinare il file delle impostazioni</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Impossibile scrivere %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Passa al tema chiaro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Passa al tema scuro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Mostra le chat</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Sfoca le chat</translation>
@@ -904,42 +1129,53 @@ Imposta la password nelle Impostazioni.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Lascia una Recensione</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>Valuta sullo Store</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>o</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Valuta su Github</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Donate via PayPal</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Dona via OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Più tardi</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>Già Fatto</translation>
     </message>
@@ -947,34 +1183,42 @@ Imposta la password nelle Impostazioni.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Tempo scaduto in attesa dell&apos;invio del messaggio</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Giornaliero</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Giorni feriali</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Settimanale</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Una volta</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Inviato</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Non riuscito</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>In attesa</translation>
     </message>
@@ -982,90 +1226,117 @@ Imposta la password nelle Impostazioni.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Messaggi programmati</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Quando</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Messaggio</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Numero di telefono in formato internazionale, es. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Etichetta facoltativa</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Una volta</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Giornaliero</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Giorni feriali</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Settimanale</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Ripeti</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Ricordamelo invece di inviare (notifica, non inviare il messaggio)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Messaggio da inviare</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>L&apos;app deve essere in esecuzione e WhatsApp connesso all&apos;ora programmata. Se è chiusa, il messaggio viene inviato alla successiva apertura dell&apos;app. L&apos;invio apre la chat del destinatario.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Programma</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Rimuovi selezionato</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Cancella inviati/non riusciti</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Inserisci un numero di telefono e un messaggio.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>L&apos;orario è nel passato: inviare questo messaggio ora?</translation>
     </message>
@@ -1073,895 +1344,1191 @@ Imposta la password nelle Impostazioni.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Dimensione del carattere dell&apos;interfaccia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dimensione in punti dell&apos;interfaccia dell&apos;app — menu, impostazioni e finestre di dialogo. Non influisce sul testo di WhatsApp Web; per quello usa lo zoom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Ricarica automaticamente dopo un arresto anomalo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se il processo della pagina di WhatsApp Web va in crash, ricaricalo automaticamente invece di chiedere prima.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Impostazioni generali</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translatorcomment>Stile Tema</translatorcomment>
         <translation>Stile Widget</translation>
     </message>
     <message>
-        <source>Widget Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In base al fuso orario e alla posizione del tuo sistema.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automatico</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Scuro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Chiaro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Segue la preferenza chiaro/scuro del desktop e cambia con essa. Ha la precedenza sul tema manuale e sul cambio automatico all&apos;alba/tramonto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Segui il tema chiaro/scuro del sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Notifiche native</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Notifiche personalizzate</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>Prova</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Tipo notifiche</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Disabilita Notifiche a Comparsa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Durata Notifica</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation>Sec</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Recapito delle notifiche</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Come vengono inviate le notifiche native su Linux. La modalità automatica usa il portale desktop all&apos;interno di una sandbox Flatpak e il servizio di sistema negli altri casi.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Nasconde i popup di notifica durante un periodo di silenzio giornaliero. Gli indicatori di messaggi non letti continuano ad aggiornarsi; viene trattenuto solo il popup.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Non disturbare</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Dalle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>alle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Evidenzia parole chiave</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Parole separate da virgole che notificano sempre, anche durante Non disturbare (senza distinzione tra maiuscole e minuscole).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>es. urgente, capo, fattura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Usa Finestra File Nativa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Silenzia Audio della Pagina</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Disabilita Auto-Riproduzione Media</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Minimizza nella barra di sistema all&apos;avvio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Mostra/Nascondi al click dell&apos;icona nella barra di sistema (se supportato)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Lingua dell&apos;interfaccia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lingua dell&apos;interfaccia di Whatly. Ha effetto dopo il riavvio dell&apos;app. La lingua delle chat proviene da WhatsApp Web e non può essere cambiata qui.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aggiunge un pulsante chiaro/scuro nella barra laterale di WhatsApp, appena sopra la tua foto profilo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Pulsante tema nella barra laterale di WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aggiunge alla barra laterale di WhatsApp un pulsante che sfoca e mostra le chat con un clic, senza aprire le Impostazioni.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Pulsante sfocatura nella barra laterale di WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usa un&apos;icona nel vassoio di un solo colore, in tono con il resto del pannello, invece di quella verde di WhatsApp. L&apos;icona si attenua anche quando WhatsApp non è connesso.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Icona nel vassoio monocromatica</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Anima lo scorrimento invece di saltare riga per riga.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Scorrimento fluido</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS personalizzato</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carica un file .css per ridisegnare WhatsApp Web: i fogli di stile della community (catppuccin e simili) funzionano qui. Applicato sopra il tema della chat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Scegli file…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rimuove completamente l&apos;icona del vassoio di sistema. Senza vassoio da cui ripristinare, chiudere la finestra chiude l&apos;app invece di nasconderla.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Nascondi l&apos;icona nel vassoio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Famiglia di caratteri</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra il testo di WhatsApp Web con un font installato sul sistema. Emoji, icone e la formattazione a spaziatura fissa dei messaggi restano invariate.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nasconde la sezione &quot;Aggiornamenti silenziati&quot; nel pannello Stato/Aggiornamenti, così gli stati dei contatti silenziati non compaiono affatto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Nascondi aggiornamenti di stato silenziati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sottolinea le parole errate mentre scrivi e offre correzioni nel menu del tasto destro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Controlla l&apos;ortografia durante la digitazione</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;La lingua di riferimento per il controllo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Sfocatura privacy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sfoca le tue chat finché non ci passi sopra, così chi guarda lo schermo non può leggerle. Passando su una riga si rivela solo quella riga.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Tema chat</translation>
+        <translation type="vanished">Tema chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ricolora WhatsApp Web stesso. Foto, avatar e adesivi mantengono i propri colori. Funziona sopra il tema chiaro o scuro, qualunque sia attivo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Sfondo chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usa una tua immagine come sfondo del pannello della chat, come fa WhatsApp su Android. L&apos;immagine è salvata dentro Whatly, non è caricata da nessuna parte ed è visibile solo a te.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Scegli immagine…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User Agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avanzate — non modificare a meno di sapere esattamente cosa si sta facendo. Uno user agent non standard può impedire il caricamento di WhatsApp e valori insoliti rischiano di far segnalare o inserire nella blacklist il tuo account WhatsApp.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>Imposta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Ripristina predefiniti</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Ingrandimento normale</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Diminuisci</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Aumenta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>ripristina</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Ingrandimento a finestra intera/schermo intero</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimizza nella barra</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Permessi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando la finestra si nasconde nel vassoio di sistema, bloccala dietro il codice. Richiede una password impostata.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Blocca quando nascosto nel vassoio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Blocca anche Whatly quando la sessione del desktop si blocca. Richiede una password impostata. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Blocca quando lo schermo si blocca</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Abilita blocco automatico dopo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>La cache HTTP/multimediale. Svuotarla è sicuro — viene scaricata di nuovo quando necessario.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Svuota cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Salva questo account (impostazioni, sessione e componenti aggiuntivi) in un archivio .tar.gz. L&apos;archivio contiene la tua sessione con accesso effettuato — tienilo privato.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Esporta profilo…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Ripristina un account da un archivio .tar.gz. Questa operazione sovrascrive i dati attuali e richiede un riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Importa profilo…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Prestazioni e privacy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Regola con precisione il motore di rendering. I valori predefiniti sono sicuri sulla maggior parte dei sistemi; se la finestra è vuota o l&apos;app si blocca all&apos;avvio, oppure se scatta, prova a modificarli. Le modifiche si applicano dopo un riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Renderizza interamente sulla CPU (--disable-gpu). Risolve finestre vuote e crash all&apos;avvio su alcune configurazioni GPU/driver. Predefinito su Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Disabilita l&apos;accelerazione GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Componi la pagina sulla CPU (--disable-gpu-compositing). Evita lo sfarfallio da fotogrammi obsoleti su alcuni driver.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Disabilita il compositing GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Disabilita VSync GPU (--disable-gpu-vsync). Può ridurre la latenza di input a costo del tearing.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Disabilita VSync GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Esegui il processo GPU all&apos;interno del processo principale (--in-process-gpu). Una soluzione alternativa per alcune configurazioni in sandbox.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Esegui la GPU nel processo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Forza l&apos;accelerazione anche quando il driver è nella blocklist (--ignore-gpu-blocklist). Prova questa opzione per riattivare la GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Ignora la blocklist GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Esegui tutto in un unico processo (--single-process). Usa meno memoria ma è meno stabile.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Modalità a processo singolo (meno memoria)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Condividi un processo di rendering per sito (--process-per-site). Riduce l&apos;uso della memoria.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Un processo per sito (meno memoria)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Nasconde i nomi dei contatti e le anteprime dei messaggi nell’elenco chat (passa il mouse per rivelarne uno). Utile quando condividi lo schermo. La conversazione aperta resta invariata.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Modalità concentrazione (nascondi anteprime)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Imposta foto e video sulla qualità HD in modo predefinito nell&apos;editor multimediale. Dipende dal layout di WhatsApp Web; se un aggiornamento di WhatsApp lo compromette, disattivalo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Invia foto e video in HD in modo predefinito</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Impedisci a WebRTC di rivelare il tuo indirizzo IP locale su connessioni non proxate.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Previeni la fuga di IP WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Limite di memoria JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Limita l&apos;heap JavaScript (V8 --max-old-space-size). 0 = automatico. Riducilo se l&apos;app usa troppa RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Cache HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Dove conservare la cache HTTP. La memoria si cancella all&apos;uscita; Nessuna disabilita la cache.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Dimensione massima</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Dimensione massima della cache su disco. 0 = automatico.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Rete &amp; Avvio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Avvia Whatly automaticamente all&apos;accesso alla sessione desktop.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Avvia Whatly all&apos;accesso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Sostituisci il bordo della finestra di sistema con la sottile barra del titolo di Whatly. Viene applicato dopo un riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Usa una cornice della finestra personalizzata (richiede il riavvio)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Controlla GitHub una volta al giorno per una versione più recente e ti avvisa. Whatly non scarica né installa mai nulla da solo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Controlla automaticamente gli aggiornamenti</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Scala dell&apos;interfaccia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Ridimensiona l&apos;intera finestra e la pagina (QT_SCALE_FACTOR). Automatico segue il desktop. Una variabile d&apos;ambiente QT_SCALE_FACTOR, se impostata, ha la precedenza. Applicato dopo il riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Come Whatly si connette alla rete. Sistema segue il sistema operativo; Nessuno si connette direttamente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nome utente</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Facoltativo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Componenti aggiuntivi JavaScript personalizzati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Carica file .js da eseguire su WhatsApp Web. Ogni componente aggiuntivo viene eseguito nella propria sandbox, quindi uno difettoso non può compromettere gli altri o la pagina. Deseleziona un componente aggiuntivo per disattivarlo senza rimuoverlo. Le modifiche vengono applicate dopo un riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Aggiungi componente aggiuntivo…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Risposte salvate</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Testi brevi che invii spesso. Inseriscine uno dalla palette dei comandi (Ctrl+K) — digita &quot;Inserisci&quot; e selezionalo; il testo viene scritto nella casella del messaggio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Aggiungi risposta…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Scorciatoie da tastiera</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Fai clic su un campo e premi la combinazione di tasti. Svuota un campo per rimuovere la scorciatoia. Le modifiche vengono applicate dopo un riavvio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Tema di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Tonalità colore della chat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Scorciatoie globali</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Alla Chiusura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Mostra scorciatoie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>Mostra permessi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Abilita blocco all&apos;avvio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Password Attuale</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Cambia Password</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Ripristina</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Mostra password</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Percorso Predefinito Scaricati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Cambia Percorso Scaricati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Proprietà</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Azione</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Chiude il pannello di emoji, GIF e adesivi quando fai clic altrove. Altrimenti WhatsApp Web lo lascia aperto finché non premi di nuovo il pulsante.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Chiudi il pannello emoji/adesivi facendo clic all&apos;esterno</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;I nuovi accessi compaiono nell&apos;elenco dei dispositivi collegati del telefono come «Whatly for Linux» (o la piattaforma corrispondente) anziché «Google Chrome (Linux)». Il nome viene salvato sul telefono quando un dispositivo viene collegato, quindi modificarlo riguarda solo i collegamenti futuri: esci e ricollega per rinominare una sessione esistente.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Identificati come Whatly nei dispositivi collegati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Archiviazione </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Svuota (richiede il riavvio)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;I dati persistenti includono cookie, archiviazione locale HTML5 e collegamenti visitati.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Dati persistenti</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Questa operazione eliminerà i dati persistenti (inclusi cookie persistenti e cache) e chiuderà l&apos;applicazione.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Eliminare i cookie e chiudere l&apos;applicazione?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Errore</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Impossibile impostare una stringa User-Agent vuota.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Il cambio automatico del tema è stato disabilitato.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Il blocco dell&apos;app non è configurato.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Vuoi configurare il blocco dell&apos;app ora?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Permessi funzionalità</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Scegli uno sfondo per la chat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Immagini (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Impossibile usare quell&apos;immagine: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Scegli un file CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Fogli di stile (*.css);;Tutti i file (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Impossibile leggere quel file: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disco</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Nessuno (diretto)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portale desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Servizio di sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Aggiungi risposta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Testo da inserire</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Scegli un file JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Tutti i file (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Impossibile aggiungere il componente aggiuntivo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Rimuovi componente aggiuntivo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Rimuovere il componente aggiuntivo &quot;%1&quot;? Questo ne elimina il file.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Correttore ortografico (nessun dizionario installato)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Nessuna</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Generali</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Aspetto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Notifiche</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Messaggistica</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privacy e blocco</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Finestra e zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Avanzate</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Scorciatoia in uso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Questa scorciatoia è già usata da un&apos;altra azione.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Svuota cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Svuotare la cache adesso? Verrà scaricata di nuovo quando necessario.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Esporta profilo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>L&apos;archivio conterrà la tua sessione WhatsApp con accesso effettuato. Tienilo privato. Continuare?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archivi (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profilo esportato.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Importa profilo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Questa operazione sovrascrive i dati dell&apos;account attuale con l&apos;archivio, quindi Whatly deve essere riavviato. Continuare?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profilo importato. Riavvia Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 lingue</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Predefinito di WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Predefinito di sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>La lingua dell&apos;interfaccia cambierà al riavvio di %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Configurazione blocco app</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Configura prima la password del blocco app.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Seleziona cartella scaricati</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1972,6 +2539,7 @@ Questo disconnetterà la sessione corrente.
 Potrebbe essere necessario anche un riavvio completo dell&apos;applicazione!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Vuoi procedere?</translation>
     </message>
@@ -1979,58 +2547,73 @@ Potrebbe essere necessario anche un riavvio completo dell&apos;applicazione!</tr
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Benvenuto in Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Un client WhatsApp Web veloce e nativo per il desktop. Configuriamo alcune cose — potrai cambiarle tutte in seguito nelle Impostazioni.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly tiene le tue chat in una vera finestra desktop, con icona nella barra delle applicazioni, notifiche, temi e più account.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Alcune preferenze</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Impostazioni predefinite sensate; personalizzale a piacere.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Segui il tema chiaro/scuro del sistema</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Avvia Whatly all&apos;accesso</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Recapito delle notifiche:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automatico</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portale desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Servizio di sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Tutto pronto</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Sei pronto. Inquadra il codice QR con il telefono per accedere.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Tutto questo si trova nelle Impostazioni, se cambi idea.</translation>
     </message>
@@ -2038,6 +2621,7 @@ Potrebbe essere necessario anche un riavvio completo dell&apos;applicazione!</tr
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Impossibile leggere l&apos;ultima versione</translation>
     </message>
@@ -2045,82 +2629,104 @@ Potrebbe essere necessario anche un riavvio completo dell&apos;applicazione!</tr
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Condividi lo schermo</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Scegli cosa condividere:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Senza titolo</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Schermo: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Finestra: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Consenti a %1 di accedere alle informazioni sulla tua posizione?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Consenti a %1 di accedere al tuo microfono?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Consenti a %1 di accedere alla tua webcam?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Consenti a %1 di accedere a microfono e webcam?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Consenti a %1 di bloccare il cursore del mouse?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Consenti a %1 di acquisire video dal tuo desktop?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Consenti a %1 di acquisire audio e video dal tuo desktop?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Consenti a %1 di mostrare la notifica sul desktop?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Consentire a %1 di leggere gli appunti? È necessario per incollare immagini in una chat.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Consentire a %1 di vedere i caratteri installati nel sistema?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Richiesta di Permesso</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Errore Certificato</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Inserisci nome utente e password per &quot;%1&quot; in %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Connettiti al proxy &quot;%1&quot; utilizzando:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Consenti a %1 di aprire tutti i %2 collegamenti?</translation>
     </message>
@@ -2128,22 +2734,27 @@ Potrebbe essere necessario anche un riavvio completo dell&apos;applicazione!</tr
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Rendering terminato normalmente</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Rendering terminato in modo anomalo</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Rendering terminato in modo anomalo</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Rendering terminato</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Rendering terminato con codice: %1

--- a/src/i18n/ja_JP.ts
+++ b/src/i18n/ja_JP.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>PayPal で寄付</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>ストアで評価</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>その他のアプリ</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>ソースコード</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;下のデバッグ情報をクリップボードにコピーし、issue トラッカーを開くので、そのままレポートに貼り付けられます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>バグを報告</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>デバッグ情報</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>バージョン: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>デバッグ情報がブラウザーで扱うには長すぎたため、クリップボードにコピーしました。issue に貼り付けてください。</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | 情報</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>日の出</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>日の入り</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  更新 </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>無効にして閉じる</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  有効にして閉じる</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 もう一度お試しください。</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>ダイアログ</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>アイコン</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp（既定）</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>バービーピンク</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>ダスティローズ</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>ラベンダー</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>バイオレット</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>スカイブルー</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>ディープオーシャン</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>ティール</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>ミント</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>コーラル</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>ピーチ</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>ゴールド</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>クリムゾン</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>グラファイト</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>コマンドパレット</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>コマンドを入力…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>コマンド検索</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>一致するコマンド</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>最小化</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>最大化</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>ダウンロード</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>ダウンロードはありません</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>ダウンロード一覧を消去</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>すべて消去</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>ファイルマネージャーでダウンロードフォルダーを開く</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>ダウンロードフォルダーを開く</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>同じ名前のファイルが既に存在します！</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>ファイルを新しい名前で保存しますか？</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>システムのアプリでファイルを開く</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %2 中 %1 をダウンロード済み - %3/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>サイズ不明 - %1 をダウンロード済み - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>完了 - %1 をダウンロード済み - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>キャンセル - %1 をダウンロード済み - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>中断: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>ダウンロードを停止</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>一覧から削除</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>ロック用パスコードを設定</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>パスコードを入力</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>パスコードを再入力</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>パスコードを設定</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>警告: Caps Lock がオンです</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;注意: パスコードは 3 文字より長く、両方の欄で一致している必要があります。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>アクセスするにはパスコードを入力してください</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>パスコードを入力</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;パスコードが違います。もう一度お試しください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>ネットワークを待っています…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>WhatsApp のウィンドウが開いていません</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>リマインダー</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>リマインダー: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>更新があります</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 が利用可能です。クリックしてダウンロードページを開きます。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| エラー</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>設定にアクセスするにはロックを解除してください。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>設定モジュールを初期化できません。
 WebEngine が初期化されていません。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | 操作が必要です</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>続行するにはページを再読み込みする必要があります。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>新規チャット</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>国番号付きの有効な WhatsApp 番号を入力してください（例: +81XXXXXXXXXX）</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>アプリを評価</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 今すぐ設定を開きますか？</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>全画面</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>トレイに最小化(&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>元に戻す(&amp;R)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>再読み込み(&amp;L)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>ロック(&amp;K)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>音声をミュート(&amp;M)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>拡大</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>縮小</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>ズームをリセット</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>設定(&amp;S)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>予約メッセージ…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>テーマを切り替え(&amp;T)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>タブ表示</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>コマンドパレット</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>このアプリについて(&amp;A)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>終了(&amp;Q)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>再読み込み</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>トレイに最小化</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>ロック</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>音声をミュート</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>新規チャット / URL を開く</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>テーマを切り替え</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>名前を変更…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>アカウントを削除</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>アカウントに切り替え: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>アカウントを追加…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>挿入: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — 未読 %2 件</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>別のアカウントを追加</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>元に戻す</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>件のメッセージ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>件のメッセージ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>アカウントを追加</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>新しいアカウントの名前:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>アカウント %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>アカウント名を変更</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>アカウント名:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>アカウント 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>アプリを再読み込みするにはロックを解除してください。</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>認証が必要です</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>アイコン</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>情報</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>ユーザー名:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>パスワード:</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>機能</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>状態</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>チャット一覧</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>開いている会話</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>チャット一覧と会話</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>写真を含むすべて</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>デバッグ情報を表示</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>デバッグ情報を隠す</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>「%1」から移行するものはありません（すでに移行済み、またはデータが見つかりません）。</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>コピー予定:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>コピーしました:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>コピーを実行するには --dry-run なしでもう一度実行してください。</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Qt WebEngine ベースの多機能な WhatsApp Web クライアント</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>コマンドラインオプションのヘルプを表示します</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>実行中のインスタンスで設定を開きます: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>実行中のインスタンスをロックします: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>実行中のインスタンスで「このアプリについて」を開きます: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>実行中のインスタンスで予約メッセージのダイアログを開きます </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>実行中のインスタンスでライトとダークのテーマを切り替えます: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>実行中のインスタンスでアプリを再読み込みします: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>実行中のインスタンスで新規チャット画面を開きます: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;独自のセッションと設定を持つ別アカウントとして、専用のウィンドウで実行します&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>実行中のインスタンスのメインウィンドウを表示します: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>以前のインストール（例: 古い「whatsie」ビルド）から設定とログイン済みセッションをこちらにコピーして終了します</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>--migrate-from では、コピーされる内容のみを表示します</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>現在の未読メッセージ数を表示して終了します</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>アプリロックが設定されていません。
 先に設定でパスワードを登録してください。</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>再読み込み中...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>インストール方式</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>バージョン</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>ソースブランチ</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>コミットハッシュ</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>ビルド日時</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt ランタイムバージョン</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt コンパイルバージョン</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>システム</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>アーキテクチャ</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>例外</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> で問題が発生しました。</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> の再起動が必要な場合があります。エラーを開発者に報告してください。</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>&apos;tar&apos; を実行できませんでした</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>バックアップするものがありません</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>%1 を作成できません</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>%1 をコピーできません</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>一時ディレクトリを作成できません</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>設定ファイルを復元できませんでした</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>%1 に書き込めません</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>ライトテーマに切り替え</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>ダークテーマに切り替え</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>チャットを表示</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>チャットをぼかす</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>このアプリを評価</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;このアプリを気に入っていただけたなら、評価に少しだけお時間をいただけますか？&lt;/p&gt;&lt;p&gt;1 分もかかりません。ご支援ありがとうございます！&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  ストアで評価</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>または</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>GitHub リポジトリにスターを付ける</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>PayPal で寄付 </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>OpenCollective で寄付</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>後で</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  対応済み  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>メッセージ送信の待機がタイムアウトしました</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>毎日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>平日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>毎週</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>1回のみ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>送信済み</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>失敗</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>保留中</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>予約メッセージ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>宛先</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>日時</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>メッセージ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>状態</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>国際形式の電話番号（例: 447700900000）</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>任意のラベル</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>1回のみ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>毎日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>平日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>毎週</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>繰り返し</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>送信せずにリマインドする（通知のみ、メッセージは送らない）</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>送信するメッセージ</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>予約時刻にアプリが起動し、WhatsApp にログインしている必要があります。閉じている場合は、次にアプリを開いたときに送信されます。送信すると受信者のチャットが開きます。</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>予約</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>選択項目を削除</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>送信済み/失敗を消去</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>電話番号とメッセージを入力してください。</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>指定時刻は過去です。今このメッセージを送信しますか？</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>インターフェースのフォントサイズ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;アプリ自体のインターフェース（メニュー、設定、ダイアログ）のポイントサイズです。WhatsApp Web のテキストには影響しません。それにはズームを使用してください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>表示テーマ</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>クラッシュ後に自動的に再読み込みする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web のページプロセスがクラッシュした場合、最初に確認せず自動的に再読み込みします。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>全般設定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>ウィジェットのスタイル</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>ウィジェットのテーマ</translation>
+        <translation type="vanished">ウィジェットのテーマ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;システムのタイムゾーンと位置情報に基づきます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>ダーク</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>ライト</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;デスクトップのライト/ダーク設定に合わせ、それに応じて変わります。手動テーマと日の出/日の入りの自動切り替えより優先されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>システムのライト/ダークテーマに従う</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>ネイティブ通知</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>カスタム通知</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  試す</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>通知の種類</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>通知ポップアップを無効にする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>ポップアップの表示時間</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> 秒</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>通知の配信方法</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Linux でネイティブ通知を送信する方法。自動では Flatpak サンドボックス内ではデスクトップポータルを使用し、それ以外ではシステムサービスを使用します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>毎日の静音時間帯は通知ポップアップを表示しません。未読バッジは更新されますが、ポップアップのみ抑制されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>おやすみモード</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>開始</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>終了</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>キーワードを強調表示</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>カンマ区切りの単語。おやすみモード中でも常に通知します（大文字と小文字を区別しません）。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>例: 緊急、上司、請求書</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>ネイティブのファイルダイアログを使う</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>ページの音声をミュート</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>メディアの自動再生を無効にする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>起動時にトレイへ最小化する</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>トレイアイコンのクリックで表示/非表示（対応している場合）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;他の場所をクリックしたときに絵文字・GIF・ステッカーのパネルを閉じます。そうしない場合、WhatsApp Web はボタンをもう一度押すまでパネルを開いたままにします。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>パネルの外をクリックしたら絵文字/ステッカーのパネルを閉じる</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>インターフェースの言語</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whatly 自身のインターフェースの言語です。アプリを再起動すると有効になります。チャット自体の言語は WhatsApp Web によるもので、ここでは変更できません。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp のサイドバー、プロフィール写真のすぐ上にライト/ダークボタンを追加します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp のサイドバーのテーマボタン</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;設定を開かずにワンクリックでチャットをぼかしたり解除したりするボタンを WhatsApp のサイドバーに追加します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp のサイドバーのぼかしボタン</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp の緑色のアイコンではなく、パネルの他の部分に合う単色のトレイアイコンを使います。WhatsApp が未接続のときはアイコンが暗くなります。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>モノクロのトレイアイコン</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;行ごとに飛ぶのではなく、スクロールをアニメーション表示します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>スムーズスクロール</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>カスタム CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web のスタイルを変更する .css ファイルを読み込みます。コミュニティのスタイルシート（catppuccin など）が使えます。チャットのテーマの上に適用されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>ファイルを選択…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>クリア</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;システムトレイアイコンを完全に削除します。復元するトレイがないため、ウィンドウを閉じるとアプリは隠れずに終了します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>トレイアイコンを隠す</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>フォントファミリー</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web のテキストをシステムにインストールされたフォントで表示します。絵文字、アイコン、等幅のメッセージ書式はそのままです。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ステータス/アップデートパネルの「ミュート中のアップデート」セクションを非表示にし、ミュートした連絡先のステータスをまったく表示しないようにします。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>ミュートしたステータスの更新を非表示</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;入力中にスペルの誤りに下線を引き、右クリックメニューで修正候補を表示します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>入力中にスペルチェック</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;チェックの対象となる言語。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>プライバシーぼかし</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;画面をちらっと見た人が読めないよう、ポインタを乗せるまでチャットをぼかします。行にポインタを乗せると、その行だけが表示されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>チャットのテーマ</translation>
+        <translation type="vanished">チャットのテーマ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>チャットの色合い</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web 自体を配色し直します。写真・アバター・ステッカーは元の色を保ちます。有効なライトまたはダークテーマの上で機能します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>チャットの壁紙</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp の Android 版のように、チャット領域の背景に自分の画像を使えます。画像は Whatly 内に保存され、どこにもアップロードされず、あなただけに見えます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>画像を選択…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;新しいログインは、スマートフォンのリンク済みデバイス一覧に「Google Chrome (Linux)」ではなく「Whatly for Linux」（または対応するプラットフォーム名）として表示されます。この名前はデバイスをリンクしたときにスマートフォンへ保存されるため、変更しても以後のリンクにのみ反映されます。既存のセッション名を変更するには、ログアウトして再リンクしてください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>リンク済みデバイスで Whatly として識別する</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>ユーザーエージェント</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;詳細設定 — 何をしているかを正確に理解している場合を除き、この項目は変更しないでください。非標準のユーザーエージェントを設定すると WhatsApp が読み込まれなくなることがあり、通常と異なる値は WhatsApp アカウントがフラグ付けされたりブラックリストに登録されたりする危険があります。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  適用</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>既定値に戻す</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>通常ウィンドウ時の拡大率</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>縮小</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>拡大</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>リセット</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>最大化/全画面時の拡大率</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>トレイに最小化</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>グローバルショートカット</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>閉じるボタンの動作</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  ショートカットを表示</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>権限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  権限を表示</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ロック画面を有効にします。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>起動時にアプリロックを有効にする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ウィンドウをシステムトレイに隠したとき、パスコードでロックします。パスワードの設定が必要です。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>トレイに隠したときにロック</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>デスクトップセッションのロック時に Whatly もロックします。パスワードの設定が必要です。(Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>画面ロック時にロックする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>現在のパスワード</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>パスワードを変更</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>次の時間が経過したら自動ロックする</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>リセット</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>パスワードを表示</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>既定のダウンロード先</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>ダウンロード先を変更</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>ストレージ </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>プロパティ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  消去（再起動が必要）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;永続データには、永続的な Cookie、HTML5 ローカルストレージ、訪問済みリンクが含まれます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>永続データ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>HTTP/メディアのキャッシュです。消去しても安全です — 必要に応じて再ダウンロードされます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>キャッシュ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  キャッシュを消去</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>サイズ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>操作</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>バックアップ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>このアカウント（設定、セッション、アドオン）を .tar.gz アーカイブに保存します。アーカイブにはログイン済みのセッションが含まれます — 他人に渡さないでください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>プロファイルをエクスポート…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>.tar.gz アーカイブからアカウントを復元します。現在のデータが上書きされ、再起動が必要です。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>プロファイルをインポート…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>パフォーマンスとプライバシー</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>レンダリングエンジンを微調整します。デフォルト設定はほとんどのシステムで安全です。ウィンドウが空白になる、起動時にクラッシュする、または動作がカクつく場合は、これらの変更を試してください。変更は再起動後に適用されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>すべてを CPU でレンダリングします（--disable-gpu）。一部の GPU／ドライバー構成での空白ウィンドウや起動時クラッシュを修正します。Linux ではデフォルトです。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU アクセラレーションを無効化</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>ページを CPU で合成します（--disable-gpu-compositing）。一部のドライバーで発生する古いフレームのちらつきを回避します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU 合成を無効化</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU VSync を無効化します（--disable-gpu-vsync）。ティアリングと引き換えに入力遅延を軽減できる場合があります。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU VSync を無効化</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>GPU プロセスをメインプロセス内で実行します（--in-process-gpu）。一部のサンドボックス構成向けの回避策です。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU をプロセス内で実行</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>ドライバーがブロックリストに含まれていてもアクセラレーションを強制します（--ignore-gpu-blocklist）。GPU を再度有効にするにはこれを試してください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU ブロックリストを無視</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>すべてを単一プロセスで実行します（--single-process）。メモリ使用量は少なくなりますが、安定性は低下します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>単一プロセスモード（メモリ削減）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>サイトごとに 1 つのレンダラープロセスを共有します（--process-per-site）。メモリ使用量を削減します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>サイトごとに 1 プロセス（メモリ削減）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>チャット一覧の連絡先名とメッセージのプレビューを隠します（ホバーで1件だけ表示）。画面共有時に便利です。開いている会話はそのままです。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>フォーカスモード（チャット一覧のプレビューを隠す）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>メディアエディターで写真と動画を既定でHD画質にします。WhatsApp Web のレイアウトに依存します。WhatsApp の更新で動作しなくなった場合はオフにしてください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>写真と動画を既定でHDで送信する</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>プロキシを経由しない接続で WebRTC がローカル IP アドレスを露呈するのを防ぎます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC の IP 漏洩を防止</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript メモリ上限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>JavaScript ヒープの上限を設定します（V8 --max-old-space-size）。0 = 自動。アプリが RAM を使いすぎる場合は下げてください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP キャッシュ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>HTTP キャッシュの保存場所。メモリは終了時にクリアされます。なしを選ぶとキャッシュが無効になります。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>最大サイズ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>ディスク上のキャッシュの最大サイズ。0 = 自動。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>ネットワークと起動</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>デスクトップセッションにログインしたときに Whatly を自動的に起動します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>ログイン時に Whatly を起動する</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>システムのウィンドウ枠を Whatly 独自のスリムなタイトルバーに置き換えます。再起動後に適用されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>カスタムウィンドウ枠を使用する（再起動が必要）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>1日に1回 GitHub をチェックして新しいリリースがあればお知らせします。Whatly が自動で何かをダウンロードまたはインストールすることは一切ありません。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>自動的に更新を確認する</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>インターフェースの拡大率</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>ウィンドウとページ全体を拡大縮小します（QT_SCALE_FACTOR）。「自動」はデスクトップの設定に従います。QT_SCALE_FACTOR 環境変数が設定されている場合はこの設定より優先されます。再起動後に適用されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>プロキシ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Whatly のネットワーク接続方法。「システム」はオペレーティングシステムの設定に従い、「なし」は直接接続します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>ホスト</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>ポート</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>ユーザー名</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>任意</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>パスワード</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>カスタムJavaScriptアドオン</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>WhatsApp Web上で実行する.jsファイルを読み込みます。各アドオンは独自のサンドボックスで実行されるため、壊れたアドオンが他のアドオンやページを巻き添えにすることはありません。アドオンのチェックを外すと、削除せずに無効化できます。変更は再起動後に適用されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>アドオンを追加…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>削除</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>保存した返信</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>よく送る短い定型文です。コマンドパレット（Ctrl+K）から挿入できます — &quot;挿入&quot; と入力して選ぶと、メッセージ入力欄にテキストが入力されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>返信を追加…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>キーボードショートカット</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>フィールドをクリックしてキーの組み合わせを押します。ショートカットを削除するにはフィールドを空にします。変更は再起動後に適用されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>永続データ（永続的な Cookie とキャッシュを含む）を削除し、アプリケーションを終了します。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Cookie を削除してアプリケーションを終了しますか？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| エラー</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>空の User-Agent 文字列は設定できません。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>テーマを手動で切り替えたため、自動テーマ切り替えは無効になりました。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>アプリロックが設定されていません。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>今すぐアプリロックを設定しますか？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>機能の権限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>チャットの壁紙を選択</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>画像 (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>その画像を使用できませんでした: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>CSS ファイルを選択</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>スタイルシート (*.css);;すべてのファイル (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>そのファイルを読み込めませんでした: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>ディスク</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>メモリ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>システム</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>なし（直接）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>デスクトップポータル (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>システムサービス (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>返信を追加</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>挿入するテキスト</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>JavaScriptファイルを選択</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;すべてのファイル (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>アドオンを追加できませんでした</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>アドオンを削除</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>アドオン &quot;%1&quot; を削除しますか？ファイルも削除されます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>スペルチェッカー（辞書がインストールされていません）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>基本</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>外観</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>チャット</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>プライバシーとロック</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>ウィンドウとズーム</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>詳細設定</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>ショートカットは使用中です</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>そのショートカットは既に別の操作で使用されています。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>キャッシュを消去</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>今すぐキャッシュを消去しますか？必要に応じて再ダウンロードされます。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>プロファイルをエクスポート</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>アーカイブにはログイン済みの WhatsApp セッションが含まれます。他人に渡さないでください。続行しますか？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>アーカイブ (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>プロファイルをエクスポートしました。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>プロファイルをインポート</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>現在のアカウントのデータをアーカイブで上書きし、その後 Whatly を再起動する必要があります。続行しますか？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>プロファイルをインポートしました。Whatly を再起動してください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 言語</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp のデフォルト</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>システムの既定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>%1 を再起動するとインターフェースの言語が変わります。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>アプリロックの設定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>先にアプリロックのパスワードを設定してください。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>ダウンロードフォルダーを選択</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 アプリケーションの完全な再起動が必要になる場合もあります！</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>続行しますか？</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Whatly へようこそ</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>デスクトップ向けの高速でネイティブな WhatsApp Web クライアントです。まずはいくつか設定しましょう — これらはすべて後から設定で変更できます。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly はチャットを本格的なデスクトップウィンドウにまとめ、トレイアイコン、通知、テーマ、複数アカウントに対応します。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>いくつかの設定</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>無難な初期設定です。お好みで調整してください。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>システムのライト/ダークテーマに合わせる</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>ログイン時に Whatly を起動する</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>通知の配信:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>デスクトップポータル (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>システムサービス (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>準備完了</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>準備が整いました。スマートフォンで QR コードをスキャンしてサインインしてください。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>ここにある項目はすべて設定にあるので、後で気が変わっても大丈夫です。</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>最新リリースを読み取れませんでした</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>画面を共有</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>共有する対象を選択してください:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>無題</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>画面: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>ウィンドウ: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>%1 による位置情報へのアクセスを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>%1 によるマイクへのアクセスを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>%1 によるカメラへのアクセスを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>%1 によるマイクとカメラへのアクセスを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>%1 によるマウスカーソルのロックを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>%1 によるデスクトップの映像の記録を許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>%1 によるデスクトップの音声と映像の記録を許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>%1 がデスクトップに通知を表示することを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>%1 によるクリップボードの読み取りを許可しますか？チャットに画像を貼り付けるために必要です。</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>%1 がシステムにインストールされたフォントを参照することを許可しますか？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>権限の要求</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>証明書エラー</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>%2 の「%1」のユーザー名とパスワードを入力してください</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>次を使ってプロキシ「%1」に接続:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>%1 がすべての %2 リンクを開くことを許可しますか？</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>レンダープロセスが正常に終了しました</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>レンダープロセスが異常終了しました</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>レンダープロセスがクラッシュしました</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>レンダープロセスが強制終了されました</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>レンダープロセスがコード %1 で終了しました

--- a/src/i18n/ko_KR.ts
+++ b/src/i18n/ko_KR.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>PayPal로 후원</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>스토어에서 평가</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>다른 앱</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>소스 코드</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;아래의 디버그 정보를 클립보드에 복사하고 이슈 트래커를 열어 보고서에 바로 붙여넣을 수 있게 합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>버그 신고</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>디버그 정보</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>버전: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>디버그 정보가 브라우저로 전달하기에 너무 길어 클립보드에 복사했습니다. 이슈에 붙여넣으세요.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | 정보</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>일출</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>일몰</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  새로 고침 </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>비활성화하고 닫기</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  활성화하고 닫기</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 다시 시도하세요.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>대화 상자</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>아이콘</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp(기본값)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>바비 핑크</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>더스티 로즈</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>라벤더</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>바이올렛</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>하늘색</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>딥 오션</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>틸</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>민트</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>코랄</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>피치</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>골드</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>크림슨</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>그래파이트</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>명령 팔레트</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>명령 입력…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>명령 검색</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>일치하는 명령</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>최소화</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>최대화</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>다운로드</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>다운로드 없음</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>다운로드 목록 비우기</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>모두 비우기</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>파일 관리자에서 다운로드 폴더 열기</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>다운로드 폴더 열기</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>같은 이름의 파일이 이미 있습니다!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>파일을 새 이름으로 저장할까요?</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>시스템 앱으로 파일 열기</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %2 중 %1 다운로드됨 - %3/초</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>크기 알 수 없음 - %1 다운로드됨 - %2/초</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>완료 - %1 다운로드됨 - %2/초</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>취소됨 - %1 다운로드됨 - %2/초</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>중단됨: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>다운로드 중지</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>목록에서 제거</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>잠금 암호 설정</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>암호 입력</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>암호 다시 입력</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>암호 설정</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>경고: Caps Lock이 켜져 있습니다</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;참고: 암호는 3자보다 길어야 하며 두 칸의 내용이 같아야 합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>접근하려면 암호를 입력하세요</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>암호를 입력하세요</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;암호가 올바르지 않습니다. 다시 시도하세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>네트워크 대기 중…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>열려 있는 WhatsApp 창이 없습니다</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>알림</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>알림: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>업데이트 사용 가능</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1을(를) 사용할 수 있습니다. 클릭하여 다운로드 페이지를 여세요.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| 오류</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>설정에 접근하려면 잠금을 해제하세요.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>설정 모듈을 초기화할 수 없습니다.
 WebEngine이 초기화되지 않았습니다.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | 작업 필요</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>계속하려면 페이지를 다시 불러와야 합니다.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>새 대화</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>국가 번호를 포함한 유효한 WhatsApp 번호를 입력하세요 (예: +82XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>앱 평가</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 지금 설정을 여시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>전체 화면</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>트레이로 최소화(&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>복원(&amp;R)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>새로 고침(&amp;L)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>잠금(&amp;K)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>오디오 음소거(&amp;M)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>확대</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>축소</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>확대/축소 초기화</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>설정(&amp;S)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>예약 메시지…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>테마 전환(&amp;T)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>탭 보기</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>명령 팔레트</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>정보(&amp;A)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>종료(&amp;Q)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>새로 고침</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>트레이로 최소화</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>잠금</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>오디오 음소거</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>새 채팅 / URL 열기</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>테마 전환</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>이름 바꾸기…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>계정 제거</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>계정으로 전환: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>계정 추가…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>삽입: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — 읽지 않음 %2개</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>다른 계정 추가</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>복원</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>개의 메시지</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>개의 메시지</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>계정 추가</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>새 계정 이름:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>계정 %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>계정 이름 바꾸기</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>계정 이름:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>계정 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>앱을 새로 고치려면 잠금을 해제하세요.</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>인증 필요</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>아이콘</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>정보</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>사용자 이름:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>비밀번호:</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>기능</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>상태</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>채팅 목록</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>열린 대화</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>채팅 목록과 대화</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>사진 포함 전체</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>디버그 정보 표시</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>디버그 정보 숨기기</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>&quot;%1&quot;에서 마이그레이션할 항목이 없습니다 — 이미 완료되었거나 데이터가 없습니다.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>복사 예정:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>복사됨:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>복사를 수행하려면 --dry-run 없이 다시 실행하세요.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Qt WebEngine 기반의 다기능 WhatsApp Web 클라이언트</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>명령줄 옵션 도움말을 표시합니다</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>실행 중인 인스턴스에서 설정을 엽니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>실행 중인 인스턴스를 잠급니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>실행 중인 인스턴스에서 «정보» 창을 엽니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>실행 중인 인스턴스에서 예약 메시지 대화상자를 엽니다 </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>실행 중인 인스턴스에서 밝은 테마와 어두운 테마를 전환합니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>실행 중인 인스턴스에서 앱을 새로 고칩니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>실행 중인 인스턴스에서 새 대화 창을 엽니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;자체 세션과 설정을 가진 별도 계정으로, 별도의 창에서 실행합니다&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>실행 중인 인스턴스의 기본 창을 표시합니다: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>이전 설치(예: 이전 &quot;whatsie&quot; 빌드)에서 설정과 로그인된 세션을 여기로 복사한 후 종료합니다</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>--migrate-from와 함께 사용하면 복사될 항목만 표시합니다</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>현재 읽지 않은 메시지 수를 출력하고 종료합니다</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>앱 잠금이 설정되어 있지 않습니다.
 먼저 설정에서 비밀번호를 지정하세요.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>새로 고치는 중...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>설치 방식</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>소스 브랜치</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>커밋 해시</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>빌드 일시</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt 런타임 버전</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt 컴파일 버전</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>시스템</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>아키텍처</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>예외</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> 에서 문제가 발생했습니다.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> 을(를) 다시 시작해야 할 수 있습니다. 개발자에게 오류를 알려 주세요.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>&apos;tar&apos;을(를) 실행할 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>백업할 항목이 없습니다</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>%1 을(를) 만들 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>%1을(를) 복사할 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>임시 디렉터리를 만들 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>설정 파일을 복원할 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>%1 에 쓸 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>밝은 테마로 전환</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>어두운 테마로 전환</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>채팅 표시</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>채팅 흐리게</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>이 앱 평가하기</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;이 앱이 마음에 드셨다면 잠시 시간을 내어 평가해 주시겠어요?&lt;/p&gt;&lt;p&gt;1분도 걸리지 않습니다. 응원해 주셔서 감사합니다!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  스토어에서 평가</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>또는</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>GitHub 저장소에 별 주기</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>PayPal로 후원 </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>OpenCollective로 후원</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>나중에</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  이미 했어요  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>메시지 전송을 기다리는 중 시간이 초과되었습니다</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>매일</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>평일</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>매주</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>한 번</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>전송됨</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>실패</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>대기 중</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>예약 메시지</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>받는 사람</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>시간</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>메시지</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>상태</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>국제 형식 전화번호, 예: 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>선택 라벨</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>한 번</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>매일</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>평일</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>매주</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>반복</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>보내지 않고 알림 받기 (메시지 전송 없이 알림)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>보낼 메시지</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>예약된 시간에 앱이 실행 중이고 WhatsApp에 로그인되어 있어야 합니다. 닫혀 있으면 다음에 앱을 열 때 메시지가 전송됩니다. 전송하면 받는 사람의 대화가 열립니다.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>예약</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>선택 항목 제거</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>전송됨/실패 지우기</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>전화번호와 메시지를 입력하세요.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>지정한 시간이 지났습니다 — 이 메시지를 지금 보낼까요?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>인터페이스 글꼴 크기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;앱 자체 인터페이스(메뉴, 설정, 대화 상자)의 포인트 크기입니다. WhatsApp Web의 텍스트에는 영향을 주지 않습니다. 그것은 확대/축소를 사용하세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>화면 테마</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>충돌 후 자동으로 다시 로드</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web의 페이지 프로세스가 충돌하면 먼저 묻지 않고 자동으로 다시 로드합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>일반 설정</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>위젯 스타일</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>위젯 테마</translation>
+        <translation type="vanished">위젯 테마</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;시스템의 표준 시간대와 위치를 기준으로 합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>자동</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>어두움</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>밝음</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;데스크톱의 밝게/어둡게 설정을 따르고 그에 맞춰 바뀝니다. 수동 테마와 일출/일몰 자동 전환보다 우선합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>시스템 밝게/어둡게 테마 따르기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>시스템 알림</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>사용자 지정 알림</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  시험</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>알림 유형</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>알림 팝업 사용 안 함</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>팝업 표시 시간</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> 초</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>알림 전달</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Linux에서 네이티브 알림을 보내는 방식입니다. 자동은 Flatpak 샌드박스 내에서는 데스크톱 포털을, 그 외에는 시스템 서비스를 사용합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>매일 지정한 조용한 시간대에 알림 팝업을 표시하지 않습니다. 읽지 않음 배지는 계속 업데이트되며 팝업만 보류됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>방해 금지</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>시작</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>종료</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>키워드 강조</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>쉼표로 구분된 단어로, 방해 금지 중에도 항상 알림을 보냅니다(대소문자 구분 안 함).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>예: 긴급, 상사, 청구서</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>시스템 파일 대화 상자 사용</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>페이지 소리 음소거</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>미디어 자동 재생 사용 안 함</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>시작할 때 트레이로 최소화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>트레이 아이콘 클릭 시 표시/숨기기 (지원되는 경우)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;다른 곳을 클릭하면 이모지, GIF, 스티커 패널을 닫습니다. 그렇지 않으면 WhatsApp Web은 버튼을 다시 누를 때까지 패널을 열어 둡니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>패널 바깥을 클릭하면 이모지/스티커 패널 닫기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>인터페이스 언어</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whatly 자체 인터페이스의 언어입니다. 앱을 다시 시작하면 적용됩니다. 채팅 자체의 언어는 WhatsApp Web에서 오며 여기서 바꿀 수 없습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp 사이드바의 프로필 사진 바로 위에 밝게/어둡게 버튼을 추가합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp 사이드바의 테마 버튼</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;설정을 열지 않고 한 번의 클릭으로 채팅을 흐리게 하거나 다시 보이게 하는 버튼을 WhatsApp 사이드바에 추가합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp 사이드바의 흐림 버튼</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp의 녹색 아이콘 대신 패널의 나머지와 어울리는 단색 트레이 아이콘을 사용합니다. WhatsApp이 연결되지 않으면 아이콘이 흐려집니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>단색 트레이 아이콘</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;한 줄씩 건너뛰는 대신 스크롤을 부드럽게 움직입니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>부드러운 스크롤</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>사용자 지정 CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web의 스타일을 바꾸는 .css 파일을 불러옵니다 — 커뮤니티 스타일시트(catppuccin 등)가 여기서 작동합니다. 채팅 테마 위에 적용됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>파일 선택…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>지우기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;시스템 트레이 아이콘을 완전히 제거합니다. 복원할 트레이가 없으므로 창을 닫으면 앱이 숨겨지지 않고 종료됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>트레이 아이콘 숨기기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>글꼴</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web의 텍스트를 시스템에 설치된 글꼴로 표시합니다. 이모지, 아이콘, 고정폭 메시지 서식은 그대로 유지됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;상태/업데이트 패널의 &quot;음소거된 업데이트&quot; 섹션을 숨겨, 음소거한 연락처의 상태가 전혀 표시되지 않도록 합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>음소거된 상태 업데이트 숨기기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;입력하는 동안 맞춤법이 틀린 단어에 밑줄을 긋고 오른쪽 클릭 메뉴에서 수정안을 제안합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>입력하는 동안 맞춤법 검사</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;검사 기준이 되는 언어입니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>개인정보 흐림</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;화면을 흘깃 보는 사람이 읽지 못하도록, 마우스를 올리기 전까지 채팅을 흐리게 합니다. 한 줄에 마우스를 올리면 그 줄만 보입니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>채팅 테마</translation>
+        <translation type="vanished">채팅 테마</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>채팅 색조</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web 자체의 색을 다시 입힙니다. 사진, 아바타, 스티커는 원래 색을 유지합니다. 활성화된 밝은 또는 어두운 테마 위에서 작동합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>채팅 배경</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp의 Android처럼 채팅 창의 배경으로 자신의 이미지를 사용합니다. 이미지는 Whatly 내부에 저장되며 어디에도 업로드되지 않고 본인에게만 보입니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>이미지 선택…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;새 로그인은 휴대전화의 연결된 기기 목록에 «Google Chrome (Linux)» 대신 «Whatly for Linux»(또는 해당 플랫폼)로 표시됩니다. 이 이름은 기기를 연결할 때 휴대전화에 저장되므로, 이 설정을 바꿔도 이후의 연결에만 적용됩니다. 기존 세션의 이름을 바꾸려면 로그아웃한 뒤 다시 연결하세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>연결된 기기에서 Whatly로 표시</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>사용자 에이전트</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;고급 — 정확히 무엇을 하는지 알지 못한다면 이 설정을 그대로 두세요. 비표준 user agent는 WhatsApp이 로드되지 않게 만들 수 있으며, 비정상적인 값은 WhatsApp 계정이 플래그 처리되거나 블랙리스트에 오를 위험이 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  적용</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>기본값으로 되돌리기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>일반 창일 때의 확대 비율</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>축소</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>확대</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>초기화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>최대화/전체 화면일 때의 확대 비율</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>트레이로 최소화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>전역 단축키</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>닫기 단추 동작</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  단축키 보기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>권한</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  권한 보기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;잠금 화면을 사용합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>시작할 때 앱 잠금 사용</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;창이 시스템 트레이로 숨겨질 때 암호로 잠급니다. 비밀번호가 설정되어 있어야 합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>트레이로 숨길 때 잠금</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>데스크톱 세션이 잠길 때 Whatly도 잠급니다. 비밀번호가 설정되어 있어야 합니다. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>화면이 잠길 때 잠그기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>현재 비밀번호</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>비밀번호 변경</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>다음 시간 후 자동 잠금</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>초기화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>비밀번호 보기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>기본 다운로드 위치</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>다운로드 위치 변경</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>저장소 </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>속성</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  비우기 (다시 시작 필요)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;지속 데이터에는 지속 쿠키, HTML5 로컬 저장소, 방문한 링크가 포함됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>지속 데이터</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>HTTP/미디어 캐시입니다. 지워도 안전합니다 — 필요할 때 다시 다운로드됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>캐시</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  캐시 지우기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>동작</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>백업</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>이 계정(설정, 세션, 부가 기능)을 .tar.gz 압축 파일에 저장합니다. 압축 파일에는 로그인된 세션이 포함되어 있으니 — 외부에 공개하지 마세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>프로필 내보내기…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>.tar.gz 압축 파일에서 계정을 복원합니다. 현재 데이터를 덮어쓰며 다시 시작해야 합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>프로필 가져오기…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>성능 및 개인정보 보호</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>렌더링 엔진을 세밀하게 조정합니다. 기본값은 대부분의 시스템에서 안전합니다. 창이 비어 있거나 시작 시 앱이 충돌하거나 끊김이 발생하면 이 값을 변경해 보세요. 변경 사항은 다시 시작한 후에 적용됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>전적으로 CPU에서 렌더링합니다 (--disable-gpu). 일부 GPU/드라이버 환경에서 빈 창과 시작 시 충돌을 해결합니다. Linux에서 기본값입니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU 가속 비활성화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>페이지를 CPU에서 합성합니다 (--disable-gpu-compositing). 일부 드라이버에서 오래된 프레임 깜박임을 방지합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU 합성 비활성화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU VSync를 비활성화합니다 (--disable-gpu-vsync). 화면 찢어짐을 감수하는 대신 입력 지연을 줄일 수 있습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU VSync 비활성화</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>GPU 프로세스를 메인 프로세스 내에서 실행합니다 (--in-process-gpu). 일부 샌드박스 환경을 위한 해결 방법입니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU를 프로세스 내에서 실행</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>드라이버가 차단 목록에 있어도 가속을 강제합니다 (--ignore-gpu-blocklist). GPU를 다시 켜려면 이 옵션을 사용해 보세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU 차단 목록 무시</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>모든 것을 단일 프로세스에서 실행합니다 (--single-process). 메모리를 적게 사용하지만 안정성은 떨어집니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>단일 프로세스 모드 (메모리 절약)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>사이트당 렌더러 프로세스 하나를 공유합니다 (--process-per-site). 메모리 사용량을 줄입니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>사이트당 프로세스 하나 (메모리 절약)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>대화 목록의 연락처 이름과 메시지 미리보기를 숨깁니다(마우스를 올리면 하나만 표시). 화면 공유 시 유용합니다. 열려 있는 대화는 그대로 유지됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>집중 모드 (대화 목록 미리보기 숨기기)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>미디어 편집기에서 사진과 동영상을 기본적으로 HD 화질로 설정합니다. WhatsApp Web의 레이아웃에 따라 달라지며, WhatsApp 업데이트로 인해 작동하지 않으면 끄세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>기본적으로 사진과 동영상을 HD로 보내기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>프록시를 거치지 않는 연결에서 WebRTC가 로컬 IP 주소를 노출하지 못하도록 합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC IP 유출 방지</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript 메모리 제한</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>JavaScript 힙 크기를 제한합니다 (V8 --max-old-space-size). 0 = 자동. 앱이 RAM을 너무 많이 사용하면 값을 낮추세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP 캐시</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>HTTP 캐시를 저장할 위치입니다. 메모리는 종료 시 지워지며, 없음은 캐싱을 비활성화합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>최대 크기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>디스크 캐시 최대 크기. 0 = 자동.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>네트워크 및 시작</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>데스크톱 세션에 로그인할 때 Whatly를 자동으로 실행합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>로그인할 때 Whatly 시작</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>시스템 창 테두리를 Whatly 고유의 얇은 제목 표시줄로 바꿉니다. 다시 시작한 후에 적용됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>사용자 지정 창 프레임 사용 (다시 시작 필요)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>하루에 한 번 GitHub에서 새 릴리스를 확인하고 알려 드립니다. Whatly는 스스로 아무것도 다운로드하거나 설치하지 않습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>자동으로 업데이트 확인</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>인터페이스 배율</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>전체 창과 페이지의 배율을 조정합니다(QT_SCALE_FACTOR). 자동은 데스크톱 설정을 따릅니다. QT_SCALE_FACTOR 환경 변수가 설정되어 있으면 이 설정보다 우선합니다. 다시 시작한 후 적용됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>프록시</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Whatly가 네트워크에 연결하는 방식입니다. 시스템은 운영 체제 설정을 따르고, 없음은 직접 연결합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>호스트</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>포트</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>사용자 이름</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>선택 사항</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>비밀번호</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>사용자 지정 JavaScript 애드온</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>WhatsApp Web에서 실행할 .js 파일을 불러옵니다. 각 애드온은 자체 샌드박스에서 실행되므로, 하나가 손상되어도 다른 애드온이나 페이지를 중단시키지 않습니다. 애드온의 체크를 해제하면 제거하지 않고 비활성화됩니다. 변경 사항은 다시 시작한 후에 적용됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>애드온 추가…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>제거</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>저장된 답장</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>자주 보내는 짧은 문구입니다. 명령 팔레트(Ctrl+K)에서 하나를 삽입하세요 — &quot;삽입&quot;을 입력한 뒤 선택하면 메시지 입력란에 텍스트가 입력됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>답장 추가…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>키보드 단축키</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>필드를 클릭하고 키 조합을 누르세요. 단축키를 제거하려면 필드를 비우세요. 변경 사항은 다시 시작한 후에 적용됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>영구 데이터(영구 쿠키 및 캐시 포함)를 삭제하고 애플리케이션을 종료합니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>쿠키를 삭제하고 애플리케이션을 종료할까요?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| 오류</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>빈 User-Agent 문자열은 설정할 수 없습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>테마를 직접 변경했기 때문에 자동 테마 전환이 해제되었습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>앱 잠금이 설정되지 않았습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>지금 앱 잠금을 설정할까요?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>기능 권한</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>채팅 배경 선택</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>이미지 (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>이미지를 사용할 수 없습니다: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>CSS 파일 선택</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>스타일시트 (*.css);;모든 파일 (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>파일을 읽을 수 없습니다: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>디스크</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>시스템</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>없음(직접)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>데스크톱 포털 (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>시스템 서비스 (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>답장 추가</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>삽입할 텍스트</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>JavaScript 파일 선택</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;모든 파일 (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>애드온을 추가할 수 없습니다</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>애드온 제거</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>애드온 &quot;%1&quot;을(를) 제거하시겠습니까? 해당 파일이 삭제됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>맞춤법 검사기(설치된 사전 없음)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>기본</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>모양</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>알림</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>채팅</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>개인정보 및 잠금</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>창 및 확대/축소</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>고급</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>단축키 사용 중</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>해당 단축키는 이미 다른 동작에서 사용 중입니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>캐시 지우기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>지금 캐시를 지우시겠습니까? 필요할 때 다시 다운로드됩니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>프로필 내보내기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>압축 파일에는 로그인된 WhatsApp 세션이 포함됩니다. 외부에 공개하지 마세요. 계속하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>압축 파일 (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>프로필을 내보냈습니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>프로필 가져오기</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>현재 계정의 데이터를 압축 파일로 덮어쓴 후 Whatly를 다시 시작해야 합니다. 계속하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>프로필을 가져왔습니다. Whatly를 다시 시작하세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>언어 %1개</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp 기본값</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>시스템 기본값</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>%1 을(를) 다시 시작하면 인터페이스 언어가 바뀝니다.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>앱 잠금 설정</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>먼저 앱 잠금 비밀번호를 설정하세요.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>다운로드 폴더 선택</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 애플리케이션을 완전히 다시 시작해야 할 수도 있습니다!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>계속할까요?</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Whatly에 오신 것을 환영합니다</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>빠르고 네이티브한 데스크톱용 WhatsApp Web 클라이언트입니다. 몇 가지만 설정해 볼게요 — 나중에 설정에서 모두 변경할 수 있습니다.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly는 트레이 아이콘, 알림, 테마, 다중 계정과 함께 대화를 제대로 된 데스크톱 창에서 유지해 줍니다.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>몇 가지 환경설정</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>합리적인 기본값이며, 취향에 맞게 조정하세요.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>시스템의 밝은/어두운 테마에 맞추기</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>로그인할 때 Whatly 시작</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>알림 전달:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>자동</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>데스크톱 포털 (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>시스템 서비스 (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>모두 완료</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>이제 준비가 끝났습니다. 휴대폰으로 QR 코드를 스캔하여 로그인하세요.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>마음이 바뀌면 여기 있는 모든 항목을 설정에서 다시 바꿀 수 있습니다.</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>최신 릴리스를 읽을 수 없습니다</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>화면 공유</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>공유할 항목을 선택하세요:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>제목 없음</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>화면: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>창: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>%1 이(가) 위치 정보에 접근하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>%1 이(가) 마이크에 접근하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>%1 이(가) 카메라에 접근하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>%1 이(가) 마이크와 카메라에 접근하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>%1 이(가) 마우스 커서를 고정하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>%1 이(가) 바탕 화면의 영상을 녹화하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>%1 이(가) 바탕 화면의 소리와 영상을 녹화하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>%1 이(가) 바탕 화면에 알림을 표시하도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>%1 이(가) 클립보드를 읽도록 허용하시겠습니까? 대화에 이미지를 붙여 넣으려면 필요합니다.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>%1 이(가) 시스템에 설치된 글꼴을 보도록 허용하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>권한 요청</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>인증서 오류</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>%2 의 «%1» 에 대한 사용자 이름과 비밀번호를 입력하세요</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>다음을 사용하여 프록시 «%1» 에 연결:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>%1 이(가) 모든 %2 링크를 열도록 허용하시겠습니까?</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>렌더 프로세스가 정상적으로 종료되었습니다</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>렌더 프로세스가 비정상적으로 종료되었습니다</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>렌더 프로세스가 충돌했습니다</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>렌더 프로세스가 강제 종료되었습니다</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>렌더 프로세스가 코드 %1 (으)로 종료되었습니다

--- a/src/i18n/nl_NL.ts
+++ b/src/i18n/nl_NL.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Doneren via PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Beoordelen in de store</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Meer toepassingen</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Broncode</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kopieert de onderstaande foutopsporingsinformatie naar het klembord en opent de issue-tracker, zodat deze rechtstreeks in het rapport kan worden geplakt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Een bug melden</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Foutopsporingsinformatie</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Versie: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>De foutopsporingsinformatie was te lang voor de browser en is naar het klembord gekopieerd. Plak deze in het issue.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Over</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Zonsopgang</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Zonsondergang</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Vernieuwen </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Uitschakelen en sluiten</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Inschakelen en sluiten</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Probeer het opnieuw.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Probeer het opnieuw.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialoogvenster</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Pictogram</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (standaard)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Barbieroze</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Oudroze</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavendel</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Violet</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Hemelsblauw</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Diepe oceaan</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Blauwgroen</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Mint</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Koraal</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Perzik</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Goud</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Karmozijn</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafiet</translation>
     </message>
@@ -209,18 +256,22 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Opdrachtenpalet</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Typ een opdracht…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Opdracht zoeken</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Overeenkomende opdrachten</translation>
     </message>
@@ -228,14 +279,17 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimaliseren</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maximaliseren</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
@@ -243,34 +297,42 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Geen downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Downloadlijst wissen</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Alles wissen</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Downloadmap openen in de bestandsbeheerder</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Downloadmap openen</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Er bestaat al een bestand met dezelfde naam!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Bestand onder een nieuwe naam opslaan?</translation>
     </message>
@@ -278,54 +340,68 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Bestand openen met de systeemtoepassing</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 van %2 gedownload - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>onbekende grootte - %1 gedownload - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>voltooid - %1 gedownload - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>geannuleerd - %1 gedownload - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>onderbroken: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Download stoppen</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Uit de lijst verwijderen</translation>
     </message>
@@ -333,46 +409,58 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Vergrendelingscode instellen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>voer de code in</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>voer de code nogmaals in</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Code instellen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Let op: Caps Lock staat aan</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Let op: de code moet langer zijn dan 3 tekens en in beide velden gelijk zijn.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Voer uw code in om toegang te krijgen</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>voer uw code in</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Onjuiste code. Probeer het opnieuw.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Wilt u de beveiligingscontrole negeren en doorgaan?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Wachten op netwerk…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Er is geen WhatsApp-venster geopend</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Herinnering</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Herinnering: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Update beschikbaar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 is beschikbaar. Klik om de downloadpagina te openen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Fout</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Ontgrendel om de instellingen te openen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Kan de instellingenmodule niet initialiseren.
 WebEngine is niet geïnitialiseerd.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Actie vereist</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>De pagina moet opnieuw worden geladen om door te gaan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nieuw gesprek</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Voer een geldig WhatsApp-nummer met landnummer in (bijv. +31XXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Toepassing beoordelen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Stel eerst het wachtwoord in bij de instellingen.
 Instellingen nu openen?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Volledig scherm</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimaliseren naar het systeemvak</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Herstellen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Her&amp;laden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Ver&amp;grendelen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>Geluid de&amp;mpen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Zoom herstellen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellingen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>Geplande &amp;berichten…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>&amp;Thema wisselen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Tabbladweergave</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Opdrachtenpalet</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Over</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Afsluiten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Opnieuw laden</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Minimaliseren naar systeemvak</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Vergrendelen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Geluid dempen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nieuwe chat / URL openen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Thema wisselen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Naam wijzigen…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Account verwijderen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Overschakelen naar account: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Account toevoegen…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Invoegen: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 ongelezen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Nog een account toevoegen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Herstellen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>berichten</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>bericht</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Account toevoegen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Naam voor het nieuwe account:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Account %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Accountnaam wijzigen</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Accountnaam:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Account 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Ontgrendel om de toepassing te herladen.</translation>
     </message>
@@ -623,10 +779,12 @@ Instellingen nu openen?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Instellingen nu openen?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
@@ -641,22 +800,27 @@ Instellingen nu openen?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Authenticatie vereist</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Pictogram</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informatie</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Gebruikersnaam:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Wachtwoord:</translation>
     </message>
@@ -664,14 +828,17 @@ Instellingen nu openen?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Functie</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
@@ -679,22 +846,27 @@ Instellingen nu openen?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Chatlijst</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Geopend gesprek</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Chatlijst en gesprek</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Alles, inclusief foto&apos;s</translation>
     </message>
@@ -702,10 +874,13 @@ Instellingen nu openen?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Foutopsporingsinformatie tonen</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Instellingen nu openen?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Foutopsporingsinformatie verbergen</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Niets te migreren van &quot;%1&quot; — al gemigreerd, of geen gegevens gevonden.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Zou kopiëren:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Gekopieerd:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Voer opnieuw uit zonder --dry-run om de kopie uit te voeren.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Veelzijdige WhatsApp Web-client op basis van Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Toont de hulp voor de opdrachtregelopties</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Opent de instellingen in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Vergrendelt een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Opent het venster «Over» in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Opent het dialoogvenster voor geplande berichten in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Wisselt tussen licht en donker thema in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Herlaadt de toepassing in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Opent het venster voor een nieuw gesprek in een actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uitvoeren als een apart account met een eigen sessie en instellingen, in een eigen venster&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Toont het hoofdvenster van de actieve instantie van </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Kopieer instellingen en de aangemelde sessie van een eerdere installatie (bijv. de oudere &quot;whatsie&quot;-versie) naar deze en sluit af</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Met --migrate-from alleen tonen wat er gekopieerd zou worden</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Toon het huidige aantal ongelezen berichten en sluit af</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>De app-vergrendeling is niet ingesteld.
 Stel eerst het wachtwoord in bij de instellingen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Bezig met herladen...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Installatiemodus</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Bronbranch</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Commit-hash</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Bouwdatum</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt-runtimeversie</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt-compilatieversie</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Systeem</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Architectuur</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Uitzondering</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> heeft een probleem ondervonden.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> moet mogelijk opnieuw worden gestart. Meld de fout aan de ontwikkelaar.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Kon &apos;tar&apos; niet uitvoeren</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Niets om een back-up van te maken</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Kan %1 niet aanmaken</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Kan %1 niet kopiëren</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Kan geen tijdelijke map maken</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Kon het instellingenbestand niet herstellen</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Kan %1 niet schrijven</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Naar licht thema wisselen</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Naar donker thema wisselen</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Chats tonen</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Chats vervagen</translation>
@@ -898,42 +1123,53 @@ Stel eerst het wachtwoord in bij de instellingen.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Deze app beoordelen</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Als u deze app graag gebruikt, wilt u dan even de tijd nemen om hem te beoordelen?&lt;/p&gt;&lt;p&gt;Het duurt niet langer dan een minuut. Bedankt voor uw steun!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Beoordelen in de store</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Of</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Geef de GitHub-repository een ster</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Doneren via PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Doneren via OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Later</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Al gedaan  </translation>
     </message>
@@ -941,34 +1177,42 @@ Stel eerst het wachtwoord in bij de instellingen.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Time-out bij het wachten op het verzenden van het bericht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Dagelijks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Doordeweeks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Wekelijks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Eenmalig</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Verzonden</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Mislukt</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>In behandeling</translation>
     </message>
@@ -976,90 +1220,117 @@ Stel eerst het wachtwoord in bij de instellingen.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Geplande berichten</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Aan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Wanneer</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Telefoonnummer in internationaal formaat, bijv. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Optioneel label</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Eenmalig</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Dagelijks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Doordeweeks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Wekelijks</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Herhalen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Herinner mij in plaats van te verzenden (melden, geen bericht sturen)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Te verzenden bericht</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>De app moet actief zijn en WhatsApp aangemeld op het geplande tijdstip. Als de app gesloten is, wordt het bericht verzonden zodra je de app weer opent. Bij verzenden wordt de chat van de ontvanger geopend.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Plannen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Selectie verwijderen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Verzonden/mislukt wissen</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Voer een telefoonnummer en een bericht in.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Het tijdstip ligt in het verleden — dit bericht nu verzenden?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Stel eerst het wachtwoord in bij de instellingen.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Lettergrootte van de interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Puntgrootte van de eigen interface van de app — menu&apos;s, instellingen en dialoogvensters. Dit heeft geen invloed op de tekst van WhatsApp Web; gebruik daarvoor de zoom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Weergavethema</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Automatisch herladen na een crash</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Als het paginaproces van WhatsApp Web crasht, dit automatisch herladen in plaats van eerst te vragen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Algemene instellingen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Widgetstijl</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Widgetthema</translation>
+        <translation type="vanished">Widgetthema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Op basis van de tijdzone en locatie van uw systeem.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Donker</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Licht</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Volgt de licht/donker-voorkeur van het bureaublad en verandert mee. Overschrijft het handmatige thema en de automatische zonop-/ondergangswissel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Systeemthema (licht/donker) volgen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Systeemeigen melding</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Aangepaste melding</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Proberen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Type melding</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Meldingspop-up uitschakelen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Time-out van de pop-up</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> sec.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Meldingsbezorging</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Hoe systeemeigen meldingen op Linux worden verzonden. Automatisch gebruikt het bureaubladportaal binnen een Flatpak-sandbox en anders de systeemservice.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Onderdrukt meldingspop-ups tijdens een dagelijkse stille periode. Ongelezen-badges worden nog steeds bijgewerkt; alleen de pop-up wordt tegengehouden.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Niet storen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Van</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>tot</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Trefwoorden markeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Door komma&apos;s gescheiden woorden die altijd een melding geven, zelfs tijdens Niet storen (niet hoofdlettergevoelig).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>bijv. urgent, baas, factuur</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Systeemeigen bestandsvenster gebruiken</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Geluid van de pagina dempen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Automatisch afspelen van media uitschakelen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Bij het starten minimaliseren naar het systeemvak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Tonen/verbergen bij klikken op het systeemvakpictogram (indien ondersteund)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sluit het emoji-, gif- en stickerpaneel wanneer u ergens anders klikt. Anders houdt WhatsApp Web het open totdat de knop opnieuw wordt ingedrukt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Emoji-/stickerpaneel sluiten bij klikken erbuiten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Taal van de interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Taal van Whatly&apos;s eigen interface. Wordt van kracht na het opnieuw starten van de app. De taal van de chats komt van WhatsApp Web en kan hier niet worden gewijzigd.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voegt een licht/donker-knop toe aan WhatsApps zijbalk, net boven je profielfoto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Themaknop in WhatsApps zijbalk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voegt aan WhatsApps zijbalk een knop toe die je chats met één klik vervaagt en weer toont, zonder de instellingen te openen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Vervagingsknop in WhatsApps zijbalk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gebruikt een eenkleurig systeemvakpictogram dat bij de rest van je paneel past, in plaats van het groene van WhatsApp. Het pictogram wordt ook gedimd wanneer WhatsApp niet verbonden is.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Monochroom systeemvakpictogram</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animeert het scrollen in plaats van regel voor regel te springen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Vloeiend scrollen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>Aangepaste CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Laad een .css-bestand om WhatsApp Web een nieuwe stijl te geven — de community-stylesheets (catppuccin en dergelijke) werken hier. Toegepast bovenop het chatthema.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Bestand kiezen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Wissen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verwijdert het systeemvakpictogram volledig. Zonder vak om te herstellen sluit het venster de app af in plaats van deze te verbergen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Systeemvakpictogram verbergen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Lettertype</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Geeft de tekst van WhatsApp Web weer in een op je systeem geïnstalleerd lettertype. Emoji&apos;s, pictogrammen en opmaak met vaste tekenbreedte blijven ongewijzigd.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verbergt de sectie &quot;Gedempte updates&quot; in het Status-/Updates-paneel, zodat statussen van gedempte contacten helemaal niet verschijnen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Gedempte statusupdates verbergen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Onderstreept verkeerd gespelde woorden tijdens het typen en biedt correcties in het rechtsklikmenu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Spelling controleren tijdens het typen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;De taal waartegen wordt gecontroleerd.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Privacyvervaging</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vervaagt je chats totdat je erover zweeft, zodat iemand die naar het scherm kijkt ze niet kan lezen. Over een rij zweven toont alleen die rij.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Chatthema</translation>
+        <translation type="vanished">Chatthema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Kleurtint van chat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kleurt WhatsApp Web zelf opnieuw. Foto&apos;s, avatars en stickers behouden hun eigen kleuren. Werkt bovenop het lichte of donkere thema, welke ook actief is.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Chatachtergrond</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gebruik een van je eigen afbeeldingen als achtergrond van het chatvenster, zoals WhatsApp op Android doet. De afbeelding wordt in Whatly opgeslagen, nergens geüpload en is alleen voor jou zichtbaar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Afbeelding kiezen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nieuwe aanmeldingen verschijnen als «Whatly voor Linux» (of het overeenkomstige platform) in de lijst met gekoppelde apparaten op uw telefoon, in plaats van «Google Chrome (Linux)». De naam wordt op de telefoon opgeslagen wanneer een apparaat wordt gekoppeld, dus dit wijzigen heeft alleen invloed op toekomstige koppelingen: meld u af en koppel opnieuw om een bestaande sessie te hernoemen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Als Whatly identificeren bij gekoppelde apparaten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User-agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Geavanceerd — laat dit ongemoeid tenzij u precies weet wat u doet. Een niet-standaard user agent kan ervoor zorgen dat WhatsApp weigert te laden, en ongebruikelijke waarden brengen het risico met zich mee dat uw WhatsApp-account wordt gemarkeerd of op een zwarte lijst wordt geplaatst.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Toepassen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Standaardwaarden herstellen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Zoomfactor bij normaal venster</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>herstellen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Zoomfactor bij gemaximaliseerd/volledig scherm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimaliseren naar het systeemvak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Globale sneltoetsen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Actie van de sluitknop</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Sneltoetsen tonen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Machtigingen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Machtigingen tonen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vergrendelingsscherm inschakelen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>App-vergrendeling inschakelen bij het starten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wanneer het venster naar het systeemvak verdwijnt, vergrendel het achter de toegangscode. Vereist een ingesteld wachtwoord.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Vergrendelen bij verbergen naar systeemvak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Vergrendel Whatly ook wanneer de bureaubladsessie vergrendelt. Vereist een ingesteld wachtwoord. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Vergrendelen wanneer het scherm vergrendelt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Huidig wachtwoord</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Wachtwoord wijzigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Automatisch vergrendelen inschakelen na</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Herstellen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Wachtwoord tonen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Standaard downloadmap</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Downloadmap wijzigen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Opslag </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Eigenschap</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Wissen (herstart vereist)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistente gegevens omvatten permanente cookies, HTML5-lokale opslag en bezochte links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Persistente gegevens</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>De HTTP-/mediacache. Het wissen is veilig — deze wordt opnieuw gedownload wanneer dat nodig is.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Cache wissen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Actie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Back-up</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Sla dit account (instellingen, sessie en add-ons) op in een .tar.gz-archief. Het archief bevat je aangemelde sessie — houd het privé.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Profiel exporteren…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Herstel een account uit een .tar.gz-archief. Dit overschrijft de huidige gegevens en vereist een herstart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Profiel importeren…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Prestaties &amp; privacy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Verfijn de rendering-engine. De standaardwaarden zijn veilig op de meeste systemen; als het venster leeg is of de app vastloopt bij het starten, of als het hapert, probeer deze dan te wijzigen. Wijzigingen worden toegepast na een herstart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Volledig renderen op de CPU (--disable-gpu). Lost lege vensters en opstartcrashes op bij sommige GPU-/stuurprogrammaconfiguraties. Standaard op Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU-versnelling uitschakelen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Stel de pagina samen op de CPU (--disable-gpu-compositing). Voorkomt flikkeren door verouderde frames bij sommige stuurprogramma&apos;s.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU-compositing uitschakelen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU-VSync uitschakelen (--disable-gpu-vsync). Kan invoervertraging verminderen ten koste van tearing.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU-VSync uitschakelen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Voer het GPU-proces uit binnen het hoofdproces (--in-process-gpu). Een tijdelijke oplossing voor sommige sandboxconfiguraties.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU in het proces uitvoeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Forceer versnelling zelfs als het stuurprogramma op de blokkeerlijst staat (--ignore-gpu-blocklist). Probeer dit om de GPU weer in te schakelen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU-blokkeerlijst negeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Alles in één proces uitvoeren (--single-process). Gebruikt minder geheugen maar is minder stabiel.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Enkelprocesmodus (minder geheugen)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Deel één rendererproces per site (--process-per-site). Vermindert geheugengebruik.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Eén proces per site (minder geheugen)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Verberg contactnamen en berichtvoorbeelden in de chatlijst (beweeg de muis eroverheen om er één te tonen). Handig bij schermdelen. Het geopende gesprek blijft ongewijzigd.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Focusmodus (voorbeelden verbergen)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
-        <translation>Foto's en video's standaard in HD-kwaliteit in de media-editor. Afhankelijk van de lay-out van WhatsApp Web; als een WhatsApp-update het onbruikbaar maakt, schakel het dan uit.</translation>
+        <translation>Foto&apos;s en video&apos;s standaard in HD-kwaliteit in de media-editor. Afhankelijk van de lay-out van WhatsApp Web; als een WhatsApp-update het onbruikbaar maakt, schakel het dan uit.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
-        <translation>Foto's en video's standaard in HD verzenden</translation>
+        <translation>Foto&apos;s en video&apos;s standaard in HD verzenden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Voorkom dat WebRTC uw lokale IP-adres onthult via niet-geproxyde verbindingen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC-IP-lek voorkomen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript-geheugenlimiet</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Beperk de JavaScript-heap (V8 --max-old-space-size). 0 = automatisch. Verlaag dit als de app te veel RAM gebruikt.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP-cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Waar de HTTP-cache wordt bewaard. Geheugen wordt gewist bij afsluiten; Geen schakelt caching uit.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Maximale grootte</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Maximale cachegrootte op schijf. 0 = automatisch.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Netwerk &amp; opstarten</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Whatly automatisch starten wanneer u zich aanmeldt bij uw bureaubladsessie.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Whatly starten wanneer ik me aanmeld</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Vervang de vensterrand van het systeem door de eigen slanke titelbalk van Whatly. Wordt toegepast na een herstart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Gebruik een aangepast vensterkader (herstart vereist)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Eenmaal per dag GitHub controleren op een nieuwere release en je op de hoogte stellen. Whatly downloadt of installeert nooit iets uit zichzelf.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Automatisch op updates controleren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Interfaceschaal</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Schaal het hele venster en de pagina (QT_SCALE_FACTOR). Automatisch volgt het bureaublad. Een QT_SCALE_FACTOR-omgevingsvariabele heeft, indien ingesteld, voorrang hierop. Wordt van kracht na een herstart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Hoe Whatly verbinding maakt met het netwerk. Systeem volgt het besturingssysteem; Geen maakt rechtstreeks verbinding.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Optioneel</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Aangepaste JavaScript-add-ons</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Laad .js-bestanden om uit te voeren op WhatsApp Web. Elke add-on draait in zijn eigen sandbox, zodat een defecte add-on de andere of de pagina niet kan verstoren. Vink een add-on uit om deze uit te schakelen zonder te verwijderen. Wijzigingen worden toegepast na een herstart.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Add-on toevoegen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Opgeslagen antwoorden</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Korte teksten die je vaak verstuurt. Voeg er een in via het opdrachtenpalet (Ctrl+K) — typ &quot;Invoegen&quot; en kies hem; de tekst wordt in het berichtvak getypt.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Antwoord toevoegen…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Klik op een veld en druk op de toetsencombinatie. Wis een veld om de sneltoets te verwijderen. Wijzigingen worden na een herstart toegepast.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Hiermee worden de persistente gegevens (inclusief persistente cookies en cache) verwijderd en wordt de toepassing afgesloten.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Cookies verwijderen en de toepassing afsluiten?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Fout</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Kan geen lege User-Agent-tekenreeks instellen.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Het automatisch wisselen van thema is uitgeschakeld omdat het thema handmatig is gewijzigd.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>De app-vergrendeling is niet ingesteld.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Wilt u de app-vergrendeling nu instellen?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Functiemachtigingen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Kies een chatachtergrond</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Afbeeldingen (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Kon die afbeelding niet gebruiken: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Kies een CSS-bestand</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Stylesheets (*.css);;Alle bestanden (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Kon dat bestand niet lezen: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Schijf</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Systeem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Geen (rechtstreeks)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Bureaubladportaal (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Systeemservice (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Antwoord toevoegen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>In te voegen tekst</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Kies een JavaScript-bestand</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Alle bestanden (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Kan add-on niet toevoegen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Add-on verwijderen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Add-on &quot;%1&quot; verwijderen? Hiermee wordt het bestand verwijderd.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Spellingcontrole (geen woordenboeken geïnstalleerd)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Weergave</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Meldingen</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Chatten</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privacy en vergrendeling</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Venster en zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Geavanceerd</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Sneltoets al in gebruik</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Die sneltoets wordt al door een andere actie gebruikt.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Cache wissen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Cache nu wissen? Deze wordt opnieuw gedownload wanneer dat nodig is.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Profiel exporteren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Het archief bevat je aangemelde WhatsApp-sessie. Houd het privé. Doorgaan?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archieven (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profiel geëxporteerd.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Profiel importeren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Dit overschrijft de gegevens van het huidige account met het archief, waarna Whatly opnieuw moet worden gestart. Doorgaan?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profiel geïmporteerd. Start Whatly opnieuw.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 talen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp-standaard</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Systeemstandaard</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>De interfacetaal verandert wanneer u %1 opnieuw start.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>App-vergrendeling instellen</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Stel eerst het wachtwoord voor de app-vergrendeling in.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Downloadmap selecteren</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Hierdoor wordt uw huidige sessie afgemeld.
 Mogelijk is ook een volledige herstart van de toepassing vereist!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Wilt u doorgaan?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Mogelijk is ook een volledige herstart van de toepassing vereist!</translation>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Welkom bij Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Een snelle, native WhatsApp Web-client voor de desktop. Laten we een paar dingen instellen — je kunt dit allemaal later wijzigen in Instellingen.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly houdt je chats in een volwaardig desktopvenster, met een systeemvakpictogram, meldingen, thema&apos;s en meerdere accounts.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Een paar voorkeuren</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Verstandige standaardinstellingen; pas aan naar smaak.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Volg het lichte/donkere thema van het systeem</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Whatly starten wanneer ik me aanmeld</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Bezorging van meldingen:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Bureaubladportaal (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Systeemservice (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Helemaal klaar</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Je bent klaar om te beginnen. Scan de QR-code met je telefoon om in te loggen.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Alles hier vind je terug in Instellingen als je van gedachten verandert.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Mogelijk is ook een volledige herstart van de toepassing vereist!</translation>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Kon de nieuwste release niet lezen</translation>
     </message>
@@ -2038,82 +2626,104 @@ Mogelijk is ook een volledige herstart van de toepassing vereist!</translation>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Uw scherm delen</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Kies wat u wilt delen:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Naamloos</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Scherm: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Venster: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>%1 toegang geven tot uw locatiegegevens?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>%1 toegang geven tot uw microfoon?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>%1 toegang geven tot uw camera?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>%1 toegang geven tot uw microfoon en camera?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>%1 toestaan uw muisaanwijzer vast te zetten?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>%1 toestaan video van uw bureaublad op te nemen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>%1 toestaan audio en video van uw bureaublad op te nemen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>%1 toestaan meldingen op uw bureaublad te tonen?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>%1 toestaan uw klembord te lezen? Dit is nodig om afbeeldingen in een gesprek te plakken.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>%1 toestaan de op uw systeem geïnstalleerde lettertypen te zien?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Machtigingsverzoek</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Certificaatfout</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Voer gebruikersnaam en wachtwoord in voor «%1» op %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Verbinden met proxy «%1» via:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>%1 toestaan alle %2-koppelingen te openen?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Mogelijk is ook een volledige herstart van de toepassing vereist!</translation>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Renderproces normaal beëindigd</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Renderproces abnormaal beëindigd</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Renderproces vastgelopen</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Renderproces beëindigd</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Renderproces afgesloten met code: %1

--- a/src/i18n/pl_PL.ts
+++ b/src/i18n/pl_PL.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Wesprzyj przez PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Oceń w sklepie</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Więcej aplikacji</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Kod źródłowy</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kopiuje poniższe informacje diagnostyczne do schowka i otwiera system zgłoszeń, aby wkleić je bezpośrednio do zgłoszenia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Zgłoś błąd</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Informacje diagnostyczne</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Wersja: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Informacje diagnostyczne były zbyt długie dla przeglądarki, więc skopiowano je do schowka. Wklej je do zgłoszenia.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | O programie</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Wschód słońca</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Zachód słońca</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Odśwież </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Wyłącz i zamknij</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Włącz i zamknij</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Spróbuj ponownie.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Spróbuj ponownie.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Okno dialogowe</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Ikona</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (domyślny)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Różowy Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Przygaszony róż</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lawenda</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Fiolet</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Błękit nieba</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Głęboki ocean</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Morski</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Miętowy</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Koralowy</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Brzoskwiniowy</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Złoty</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Karmazynowy</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafit</translation>
     </message>
@@ -209,18 +256,22 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Paleta poleceń</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Wpisz polecenie…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Wyszukiwanie poleceń</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Pasujące polecenia</translation>
     </message>
@@ -228,14 +279,17 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimalizuj</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maksymalizuj</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
@@ -243,34 +297,42 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Pobieranie</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Brak pobrań</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Wyczyść listę pobrań</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Wyczyść wszystko</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Otwórz katalog pobierania w menedżerze plików</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Otwórz katalog pobierania</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Plik o tej samej nazwie już istnieje!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Zapisać plik pod nową nazwą?</translation>
     </message>
@@ -278,54 +340,68 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Otwórz plik za pomocą aplikacji systemowej</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - pobrano %1 z %2 - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>nieznany rozmiar - pobrano %1 - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>ukończono - pobrano %1 - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>anulowano - pobrano %1 - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>przerwano: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Zatrzymaj pobieranie</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Usuń z listy</translation>
     </message>
@@ -333,46 +409,58 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Ustaw kod blokady</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>wprowadź kod</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>wprowadź kod ponownie</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Ustaw kod</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Uwaga: Caps Lock jest włączony</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uwaga: kod musi mieć więcej niż 3 znaki i być taki sam w obu polach.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Wprowadź kod, aby uzyskać dostęp</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>wprowadź swój kod</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nieprawidłowy kod. Spróbuj ponownie.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Czy chcesz pominąć kontrolę bezpieczeństwa i kontynuować?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Oczekiwanie na sieć…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Żadne okno WhatsApp nie jest otwarte</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Przypomnienie</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Przypomnienie: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Dostępna aktualizacja</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 jest dostępny. Kliknij, aby otworzyć stronę pobierania.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Błąd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Odblokuj, aby otworzyć ustawienia.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Nie można zainicjować modułu ustawień.
 WebEngine nie jest zainicjowany.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Wymagane działanie</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>Aby kontynuować, strona musi zostać przeładowana.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nowy czat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Wprowadź prawidłowy numer WhatsApp z numerem kierunkowym kraju (np. +48XXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Oceń aplikację</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Najpierw ustaw hasło w ustawieniach.
 Otworzyć ustawienia teraz?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimalizuj do zasobnika</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Przywróć</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Prze&amp;ładuj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Za&amp;blokuj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>Wy&amp;cisz dźwięk</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Powiększ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Pomniejsz</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Resetuj powiększenie</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ustawienia</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>Zaplanowane &amp;wiadomości…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Przełącz &amp;motyw</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Widok kart</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Widok siatki</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Paleta poleceń</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;O programie</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Zakończ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Załaduj ponownie</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Zminimalizuj do zasobnika</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Zablokuj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Wycisz dźwięk</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nowy czat / otwórz URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Przełącz motyw</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Zakończ</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Zmień nazwę…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Usuń konto</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Przełącz na konto: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Dodaj konto…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Wstaw: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 nieprzeczytane</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Dodaj kolejne konto</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Przywróć</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>wiadomości</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>wiadomość</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Dodaj konto</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nazwa nowego konta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Konto %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Zmień nazwę konta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nazwa konta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Konto 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Odblokuj, aby przeładować aplikację.</translation>
     </message>
@@ -623,10 +779,12 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
@@ -641,22 +800,27 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Wymagane uwierzytelnienie</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Ikona</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informacje</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Nazwa użytkownika:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Hasło:</translation>
     </message>
@@ -664,14 +828,17 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Funkcja</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Stan</translation>
     </message>
@@ -679,22 +846,27 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Wyłączone</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Lista czatów</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Otwarta rozmowa</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Lista czatów i rozmowa</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Wszystko, łącznie ze zdjęciami</translation>
     </message>
@@ -702,10 +874,13 @@ Otworzyć ustawienia teraz?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Pokaż informacje diagnostyczne</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Otworzyć ustawienia teraz?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Ukryj informacje diagnostyczne</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Nie ma nic do migracji z „%1” — już zmigrowano lub nie znaleziono danych.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Skopiowano by:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Skopiowano:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Uruchom ponownie bez --dry-run, aby wykonać kopię.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Rozbudowany klient WhatsApp Web oparty na Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Wyświetla pomoc dotyczącą opcji wiersza poleceń</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Otwiera ustawienia w uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Blokuje uruchomioną instancję </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Otwiera okno „O programie” w uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Otwiera okno zaplanowanych wiadomości w działającej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Przełącza między jasnym a ciemnym motywem w uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Przeładowuje aplikację w uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Otwiera okno nowego czatu w uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uruchom jako osobne konto z własną sesją i ustawieniami, we własnym oknie&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Pokazuje główne okno uruchomionej instancji </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Skopiuj ustawienia i zalogowaną sesję z poprzedniej instalacji (np. starszej wersji „whatsie”) do tej, a następnie zakończ</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Z --migrate-from tylko pokaż, co zostałoby skopiowane</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Wypisz liczbę nieprzeczytanych wiadomości i zakończ</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Blokada aplikacji nie jest skonfigurowana.
 Najpierw ustaw hasło w ustawieniach.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Przeładowywanie...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Tryb instalacji</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Gałąź źródłowa</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Skrót commita</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Data kompilacji</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Wersja Qt w czasie działania</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Wersja Qt w czasie kompilacji</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Architektura</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Wyjątek</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> napotkał problem.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> może wymagać ponownego uruchomienia. Zgłoś błąd deweloperowi.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Nie udało się uruchomić &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Brak danych do zapisania</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Nie można utworzyć %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Nie można skopiować %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Nie można utworzyć katalogu tymczasowego</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Nie udało się przywrócić pliku ustawień</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Nie można zapisać %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Przełącz na jasny motyw</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Przełącz na ciemny motyw</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Pokaż czaty</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Rozmyj czaty</translation>
@@ -898,42 +1123,53 @@ Najpierw ustaw hasło w ustawieniach.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Oceń tę aplikację</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jeśli podoba Ci się ta aplikacja, czy zechcesz poświęcić chwilę na jej ocenę?&lt;/p&gt;&lt;p&gt;Nie zajmie to więcej niż minutę. Dziękujemy za wsparcie!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Oceń w sklepie</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Lub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Zostaw gwiazdkę repozytorium na GitHubie</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Wesprzyj przez PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Wesprzyj przez OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Później</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Już to zrobiłem  </translation>
     </message>
@@ -941,34 +1177,42 @@ Najpierw ustaw hasło w ustawieniach.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Przekroczono czas oczekiwania na wysłanie wiadomości</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Codziennie</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Dni robocze</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Co tydzień</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Jednorazowo</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Wysłano</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Niepowodzenie</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Oczekujące</translation>
     </message>
@@ -976,90 +1220,117 @@ Najpierw ustaw hasło w ustawieniach.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Zaplanowane wiadomości</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Kiedy</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Wiadomość</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Stan</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Numer telefonu w formacie międzynarodowym, np. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Etykieta opcjonalna</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Jednorazowo</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Codziennie</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Dni robocze</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Co tydzień</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Powtarzaj</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Przypomnij mi zamiast wysyłać (powiadom, nie wysyłaj wiadomości)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Wiadomość do wysłania</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>Aplikacja musi być uruchomiona, a WhatsApp zalogowany o zaplanowanej godzinie. Jeśli jest zamknięta, wiadomość zostanie wysłana przy następnym uruchomieniu aplikacji. Wysłanie otwiera czat odbiorcy.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Zaplanuj</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Usuń zaznaczone</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Wyczyść wysłane/nieudane</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Wprowadź numer telefonu i wiadomość.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Godzina już minęła — wysłać tę wiadomość teraz?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Najpierw ustaw hasło w ustawieniach.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Rozmiar czcionki interfejsu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rozmiar w punktach interfejsu aplikacji — menu, ustawień i okien dialogowych. Nie wpływa to na tekst WhatsApp Web; do tego użyj powiększenia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Motyw wyświetlania</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Automatycznie przeładuj po awarii</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jeśli proces strony WhatsApp Web ulegnie awarii, przeładuj go automatycznie zamiast najpierw pytać.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Ustawienia ogólne</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Styl widżetów</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Motyw widżetów</translation>
+        <translation type="vanished">Motyw widżetów</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Na podstawie strefy czasowej i lokalizacji systemu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automatyczny</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Ciemny</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Jasny</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dopasowuje się do preferencji jasny/ciemny pulpitu i zmienia się wraz z nią. Zastępuje ręczny motyw i automatyczne przełączanie wschód/zachód słońca.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Podążaj za jasnym/ciemnym motywem systemu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Powiadomienie systemowe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Powiadomienie niestandardowe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Wypróbuj</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Typ powiadomienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Wyłącz wyskakujące powiadomienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Czas wyświetlania powiadomienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> s</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Dostarczanie powiadomień</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Sposób wysyłania natywnych powiadomień w systemie Linux. Tryb automatyczny używa portalu pulpitu w piaskownicy Flatpak, a w innych przypadkach usługi systemowej.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Wstrzymuje wyskakujące powiadomienia w codziennym okresie ciszy. Odznaki nieprzeczytanych są nadal aktualizowane; wstrzymywane jest tylko okienko.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Nie przeszkadzać</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>do</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Wyróżniaj słowa kluczowe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Słowa oddzielone przecinkami, które zawsze powiadamiają, nawet w trybie Nie przeszkadzać (bez rozróżniania wielkości liter).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>np. pilne, szef, faktura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Użyj systemowego okna wyboru plików</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Wycisz dźwięk strony</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Wyłącz automatyczne odtwarzanie multimediów</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Uruchamiaj zminimalizowany w zasobniku</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Pokaż/ukryj po kliknięciu ikony w zasobniku (jeśli obsługiwane)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zamyka panel emoji, GIF-ów i naklejek po kliknięciu w innym miejscu. W przeciwnym razie WhatsApp Web pozostawia go otwartym do ponownego naciśnięcia przycisku.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Zamykaj panel emoji/naklejek po kliknięciu poza nim</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Język interfejsu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Język interfejsu Whatly. Działa po ponownym uruchomieniu aplikacji. Język samych czatów pochodzi z WhatsApp Web i nie można go tu zmienić.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dodaje przycisk jasny/ciemny do paska bocznego WhatsApp, tuż nad zdjęciem profilowym.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Przycisk motywu na pasku bocznym WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dodaje do paska bocznego WhatsApp przycisk, który jednym kliknięciem rozmywa i odsłania czaty, bez otwierania Ustawień.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Przycisk rozmycia na pasku bocznym WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Używa jednokolorowej ikony w zasobniku, pasującej do reszty panelu, zamiast zielonej ikony WhatsApp. Ikona jest też przygaszana, gdy WhatsApp nie jest połączony.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Monochromatyczna ikona w zasobniku</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animuje przewijanie zamiast przeskakiwać wiersz po wierszu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Płynne przewijanie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>Własny CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wczytaj plik .css, aby zmienić styl WhatsApp Web — arkusze stylów społeczności (catppuccin i podobne) działają tutaj. Nakładane na motyw czatu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Wybierz plik…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Wyczyść</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Całkowicie usuwa ikonę zasobnika systemowego. Bez zasobnika do przywrócenia zamknięcie okna kończy aplikację zamiast ją ukrywać.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Ukryj ikonę zasobnika</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Rodzina czcionek</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wyświetla tekst WhatsApp Web czcionką zainstalowaną w systemie. Emoji, ikony i formatowanie wiadomości o stałej szerokości pozostają bez zmian.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukrywa sekcję „Wyciszone aktualizacje” w panelu Statusy/Aktualności, dzięki czemu statusy wyciszonych kontaktów w ogóle się nie pojawiają.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Ukryj wyciszone aktualizacje statusu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Podkreśla błędnie napisane słowa podczas pisania i proponuje poprawki w menu prawego przycisku.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Sprawdzaj pisownię podczas pisania</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Język, względem którego następuje sprawdzanie.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Rozmycie prywatności</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rozmywa twoje czaty, dopóki nie najedziesz na nie kursorem, aby ktoś zerkający na ekran nie mógł ich przeczytać. Najechanie na wiersz odsłania tylko ten wiersz.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Motyw czatu</translation>
+        <translation type="vanished">Motyw czatu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Odcień koloru czatu</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zmienia kolory samego WhatsApp Web. Zdjęcia, awatary i naklejki zachowują własne kolory. Działa na wierzchu motywu jasnego lub ciemnego, zależnie od aktywnego.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Tapeta czatu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Użyj własnego obrazu jako tła panelu czatu, tak jak robi to WhatsApp na Androidzie. Obraz jest przechowywany w Whatly, nigdzie nie jest wysyłany i widzisz go tylko Ty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Wybierz obraz…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nowe logowania pojawiają się na liście połączonych urządzeń w telefonie jako „Whatly dla Linuksa” (lub odpowiednia platforma) zamiast „Google Chrome (Linux)”. Nazwa jest zapisywana w telefonie podczas łączenia urządzenia, więc zmiana dotyczy tylko przyszłych połączeń — wyloguj się i połącz ponownie, aby zmienić nazwę istniejącej sesji.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Identyfikuj się jako Whatly na połączonych urządzeniach</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User Agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zaawansowane — nie zmieniaj tego, jeśli nie wiesz dokładnie, co robisz. Niestandardowy user agent może uniemożliwić załadowanie WhatsApp, a nietypowe wartości grożą oznaczeniem lub wpisaniem Twojego konta WhatsApp na czarną listę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Zastosuj</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Przywróć domyślne</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Współczynnik powiększenia w oknie normalnym</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Pomniejsz</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Powiększ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>resetuj</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Współczynnik powiększenia po maksymalizacji/pełnym ekranie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimalizuj do zasobnika</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Zakończ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Skróty globalne</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Działanie przycisku zamykania</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Pokaż skróty</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Uprawnienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Pokaż uprawnienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Włącz ekran blokady.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Włącz blokadę aplikacji przy starcie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gdy okno chowa się do zasobnika systemowego, zablokuj je za kodem. Wymaga ustawionego hasła.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Zablokuj po ukryciu do zasobnika</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Blokuj też Whatly, gdy sesja pulpitu zostanie zablokowana. Wymaga ustawionego hasła. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Blokuj, gdy ekran się zablokuje</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Bieżące hasło</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Zmień hasło</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Zmień</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Włącz automatyczną blokadę po</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Resetuj</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Pokaż hasło</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Domyślny katalog pobierania</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Zmień katalog pobierania</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Pamięć </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Właściwość</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Wyczyść (wymaga ponownego uruchomienia)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dane trwałe obejmują trwałe ciasteczka, pamięć lokalną HTML5 i odwiedzone odnośniki.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Dane trwałe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>Pamięć podręczna HTTP/multimediów. Jej wyczyszczenie jest bezpieczne — zostanie pobrana ponownie w razie potrzeby.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Pamięć podręczna</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Wyczyść pamięć podręczną</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Działanie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Kopia zapasowa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Zapisz to konto (ustawienia, sesję i dodatki) do archiwum .tar.gz. Archiwum zawiera Twoją zalogowaną sesję — zachowaj je dla siebie.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Eksportuj profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Przywróć konto z archiwum .tar.gz. Spowoduje to nadpisanie bieżących danych i wymaga ponownego uruchomienia.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Importuj profil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Wydajność i prywatność</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Dostrój silnik renderowania. Domyślne ustawienia są bezpieczne w większości systemów; jeśli okno jest puste, aplikacja ulega awarii przy uruchamianiu lub przycina się, spróbuj je zmienić. Zmiany zostaną zastosowane po ponownym uruchomieniu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Renderuj w całości na CPU (--disable-gpu). Naprawia puste okna i awarie przy uruchamianiu na niektórych konfiguracjach GPU/sterowników. Domyślnie w systemie Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Wyłącz akcelerację GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Komponuj stronę na CPU (--disable-gpu-compositing). Zapobiega migotaniu nieaktualnych klatek na niektórych sterownikach.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Wyłącz komponowanie GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Wyłącz VSync GPU (--disable-gpu-vsync). Może zmniejszyć opóźnienie wejścia kosztem rozrywania obrazu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Wyłącz VSync GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Uruchom proces GPU wewnątrz procesu głównego (--in-process-gpu). Obejście dla niektórych konfiguracji z piaskownicą.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Uruchom GPU w procesie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Wymuś akcelerację nawet gdy sterownik jest na czarnej liście (--ignore-gpu-blocklist). Spróbuj tego, aby ponownie włączyć GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Ignoruj czarną listę GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Uruchom wszystko w jednym procesie (--single-process). Zużywa mniej pamięci, ale jest mniej stabilne.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Tryb jednoprocesowy (mniejsze zużycie pamięci)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Współdziel jeden proces renderujący na witrynę (--process-per-site). Zmniejsza zużycie pamięci.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Jeden proces na witrynę (mniejsze zużycie pamięci)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Ukrywa nazwy kontaktów i podglądy wiadomości na liście czatów (najedź, aby odsłonić jeden). Przydatne przy udostępnianiu ekranu. Otwarta rozmowa pozostaje bez zmian.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Tryb skupienia (ukryj podglądy czatów)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Domyślnie ustaw jakość HD dla zdjęć i filmów w edytorze multimediów. Zależy od układu WhatsApp Web; jeśli aktualizacja WhatsApp to zepsuje, wyłącz tę opcję.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Domyślnie wysyłaj zdjęcia i filmy w HD</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Uniemożliw WebRTC ujawnianie Twojego lokalnego adresu IP przez połączenia bez serwera proxy.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Zapobiegaj wyciekowi IP przez WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Limit pamięci JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Ogranicz stertę JavaScript (V8 --max-old-space-size). 0 = automatycznie. Zmniejsz, jeśli aplikacja zużywa zbyt dużo RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Pamięć podręczna HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Gdzie przechowywać pamięć podręczną HTTP. Pamięć jest czyszczona przy wyjściu; Brak wyłącza buforowanie.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Maksymalny rozmiar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Maksymalny rozmiar pamięci podręcznej na dysku. 0 = automatycznie.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Sieć i uruchamianie</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Automatycznie uruchamiaj Whatly po zalogowaniu do sesji pulpitu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Uruchamiaj Whatly po zalogowaniu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Zastąp systemową ramkę okna własnym smukłym paskiem tytułu Whatly. Zmiana obowiązuje po ponownym uruchomieniu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Użyj niestandardowej ramki okna (wymaga ponownego uruchomienia)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Sprawdzanie GitHub raz dziennie w poszukiwaniu nowszej wersji i powiadamianie Cię o niej. Whatly nigdy niczego samodzielnie nie pobiera ani nie instaluje.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Automatycznie sprawdzaj aktualizacje</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Skala interfejsu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Skaluje całe okno oraz stronę (QT_SCALE_FACTOR). Tryb automatyczny korzysta z ustawień pulpitu. Zmienna środowiskowa QT_SCALE_FACTOR, jeśli jest ustawiona, ma pierwszeństwo. Zmiana obowiązuje po ponownym uruchomieniu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Serwer proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Sposób łączenia Whatly z siecią. System korzysta z ustawień systemu operacyjnego; Brak łączy się bezpośrednio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nazwa użytkownika</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Opcjonalne</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Hasło</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Własne dodatki JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Wczytaj pliki .js uruchamiane w WhatsApp Web. Każdy dodatek działa we własnej piaskownicy, więc uszkodzony nie wyłączy pozostałych ani strony. Odznacz dodatek, aby go wyłączyć bez usuwania. Zmiany zaczną obowiązywać po ponownym uruchomieniu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Dodaj dodatek…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Usuń</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Zapisane odpowiedzi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Krótkie teksty, które często wysyłasz. Wstaw jeden z palety poleceń (Ctrl+K) — wpisz &quot;Wstaw&quot; i wybierz go; tekst zostanie wpisany w polu wiadomości.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Dodaj odpowiedź…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Skróty klawiszowe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Kliknij pole i naciśnij kombinację klawiszy. Wyczyść pole, aby usunąć skrót. Zmiany zostaną zastosowane po ponownym uruchomieniu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Spowoduje to usunięcie danych trwałych (w tym trwałych plików cookie i pamięci podręcznej) i zamknięcie aplikacji.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Usunąć pliki cookie i zamknąć aplikację?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Błąd</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Nie można ustawić pustego ciągu User-Agent.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Automatyczne przełączanie motywu zostało wyłączone z powodu ręcznej zmiany motywu.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Blokada aplikacji nie jest skonfigurowana.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Czy chcesz teraz skonfigurować blokadę aplikacji?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Uprawnienia funkcji</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Wybierz tapetę czatu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Obrazy (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Nie można użyć tego obrazu: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Wybierz plik CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Arkusze stylów (*.css);;Wszystkie pliki (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Nie można odczytać tego pliku: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Dysk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Brak (bezpośrednio)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal pulpitu (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Usługa systemowa (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Dodaj odpowiedź</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Tekst do wstawienia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Wybierz plik JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Wszystkie pliki (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Nie można dodać dodatku</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Usuń dodatek</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Usunąć dodatek &quot;%1&quot;? Spowoduje to usunięcie jego pliku.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Sprawdzanie pisowni (brak zainstalowanych słowników)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Podstawowe</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Wygląd</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Powiadomienia</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Czat</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Prywatność i blokada</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Okno i powiększenie</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Zaawansowane</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Skrót jest już używany</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Ten skrót jest już używany przez inną akcję.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Wyczyść pamięć podręczną</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Wyczyścić pamięć podręczną teraz? Zostanie pobrana ponownie w razie potrzeby.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Eksportuj profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Archiwum będzie zawierać Twoją zalogowaną sesję WhatsApp. Zachowaj je dla siebie. Kontynuować?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Archiwa (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Wyeksportowano profil.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Importuj profil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Spowoduje to nadpisanie danych bieżącego konta zawartością archiwum, a następnie trzeba będzie ponownie uruchomić Whatly. Kontynuować?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Zaimportowano profil. Uruchom ponownie Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 języki</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Domyślna WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Domyślny systemowy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>Język interfejsu zmieni się po ponownym uruchomieniu %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Konfiguracja blokady aplikacji</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Najpierw ustaw hasło blokady aplikacji.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Wybierz katalog pobierania</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Spowoduje to wylogowanie bieżącej sesji.
 Może być również konieczne pełne ponowne uruchomienie aplikacji!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Czy chcesz kontynuować?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Może być również konieczne pełne ponowne uruchomienie aplikacji!</translati
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Witamy w Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Szybki, natywny klient WhatsApp Web na komputer. Skonfigurujmy kilka rzeczy — wszystko to możesz później zmienić w Ustawieniach.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly trzyma Twoje czaty w prawdziwym oknie na pulpicie — z ikoną w zasobniku, powiadomieniami, motywami i obsługą wielu kont.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Kilka preferencji</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Rozsądne ustawienia domyślne; dostosuj do gustu.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Dopasuj do jasnego/ciemnego motywu systemu</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Uruchamiaj Whatly po zalogowaniu</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Dostarczanie powiadomień:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automatyczny</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal pulpitu (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Usługa systemowa (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Gotowe</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Wszystko gotowe. Zeskanuj kod QR telefonem, aby się zalogować.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Wszystko to znajdziesz w Ustawieniach, jeśli zmienisz zdanie.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Może być również konieczne pełne ponowne uruchomienie aplikacji!</translati
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Nie można odczytać najnowszej wersji</translation>
     </message>
@@ -2038,82 +2626,104 @@ Może być również konieczne pełne ponowne uruchomienie aplikacji!</translati
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Udostępnij ekran</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Wybierz, co udostępnić:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Bez tytułu</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Ekran: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Okno: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Zezwolić %1 na dostęp do informacji o Twojej lokalizacji?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Zezwolić %1 na dostęp do mikrofonu?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Zezwolić %1 na dostęp do kamery?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Zezwolić %1 na dostęp do mikrofonu i kamery?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Zezwolić %1 na przechwycenie kursora myszy?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Zezwolić %1 na nagrywanie obrazu pulpitu?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Zezwolić %1 na nagrywanie dźwięku i obrazu pulpitu?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Zezwolić %1 na wyświetlanie powiadomień na pulpicie?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Zezwolić %1 na odczyt schowka? Jest to potrzebne do wklejania obrazów w czacie.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Zezwolić %1 na dostęp do czcionek zainstalowanych w systemie?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Prośba o uprawnienie</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Błąd certyfikatu</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Wprowadź nazwę użytkownika i hasło dla „%1” w %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Połącz z serwerem proxy „%1” za pomocą:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Zezwolić %1 na otwieranie wszystkich odnośników %2?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Może być również konieczne pełne ponowne uruchomienie aplikacji!</translati
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Proces renderowania zakończył się normalnie</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Proces renderowania zakończył się nieprawidłowo</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Proces renderowania uległ awarii</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Proces renderowania został zakończony</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Proces renderowania zakończył się z kodem: %1

--- a/src/i18n/pt_BR.ts
+++ b/src/i18n/pt_BR.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Doar via PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Avaliar na loja</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Mais aplicativos</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Código-fonte</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copia as informações de depuração abaixo para a área de transferência e abre o rastreador de problemas, para colá-las diretamente no relatório.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Relatar um erro</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Informações de depuração</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Versão: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>As informações de depuração eram longas demais para o navegador, então foram copiadas para a área de transferência. Cole-as no relatório.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Sobre</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Nascer do sol</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Pôr do sol</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Atualizar </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Desativar e fechar</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Ativar e fechar</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Tente novamente.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Tente novamente.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Diálogo</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Ícone</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (padrão)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Rosa Barbie</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Rosa velho</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavanda</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Violeta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Azul-céu</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Oceano profundo</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Verde-azulado</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Menta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Coral</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Pêssego</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Ouro</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Carmesim</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafite</translation>
     </message>
@@ -209,18 +256,22 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Paleta de comandos</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Digite um comando…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Busca de comandos</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Comandos correspondentes</translation>
     </message>
@@ -228,14 +279,17 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Minimizar</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Maximizar</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
@@ -243,34 +297,42 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Nenhum download</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Limpar a lista de downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Limpar tudo</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Abrir a pasta de downloads no gerenciador de arquivos</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Abrir a pasta de downloads</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Já existe um arquivo com o mesmo nome!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Salvar o arquivo com um novo nome?</translation>
     </message>
@@ -278,54 +340,68 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Abrir o arquivo com o aplicativo do sistema</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %1 de %2 baixado - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>tamanho desconhecido - %1 baixado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>concluído - %1 baixado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>cancelado - %1 baixado - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>interrompido: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Parar o download</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Remover da lista</translation>
     </message>
@@ -333,46 +409,58 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Definir código de bloqueio</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>digite o código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>digite o código novamente</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Definir código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Aviso: Caps Lock está ativado</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nota: o código deve ter mais de 3 caracteres e coincidir nos dois campos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Digite seu código para acessar</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>digite seu código</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Código incorreto. Tente novamente.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Deseja ignorar a verificação de segurança e continuar?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Aguardando a rede…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Nenhuma janela do WhatsApp está aberta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Lembrete</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Lembrete: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Atualização disponível</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>O Whatly %1 está disponível. Clique para abrir a página de download.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Erro</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Desbloqueie para acessar as configurações.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Não é possível inicializar o módulo de configurações.
 O WebEngine não está inicializado.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Ação necessária</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>A página precisa ser recarregada para continuar.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Nova conversa</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Digite um número de WhatsApp válido com o código do país (ex.: +55XXXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Avaliar o aplicativo</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Defina primeiro a senha nas configurações.
 Abrir as configurações agora?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Tela cheia</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Mi&amp;nimizar para a bandeja</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Restaurar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Re&amp;carregar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>Blo&amp;quear</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Silenciar áudio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Ampliar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Reduzir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Redefinir zoom</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configurações</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>&amp;Mensagens agendadas…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Alternar &amp;tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Visualização em abas</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Visualização em grade</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Paleta de comandos</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Sobre</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Sair</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Minimizar para a bandeja</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Bloquear</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Silenciar áudio</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Nova conversa / abrir URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Alternar tema</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Renomear…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Remover conta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Alternar para a conta: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Adicionar conta…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Inserir: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 não lidas</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Adicionar outra conta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>mensagens</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>mensagem</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Adicionar conta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Nome da nova conta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Conta %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Renomear conta</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Nome da conta:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Conta 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Desbloqueie para recarregar o aplicativo.</translation>
     </message>
@@ -623,10 +779,12 @@ Abrir as configurações agora?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Abrir as configurações agora?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
@@ -641,22 +800,27 @@ Abrir as configurações agora?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Autenticação necessária</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Ícone</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Informações</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Usuário:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Senha:</translation>
     </message>
@@ -664,14 +828,17 @@ Abrir as configurações agora?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Recurso</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
@@ -679,22 +846,27 @@ Abrir as configurações agora?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Desativado</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Lista de conversas</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Conversa aberta</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Lista de conversas e conversa</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Tudo, incluindo fotos</translation>
     </message>
@@ -702,10 +874,13 @@ Abrir as configurações agora?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Mostrar informações de depuração</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Abrir as configurações agora?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Ocultar informações de depuração</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Nada a migrar de &quot;%1&quot; — já migrado, ou nenhum dado encontrado.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Copiaria:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Copiado:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Execute novamente sem --dry-run para realizar a cópia.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Cliente completo do WhatsApp Web baseado no Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Mostra a ajuda das opções de linha de comando</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Abre as configurações em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Bloqueia uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Abre a janela «Sobre» em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Abre a caixa de diálogo de mensagens agendadas em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Alterna entre tema claro e escuro em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Recarrega o aplicativo em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Abre a janela de nova conversa em uma instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Executar como uma conta separada com sua própria sessão e configurações, em sua própria janela&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Mostra a janela principal da instância em execução do </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Copia as configurações e a sessão conectada de uma instalação anterior (ex.: a versão &quot;whatsie&quot; antiga) para esta e sai</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>Com --migrate-from, apenas informa o que seria copiado</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Exibe a contagem atual de mensagens não lidas e sai</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>O bloqueio do aplicativo não está configurado.
 Defina primeiro a senha nas configurações.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Recarregando...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Modo de instalação</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Ramo de origem</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Hash do commit</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Data da compilação</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Versão do Qt em execução</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Versão do Qt de compilação</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Arquitetura</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Exceção</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> encontrou um problema.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> pode precisar ser reiniciado. Informe o erro ao desenvolvedor.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Não foi possível executar &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Nada para fazer backup</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Não é possível criar %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Não é possível copiar %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Não é possível criar um diretório temporário</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Não foi possível restaurar o arquivo de configurações</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Não é possível gravar %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Mudar para o tema claro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Mudar para o tema escuro</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Mostrar as conversas</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Desfocar as conversas</translation>
@@ -898,42 +1123,53 @@ Defina primeiro a senha nas configurações.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Avaliar este aplicativo</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se você gosta deste aplicativo, poderia dedicar um momento para avaliá-lo?&lt;/p&gt;&lt;p&gt;Não levará mais de um minuto. Obrigado pelo seu apoio!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Avaliar na loja</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Ou</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Dar uma estrela ao repositório no GitHub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Doar via PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Doar via OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Mais tarde</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Já fiz isso  </translation>
     </message>
@@ -941,34 +1177,42 @@ Defina primeiro a senha nas configurações.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Tempo esgotado aguardando o envio da mensagem</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Diariamente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Dias úteis</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Semanalmente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Uma vez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Enviado</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Falhou</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Pendente</translation>
     </message>
@@ -976,90 +1220,117 @@ Defina primeiro a senha nas configurações.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Mensagens agendadas</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Quando</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Número de telefone no formato internacional, ex. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Rótulo opcional</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Uma vez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Diariamente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Dias úteis</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Semanalmente</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Repetir</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Lembrar-me em vez de enviar (notificar, não enviar mensagem)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Mensagem a enviar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>O aplicativo deve estar em execução e o WhatsApp conectado no horário agendado. Se estiver fechado, a mensagem é enviada na próxima vez que você abrir o aplicativo. O envio abre a conversa do destinatário.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Agendar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Remover selecionado</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Limpar enviados/com falha</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Insira um número de telefone e uma mensagem.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>O horário já passou — enviar esta mensagem agora?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Defina primeiro a senha nas configurações.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Tamanho da fonte da interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tamanho em pontos da interface do próprio aplicativo — menus, configurações e diálogos. Isso não afeta o texto do WhatsApp Web; para isso, use o zoom.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Tema de exibição</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Recarregar automaticamente após uma falha</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se o processo da página do WhatsApp Web falhar, recarregá-lo automaticamente em vez de perguntar primeiro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Configurações gerais</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Estilo dos widgets</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Tema dos widgets</translation>
+        <translation type="vanished">Tema dos widgets</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Com base no fuso horário e na localização do seu sistema.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Acompanha a preferência clara/escura do ambiente de trabalho e muda com ela. Substitui o tema manual e a troca automática por nascer/pôr do sol.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Seguir o tema claro/escuro do sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Notificação nativa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Notificação personalizada</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Testar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Tipo de notificação</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Desativar o aviso de notificações</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Tempo do aviso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> s</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Entrega de notificações</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Como as notificações nativas são enviadas no Linux. O modo automático usa o portal do desktop dentro de um sandbox Flatpak e o serviço do sistema nos demais casos.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Suprime os pop-ups de notificação durante um período de silêncio diário. Os selos de não lidas continuam sendo atualizados; apenas o pop-up é retido.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Não perturbe</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>até</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Destacar palavras-chave</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Palavras separadas por vírgulas que sempre notificam, mesmo durante o Não perturbe (não diferencia maiúsculas de minúsculas).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>ex.: urgente, chefe, fatura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Usar a janela de arquivos nativa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Silenciar o áudio da página</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Desativar a reprodução automática de mídia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Iniciar minimizado na bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Mostrar/ocultar ao clicar no ícone da bandeja (se houver suporte)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fecha o painel de emojis, GIFs e figurinhas ao clicar em outro lugar. Caso contrário, o WhatsApp Web o mantém aberto até que o botão seja pressionado de novo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Fechar o painel de emojis/figurinhas ao clicar fora</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Idioma da interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma da interface do Whatly. Tem efeito após reiniciar o aplicativo. O idioma das conversas vem do WhatsApp Web e não pode ser alterado aqui.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adiciona um botão claro/escuro à barra lateral do WhatsApp, logo acima da sua foto de perfil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Botão de tema na barra lateral do WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adiciona à barra lateral do WhatsApp um botão que desfoca e revela suas conversas com um clique, sem abrir as Configurações.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Botão de desfoque na barra lateral do WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usa um ícone de bandeja de uma só cor, combinando com o resto do painel, em vez do verde do WhatsApp. O ícone também escurece quando o WhatsApp não está conectado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Ícone monocromático na bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Anima a rolagem em vez de pular linha por linha.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Rolagem suave</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>CSS personalizado</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carregue um arquivo .css para reestilizar o WhatsApp Web — as folhas de estilo da comunidade (catppuccin e afins) funcionam aqui. Aplicado sobre o tema da conversa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Escolher arquivo…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Limpar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove completamente o ícone da bandeja do sistema. Sem bandeja para restaurar, fechar a janela encerra o app em vez de ocultá-lo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Ocultar ícone da bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Família da fonte</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exibe o texto do WhatsApp Web com uma fonte instalada no seu sistema. Emojis, ícones e a formatação monoespaçada das mensagens não são alterados.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Oculta a seção &quot;Atualizações silenciadas&quot; no painel de Status/Novidades, para que os status de contatos silenciados não apareçam.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Ocultar atualizações de status silenciadas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sublinha palavras com erros enquanto você digita e oferece correções no menu do botão direito.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Verificar ortografia enquanto digito</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O idioma usado na verificação.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Desfoque de privacidade</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Desfoca suas conversas até você passar o mouse, para que quem olhar a tela não consiga lê-las. Passar sobre uma linha revela apenas aquela linha.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Tema da conversa</translation>
+        <translation type="vanished">Tema da conversa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Tonalidade de cor da conversa</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolore o próprio WhatsApp Web. Fotos, avatares e figurinhas mantêm suas cores. Funciona sobre o tema claro ou escuro, o que estiver ativo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Papel de parede da conversa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use uma imagem sua como fundo do painel de conversa, como o WhatsApp faz no Android. A imagem é armazenada dentro do Whatly, não é enviada para lugar nenhum e só você a vê.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Escolher imagem…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Novos logins aparecem como «Whatly para Linux» (ou a plataforma correspondente) na lista de dispositivos conectados do seu celular, em vez de «Google Chrome (Linux)». O nome é salvo no celular ao conectar um dispositivo, portanto alterar isto só afeta conexões futuras: saia e conecte novamente para renomear uma sessão existente.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Identificar-se como Whatly nos dispositivos conectados</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>Agente do usuário</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avançado — não mexa nisto a menos que saiba exatamente o que está fazendo. Um user agent fora do padrão pode impedir o WhatsApp de carregar, e valores incomuns podem fazer sua conta do WhatsApp ser sinalizada ou colocada em lista negra.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Aplicar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Restaurar o padrão</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Fator de zoom na janela normal</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Diminuir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Aumentar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>redefinir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Fator de zoom em maximizado/tela cheia</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Minimizar para a bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Atalhos globais</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Ação do botão de fechar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Mostrar atalhos</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Permissões</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Mostrar permissões</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar a tela de bloqueio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Ativar o bloqueio ao iniciar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando a janela se oculta na bandeja do sistema, bloqueie-a atrás do código. Requer uma senha definida.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Bloquear ao ocultar na bandeja</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Bloquear também o Whatly quando a sessão da área de trabalho for bloqueada. Requer uma senha definida. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Bloquear quando a tela bloquear</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Senha atual</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Alterar senha</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Alterar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Ativar o bloqueio automático após</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Redefinir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Ver senha</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Pasta de downloads padrão</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Alterar a pasta de downloads</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Armazenamento </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Propriedade</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Limpar (requer reinício)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Os dados persistentes incluem cookies persistentes, armazenamento local HTML5 e links visitados.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Dados persistentes</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>O cache HTTP/de mídia. Limpá-lo é seguro — ele é baixado novamente quando necessário.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Limpar cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Ação</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Salva esta conta (configurações, sessão e complementos) em um arquivo .tar.gz. O arquivo contém sua sessão conectada — mantenha-o privado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Exportar perfil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Restaura uma conta a partir de um arquivo .tar.gz. Isso substitui os dados atuais e exige reinicialização.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Importar perfil…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Desempenho e privacidade</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Ajuste fino do mecanismo de renderização. Os padrões são seguros na maioria dos sistemas; se a janela ficar em branco, o aplicativo travar ao iniciar ou apresentar engasgos, tente alterar essas opções. As alterações são aplicadas após reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Renderiza inteiramente na CPU (--disable-gpu). Corrige janelas em branco e travamentos na inicialização em algumas configurações de GPU/driver. Padrão no Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Desativar aceleração da GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Compõe a página na CPU (--disable-gpu-compositing). Evita a tremulação de quadros antigos em alguns drivers.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Desativar composição pela GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Desativa o VSync da GPU (--disable-gpu-vsync). Pode reduzir o atraso de entrada ao custo de rasgos na imagem.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Desativar VSync da GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Executa o processo da GPU dentro do processo principal (--in-process-gpu). Uma solução alternativa para algumas configurações em sandbox.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Executar a GPU no mesmo processo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Força a aceleração mesmo quando o driver está na lista de bloqueio (--ignore-gpu-blocklist). Tente isto para reativar a GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Ignorar lista de bloqueio da GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Executa tudo em um único processo (--single-process). Usa menos memória, mas é menos estável.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Modo de processo único (menos memória)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Compartilha um processo de renderização por site (--process-per-site). Reduz o uso de memória.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Um processo por site (menos memória)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Oculta nomes de contatos e prévias de mensagens na lista de conversas (passe o mouse para revelar uma). Útil ao compartilhar a tela. A conversa aberta não é alterada.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Modo foco (ocultar prévias da lista)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Definir fotos e vídeos com qualidade HD por padrão no editor de mídia. Depende do layout do WhatsApp Web; se uma atualização do WhatsApp quebrar isso, desative.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Enviar fotos e vídeos em HD por padrão</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Impede que o WebRTC revele seu endereço IP local em conexões sem proxy.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Impedir vazamento de IP pelo WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Limite de memória do JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Limita o heap do JavaScript (V8 --max-old-space-size). 0 = automático. Reduza se o aplicativo usar muita RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Cache HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Onde manter o cache HTTP. &quot;Memória&quot; é limpa ao sair; &quot;Nenhum&quot; desativa o cache.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Tamanho máximo</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Tamanho máximo do cache em disco. 0 = automático.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Rede &amp; Inicialização</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Iniciar o Whatly automaticamente ao entrar na sua sessão da área de trabalho.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Iniciar o Whatly ao entrar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Substituir a borda de janela do sistema pela barra de título fina do Whatly. Aplica-se após reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Usar uma moldura de janela personalizada (requer reinício)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Verifica o GitHub uma vez por dia em busca de uma versão mais recente e avisa você. O Whatly nunca baixa nem instala nada por conta própria.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Verificar atualizações automaticamente</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Escala da interface</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Dimensiona toda a janela e a página (QT_SCALE_FACTOR). Automático segue a área de trabalho. A variável de ambiente QT_SCALE_FACTOR, se definida, substitui esta opção. Aplica-se após reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Proxy</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Como o Whatly se conecta à rede. Sistema segue o sistema operacional; Nenhum conecta diretamente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Nome de usuário</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Opcional</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Senha</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Complementos JavaScript personalizados</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Carregue arquivos .js para executar no WhatsApp Web. Cada complemento é executado em seu próprio sandbox, então um com defeito não pode derrubar os outros nem a página. Desmarque um complemento para desativá-lo sem removê-lo. As alterações são aplicadas após reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Adicionar complemento…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Respostas salvas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Textos curtos que você envia com frequência. Insira um pela paleta de comandos (Ctrl+K) — digite &quot;Inserir&quot; e escolha; o texto é digitado na caixa de mensagem.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Adicionar resposta…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Atalhos de teclado</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Clique em um campo e pressione a combinação de teclas. Limpe um campo para remover o atalho. As alterações são aplicadas após reiniciar.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Isto excluirá os dados persistentes (incluindo cookies persistentes e cache) e fechará o aplicativo.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Excluir os cookies e fechar o aplicativo?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Erro</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Não é possível definir uma string de User-Agent vazia.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>A troca automática de tema foi desativada porque o tema foi alterado manualmente.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>O bloqueio do aplicativo não está configurado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Deseja configurar o bloqueio do aplicativo agora?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Permissões de recursos</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Escolher um papel de parede da conversa</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Imagens (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Não foi possível usar essa imagem: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Escolher um arquivo CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Folhas de estilo (*.css);;Todos os arquivos (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Não foi possível ler esse arquivo: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disco</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Nenhum (direto)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal do desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Serviço do sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Adicionar resposta</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Texto a inserir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Escolher um arquivo JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Todos os arquivos (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Não foi possível adicionar o complemento</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Remover complemento</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Remover o complemento &quot;%1&quot;? Isso exclui o arquivo dele.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Corretor ortográfico (nenhum dicionário instalado)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Básico</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Aparência</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Notificações</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Conversas</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privacidade e bloqueio</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Janela e zoom</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Avançado</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Atalho em uso</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Esse atalho já é usado por outra ação.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Limpar cache</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Limpar o cache agora? Ele será baixado novamente quando necessário.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Exportar perfil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>O arquivo conterá sua sessão do WhatsApp conectada. Mantenha-o privado. Continuar?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Arquivos compactados (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Perfil exportado.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Importar perfil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Isso substitui os dados da conta atual pelo arquivo e, em seguida, o Whatly precisa ser reiniciado. Continuar?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Perfil importado. Reinicie o Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 idiomas</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>Padrão do WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Padrão do sistema</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>O idioma da interface mudará quando você reiniciar %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Configuração do bloqueio</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Configure primeiro a senha do bloqueio.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Selecionar a pasta de downloads</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Isto encerrará sua sessão atual.
 Também pode ser necessário reiniciar completamente o aplicativo!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Deseja continuar?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Também pode ser necessário reiniciar completamente o aplicativo!</translation>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Bem-vindo ao Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Um cliente WhatsApp Web nativo e rápido para o desktop. Vamos configurar algumas coisas — você pode alterar tudo isso depois nas Configurações.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>O Whatly mantém suas conversas em uma janela de desktop de verdade, com ícone na bandeja, notificações, temas e várias contas.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Algumas preferências</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Padrões sensatos; ajuste ao seu gosto.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Acompanhar o tema claro/escuro do sistema</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Iniciar o Whatly ao entrar</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Entrega de notificações:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Portal do desktop (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Serviço do sistema (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Tudo pronto</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Está tudo pronto. Escaneie o código QR com o seu celular para entrar.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Tudo aqui fica nas Configurações, caso você mude de ideia.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Também pode ser necessário reiniciar completamente o aplicativo!</translation>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Não foi possível ler a versão mais recente</translation>
     </message>
@@ -2038,82 +2626,104 @@ Também pode ser necessário reiniciar completamente o aplicativo!</translation>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Compartilhar sua tela</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Escolha o que compartilhar:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Sem título</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Tela: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Janela: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Permitir que %1 acesse suas informações de localização?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Permitir que %1 acesse seu microfone?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Permitir que %1 acesse sua câmera?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Permitir que %1 acesse seu microfone e sua câmera?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Permitir que %1 capture o cursor do mouse?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Permitir que %1 grave o vídeo da sua área de trabalho?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Permitir que %1 grave o áudio e o vídeo da sua área de trabalho?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Permitir que %1 mostre notificações na sua área de trabalho?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Permitir que %1 leia sua área de transferência? Isso é necessário para colar imagens em uma conversa.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Permitir que %1 veja as fontes instaladas no seu sistema?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Solicitação de permissão</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Erro de certificado</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Digite o usuário e a senha de «%1» em %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Conectar ao proxy «%1» usando:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Permitir que %1 abra todos os links %2?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Também pode ser necessário reiniciar completamente o aplicativo!</translation>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>O processo de renderização terminou normalmente</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>O processo de renderização terminou de forma anormal</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>O processo de renderização travou</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>O processo de renderização foi encerrado</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>O processo de renderização terminou com o código: %1

--- a/src/i18n/ru_RU.ts
+++ b/src/i18n/ru_RU.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>Пожертвовать через PayPal</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Оценить в магазине</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Другие приложения</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Исходный код</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Копирует приведённую ниже отладочную информацию в буфер обмена и открывает трекер задач, чтобы вставить её прямо в отчёт.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Сообщить об ошибке</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Отладочная информация</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Версия: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Отладочная информация оказалась слишком длинной для браузера, поэтому она скопирована в буфер обмена. Вставьте её в отчёт.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | О программе</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Восход</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Закат</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Обновить </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Отключить и закрыть</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Включить и закрыть</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Попробуйте ещё раз.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Диалог</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Значок</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (по умолчанию)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Розовый Барби</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Пыльная роза</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Лаванда</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Фиолетовый</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Небесно-голубой</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Глубокий океан</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Бирюзовый</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Мятный</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Коралловый</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Персиковый</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Золотой</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Малиновый</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Графитовый</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Палитра команд</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Введите команду…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Поиск команд</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Подходящие команды</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Свернуть</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Развернуть</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>Загрузки</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>Нет загрузок</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>Очистить список загрузок</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Очистить всё</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>Открыть папку загрузок в файловом менеджере</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>Открыть папку загрузок</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Файл с таким именем уже существует!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Сохранить файл под новым именем?</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Открыть файл системным приложением</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 Б</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 КиБ</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 МиБ</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 ГиБ</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - загружено %1 из %2 - %3/с</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>неизвестный размер - загружено %1 - %2/с</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>завершено - загружено %1 - %2/с</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>отменено - загружено %1 - %2/с</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>прервано: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>Остановить загрузку</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Удалить из списка</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Задать код блокировки</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>введите код</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>введите код ещё раз</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Задать код</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Внимание: включён Caps Lock</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Примечание: код должен содержать более 3 символов и совпадать в обоих полях.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Введите код для доступа</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>введите ваш код</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Неверный код. Попробуйте ещё раз.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Ожидание сети…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Нет открытого окна WhatsApp</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Напоминание</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Напоминание: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Доступно обновление</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Доступна версия Whatly %1. Нажмите, чтобы открыть страницу загрузки.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Ошибка</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Разблокируйте, чтобы открыть настройки.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Не удаётся инициализировать модуль настроек.
 WebEngine не инициализирован.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | Требуется действие</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>Чтобы продолжить, страницу нужно перезагрузить.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Новый чат</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Введите корректный номер WhatsApp с кодом страны (напр. +7XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Оценить приложение</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 Открыть настройки сейчас?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Полный экран</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Свернуть в &amp;трей</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Восстановить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>П&amp;ерезагрузить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>За&amp;блокировать</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>&amp;Отключить звук</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Увеличить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Сбросить масштаб</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>Запланированные сообщения…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>Сменить &amp;тему</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Вид вкладками</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Вид сеткой</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Палитра команд</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;О программе</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>В&amp;ыход</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Перезагрузить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Свернуть в трей</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Заблокировать</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Отключить звук</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Новый чат / открыть URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Переключить тему</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Выход</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Переименовать…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Удалить аккаунт</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Переключиться на аккаунт: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Добавить аккаунт…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Вставить: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 непрочитанных</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Добавить ещё аккаунт</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Восстановить</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>сообщений</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>сообщение</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Добавить аккаунт</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Имя нового аккаунта:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Аккаунт %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Переименовать аккаунт</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Имя аккаунта:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Аккаунт 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Разблокируйте, чтобы перезагрузить приложение.</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Требуется аутентификация</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Значок</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Информация</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Имя пользователя:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Пароль:</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Функция</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Выкл</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Список чатов</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Открытый разговор</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Список чатов и разговор</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Всё, включая фото</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Показать отладочную информацию</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Скрыть отладочную информацию</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>Нечего переносить из «%1» — уже перенесено или данные не найдены.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Будет скопировано:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Скопировано:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Запустите снова без --dry-run, чтобы выполнить копирование.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Многофункциональный клиент WhatsApp Web на основе Qt WebEngine</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Показывает справку по параметрам командной строки</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Открывает настройки в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Блокирует запущенный экземпляр </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Открывает окно «О программе» в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Открывает диалог запланированных сообщений в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Переключает светлую и тёмную тему в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Перезагружает приложение в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Открывает окно нового чата в запущенном экземпляре </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Запустить как отдельный аккаунт с собственной сессией и настройками, в своём окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Показывает главное окно запущенного экземпляра </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Скопировать настройки и активный сеанс из предыдущей установки (например, старой версии «whatsie») в эту и выйти</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>С --migrate-from только показать, что будет скопировано</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Вывести текущее число непрочитанных сообщений и выйти</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Блокировка приложения не настроена.
 Сначала задайте пароль в настройках.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Перезагрузка...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Режим установки</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Ветка исходного кода</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Хеш коммита</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Дата сборки</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Версия Qt во время выполнения</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Версия Qt при сборке</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Архитектура</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>Исключение</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> столкнулось с проблемой.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> может потребоваться перезапуск. Сообщите об ошибке разработчику.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>Не удалось запустить &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Нечего сохранять</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>Не удаётся создать %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>Не удалось скопировать %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Не удалось создать временный каталог</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Не удалось восстановить файл настроек</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>Не удаётся записать %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Переключить на светлую тему</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Переключить на тёмную тему</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Показать чаты</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Размыть чаты</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Оценить это приложение</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если вам нравится это приложение, не могли бы вы уделить минуту, чтобы оценить его?&lt;/p&gt;&lt;p&gt;Это не займёт больше минуты. Спасибо за поддержку!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Оценить в магазине</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Или</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>Поставить звезду репозиторию на GitHub</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>Пожертвовать через PayPal </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>Пожертвовать через OpenCollective</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Позже</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Уже сделано  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Истекло время ожидания отправки сообщения</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Ежедневно</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>По будням</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Еженедельно</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Один раз</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Отправлено</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Ошибка</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Ожидание</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Запланированные сообщения</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Кому</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Когда</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Номер телефона в международном формате, напр. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>Необязательная метка</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Один раз</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Ежедневно</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>По будням</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Еженедельно</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Повтор</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Напомнить вместо отправки (уведомить, не отправлять сообщение)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Сообщение для отправки</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>В запланированное время приложение должно быть запущено, а WhatsApp — авторизован. Если оно закрыто, сообщение будет отправлено при следующем открытии приложения. При отправке открывается чат получателя.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Запланировать</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Удалить выбранное</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Очистить отправленные/неудачные</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Введите номер телефона и сообщение.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Время уже прошло — отправить это сообщение сейчас?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Размер шрифта интерфейса</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Размер в пунктах собственного интерфейса приложения — меню, настроек и диалогов. Это не влияет на текст WhatsApp Web; для него используйте масштаб.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Тема оформления</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Автоматически перезагружать после сбоя</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если процесс страницы WhatsApp Web аварийно завершится, перезагружать её автоматически, не спрашивая.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Общие настройки</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Стиль виджетов</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Тема виджетов</translation>
+        <translation type="vanished">Тема виджетов</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;На основе часового пояса и местоположения вашей системы.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Автоматически</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Тёмная</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Светлая</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Повторяет светлое/тёмное предпочтение рабочего стола и меняется вместе с ним. Переопределяет ручную тему и автоматическое переключение по восходу/закату.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Следовать светлой/тёмной теме системы</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Системное уведомление</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Пользовательское уведомление</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Проверить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Тип уведомления</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Отключить всплывающие уведомления</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Время показа уведомления</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> с</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Доставка уведомлений</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Способ отправки нативных уведомлений в Linux. «Автоматически» использует портал рабочего стола в песочнице Flatpak, а в остальных случаях — системную службу.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Скрывать всплывающие уведомления в ежедневный тихий период. Счётчики непрочитанных по-прежнему обновляются; удерживается только всплывающее окно.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Не беспокоить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>С</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>по</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Выделять ключевые слова</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Слова через запятую, о которых всегда приходят уведомления, даже в режиме «Не беспокоить» (без учёта регистра).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>напр. срочно, начальник, счёт</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Использовать системный диалог файлов</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Отключить звук страницы</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Отключить автовоспроизведение мультимедиа</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Запускать свёрнутым в трей</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Показывать/скрывать по щелчку на значке в трее (если поддерживается)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Закрывает панель эмодзи, GIF и стикеров при щелчке в другом месте. Иначе WhatsApp Web оставляет её открытой до повторного нажатия кнопки.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Закрывать панель эмодзи/стикеров при щелчке вне её</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Язык интерфейса</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Язык интерфейса Whatly. Вступает в силу после перезапуска приложения. Язык самих чатов задаётся WhatsApp Web и не меняется здесь.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Добавляет кнопку светлой/тёмной темы на боковую панель WhatsApp, прямо над вашим фото профиля.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>Кнопка темы на боковой панели WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Добавляет на боковую панель WhatsApp кнопку, которая одним щелчком размывает и показывает ваши чаты, не открывая настройки.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>Кнопка размытия на боковой панели WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Использует одноцветный значок в трее в тон остальной панели вместо зелёного значка WhatsApp. Значок также тускнеет, когда WhatsApp не подключён.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Монохромный значок в трее</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Плавно анимирует прокрутку вместо перескакивания по строкам.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Плавная прокрутка</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>Пользовательский CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Загрузите файл .css, чтобы изменить стиль WhatsApp Web — стили сообщества (catppuccin и подобные) здесь работают. Применяется поверх темы чата.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Выбрать файл…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Полностью убирает значок в системном трее. Без трея для восстановления закрытие окна завершает приложение, а не сворачивает его.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Скрыть значок в трее</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Семейство шрифтов</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Отображает текст WhatsApp Web шрифтом, установленным в системе. Эмодзи, значки и моноширинное форматирование сообщений не изменяются.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Скрывает раздел «Отключённые обновления» на панели статусов, чтобы статусы отключённых контактов вообще не отображались.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Скрывать отключённые обновления статусов</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Подчёркивает слова с ошибками при вводе и предлагает исправления в контекстном меню.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Проверять орфографию при вводе</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Язык, по которому выполняется проверка.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Размытие для приватности</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Размывает ваши чаты, пока вы не наведёте на них курсор, чтобы случайный взгляд на экран не смог их прочитать. Наведение на строку открывает только её.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Тема чата</translation>
+        <translation type="vanished">Тема чата</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Оттенок цвета чата</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Перекрашивает сам WhatsApp Web. Фото, аватары и стикеры сохраняют свои цвета. Работает поверх светлой или тёмной темы, какая активна.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Обои чата</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Используйте своё изображение как фон панели чата, как это делает WhatsApp на Android. Изображение хранится внутри Whatly, никуда не загружается и видно только вам.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Выбрать изображение…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Новые входы отображаются в списке связанных устройств телефона как «Whatly для Linux» (или соответствующая платформа) вместо «Google Chrome (Linux)». Имя сохраняется на телефоне при связывании устройства, поэтому изменение влияет только на будущие связывания — выйдите и свяжите заново, чтобы переименовать существующий сеанс.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Определяться как Whatly в связанных устройствах</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>User-Agent</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Дополнительно — не меняйте это, если точно не знаете, что делаете. Нестандартный user agent может помешать загрузке WhatsApp, а необычные значения могут привести к тому, что ваш аккаунт WhatsApp будет помечен или занесён в чёрный список.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Применить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Сбросить по умолчанию</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Масштаб в обычном окне</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Увеличить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>сбросить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Масштаб в развёрнутом/полноэкранном режиме</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Свернуть в трей</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Выход</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Глобальные сочетания клавиш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Действие кнопки закрытия</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Показать сочетания клавиш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>Разрешения</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  Показать разрешения</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включить экран блокировки.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Включать блокировку при запуске</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Когда окно сворачивается в системный трей, блокировать его кодом. Требуется заданный пароль.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Блокировать при сворачивании в трей</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Также блокировать Whatly при блокировке сеанса рабочего стола. Требуется установленный пароль. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Блокировать при блокировке экрана</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Текущий пароль</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Сменить пароль</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Сменить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Включить автоблокировку через</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Показать пароль</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Папка загрузок по умолчанию</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>Изменить папку загрузок</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Хранилище </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Свойство</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Очистить (требуется перезапуск)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Постоянные данные включают постоянные cookie, локальное хранилище HTML5 и посещённые ссылки.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Постоянные данные</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>Кэш HTTP и медиафайлов. Его очистка безопасна — он загружается заново по мере необходимости.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Кэш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Очистить кэш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Действие</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Резервная копия</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Сохранить эту учётную запись (настройки, сеанс и дополнения) в архив .tar.gz. Архив содержит ваш активный сеанс — храните его в тайне.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Экспорт профиля…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Восстановление учётной записи из архива .tar.gz. Текущие данные будут перезаписаны, потребуется перезапуск.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Импорт профиля…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Производительность и конфиденциальность</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>Тонкая настройка движка отрисовки. Значения по умолчанию безопасны для большинства систем; если окно пустое, приложение падает при запуске или подтормаживает, попробуйте изменить эти параметры. Изменения вступают в силу после перезапуска.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Полная отрисовка на CPU (--disable-gpu). Устраняет пустые окна и падения при запуске на некоторых конфигурациях GPU/драйверов. По умолчанию в Linux.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>Отключить ускорение GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Композитинг страницы на CPU (--disable-gpu-compositing). Устраняет мерцание устаревших кадров на некоторых драйверах.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>Отключить композитинг GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>Отключить VSync для GPU (--disable-gpu-vsync). Может снизить задержку ввода ценой разрывов изображения.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>Отключить VSync для GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>Запускать процесс GPU внутри основного процесса (--in-process-gpu). Обходной путь для некоторых изолированных сред.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>Запускать GPU в основном процессе</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Принудительно включить ускорение, даже если драйвер в чёрном списке (--ignore-gpu-blocklist). Попробуйте, чтобы снова включить GPU.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>Игнорировать чёрный список GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Запускать всё в одном процессе (--single-process). Использует меньше памяти, но менее стабильно.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Однопроцессный режим (меньше памяти)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Общий процесс отрисовки для каждого сайта (--process-per-site). Снижает использование памяти.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Один процесс на сайт (меньше памяти)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Скрывает имена контактов и превью сообщений в списке чатов (наведите курсор, чтобы показать одно). Удобно при демонстрации экрана. Открытая переписка не изменяется.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Режим фокуса (скрыть превью чатов)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>По умолчанию использовать HD-качество для фото и видео в редакторе медиафайлов. Зависит от вёрстки WhatsApp Web; если обновление WhatsApp нарушит работу, отключите эту опцию.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Отправлять фото и видео в HD по умолчанию</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>Запретить WebRTC раскрывать ваш локальный IP-адрес через соединения без прокси.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>Предотвратить утечку IP через WebRTC</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>Лимит памяти JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>Ограничить кучу JavaScript (V8 --max-old-space-size). 0 = автоматически. Уменьшите, если приложение использует слишком много RAM.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> МБ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>Кэш HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>Где хранить кэш HTTP. Память очищается при выходе; None отключает кэширование.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>Макс. размер</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>Максимальный размер кэша на диске. 0 = автоматически.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Сеть и запуск</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Автоматически запускать Whatly при входе в сеанс рабочего стола.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Запускать Whatly при входе в систему</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Заменить системную рамку окна собственным тонким заголовком Whatly. Применяется после перезапуска.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Использовать собственную рамку окна (требуется перезапуск)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Проверять GitHub раз в день на наличие новой версии и уведомлять вас. Whatly никогда ничего не загружает и не устанавливает самостоятельно.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Проверять обновления автоматически</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Масштаб интерфейса</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Масштабирование всего окна и страницы (QT_SCALE_FACTOR). «Автоматически» использует настройки рабочего стола. Если задана переменная окружения QT_SCALE_FACTOR, она имеет приоритет. Применяется после перезапуска.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Прокси</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Способ подключения Whatly к сети. «Системный» использует настройки операционной системы; «Без прокси» подключается напрямую.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Хост</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Имя пользователя</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>Необязательно</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Пользовательские дополнения JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>Загружайте файлы .js для запуска в WhatsApp Web. Каждое дополнение работает в собственной песочнице, поэтому сбойное не нарушит работу остальных или страницы. Снимите флажок, чтобы отключить дополнение, не удаляя его. Изменения вступят в силу после перезапуска.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Добавить дополнение…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Сохранённые ответы</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Короткие тексты, которые вы часто отправляете. Вставьте один из палитры команд (Ctrl+K) — введите &quot;Вставить&quot; и выберите его; текст будет вписан в поле сообщения.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Добавить ответ…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Сочетания клавиш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Щёлкните поле и нажмите сочетание клавиш. Очистите поле, чтобы удалить сочетание. Изменения вступают в силу после перезапуска.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Это удалит постоянные данные (включая постоянные файлы cookie и кэш) и закроет приложение.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Удалить файлы cookie и закрыть приложение?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Ошибка</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Нельзя задать пустую строку User-Agent.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Автоматическое переключение темы отключено из-за ручной смены темы.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Блокировка приложения не настроена.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Настроить блокировку приложения сейчас?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Разрешения функций</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Выберите обои чата</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Изображения (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Не удалось использовать это изображение: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Выберите файл CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Таблицы стилей (*.css);;Все файлы (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Не удалось прочитать этот файл: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Диск</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Без прокси (напрямую)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Портал рабочего стола (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Системная служба (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Добавить ответ</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Текст для вставки</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Выберите файл JavaScript</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Все файлы (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Не удалось добавить дополнение</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Удалить дополнение</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>Удалить дополнение &quot;%1&quot;? Его файл будет удалён.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Проверка орфографии (словари не установлены)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Внешний вид</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Уведомления</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Общение</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Конфиденциальность и блокировка</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Окно и масштаб</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Сочетание уже используется</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Это сочетание клавиш уже используется другим действием.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Очистить кэш</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Очистить кэш сейчас? Он будет загружен заново по мере необходимости.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Экспорт профиля</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Архив будет содержать ваш активный сеанс WhatsApp. Храните его в тайне. Продолжить?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Архивы (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Профиль экспортирован.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Импорт профиля</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Это перезапишет данные текущей учётной записи содержимым архива, после чего Whatly потребуется перезапустить. Продолжить?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Профиль импортирован. Перезапустите Whatly.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>Языков: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>По умолчанию WhatsApp</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Системный по умолчанию</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>Язык интерфейса изменится после перезапуска %1.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Настройка блокировки</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Сначала задайте пароль блокировки приложения.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>Выберите папку загрузок</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 Может также потребоваться полный перезапуск приложения!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Хотите продолжить?</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Добро пожаловать в Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Быстрый нативный клиент WhatsApp Web для компьютера. Давайте кое-что настроим — всё это можно изменить позже в настройках.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly держит ваши чаты в полноценном окне на рабочем столе — со значком в трее, уведомлениями, темами и поддержкой нескольких аккаунтов.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Несколько настроек</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Разумные настройки по умолчанию; настройте по вкусу.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Использовать светлую или тёмную тему системы</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Запускать Whatly при входе в систему</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Доставка уведомлений:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Автоматически</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Портал рабочего стола (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Системная служба (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Всё готово</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Всё готово. Отсканируйте QR-код телефоном, чтобы войти.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Всё это находится в настройках, если вы передумаете.</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>Не удалось прочитать последнюю версию</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Демонстрация экрана</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Выберите, чем поделиться:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Без названия</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Экран: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Окно: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>Разрешить %1 доступ к данным о вашем местоположении?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>Разрешить %1 доступ к микрофону?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>Разрешить %1 доступ к камере?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>Разрешить %1 доступ к микрофону и камере?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>Разрешить %1 захватывать курсор мыши?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>Разрешить %1 записывать видео вашего рабочего стола?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>Разрешить %1 записывать звук и видео вашего рабочего стола?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>Разрешить %1 показывать уведомления на рабочем столе?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>Разрешить %1 читать буфер обмена? Это нужно для вставки изображений в чат.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>Разрешить %1 видеть шрифты, установленные в системе?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>Запрос разрешения</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Ошибка сертификата</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>Введите имя пользователя и пароль для «%1» на %2</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>Подключиться к прокси «%1», используя:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>Разрешить %1 открывать все ссылки %2?</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Процесс отрисовки завершился нормально</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Процесс отрисовки завершился аварийно</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Процесс отрисовки аварийно завершился</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Процесс отрисовки был остановлен</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Процесс отрисовки завершился с кодом: %1

--- a/src/i18n/tr_TR.ts
+++ b/src/i18n/tr_TR.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>PayPal ile bağış yap</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>Mağazada değerlendir</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>Diğer uygulamalar</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>Kaynak kodu</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aşağıdaki hata ayıklama bilgilerini panoya kopyalar ve sorun izleyiciyi açar, böylece doğrudan bildirime yapıştırılabilir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>Hata bildir</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>Hata ayıklama bilgileri</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>Sürüm: </translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>Hata ayıklama bilgisi tarayıcı için çok uzundu, bu yüzden panoya kopyalandı. Bunu bildirime yapıştırın.</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | Hakkında</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>Gün doğumu</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>Gün batımı</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  Yenile </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>Devre dışı bırak ve kapat</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  Etkinleştir ve kapat</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 Lütfen tekrar deneyin.</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Lütfen tekrar deneyin.</translation>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>İletişim kutusu</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>Simge</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp (varsayılan)</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>Barbie pembesi</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>Gül kurusu</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>Lavanta</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>Mor</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>Gök mavisi</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>Derin okyanus</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>Deniz mavisi</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>Nane</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>Mercan</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>Şeftali</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>Altın</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>Kızıl</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>Grafit</translation>
     </message>
@@ -209,18 +256,22 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>Komut paleti</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>Bir komut yazın…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>Komut arama</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>Eşleşen komutlar</translation>
     </message>
@@ -228,14 +279,17 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>Küçült</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>Büyüt</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -243,34 +297,42 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>İndirilenler</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>İndirme yok</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>İndirme listesini temizle</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>Tümünü temizle</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>İndirme klasörünü dosya yöneticisinde aç</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>İndirme klasörünü aç</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>Aynı ada sahip bir dosya zaten var!</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>Dosya yeni bir adla kaydedilsin mi?</translation>
     </message>
@@ -278,54 +340,68 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>Dosyayı sistem uygulamasıyla aç</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - %2 içinden %1 indirildi - %3/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>bilinmeyen boyut - %1 indirildi - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>tamamlandı - %1 indirildi - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>iptal edildi - %1 indirildi - %2/s</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>kesildi: %1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>İndirmeyi durdur</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>Listeden kaldır</translation>
     </message>
@@ -333,46 +409,58 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>Kilit kodunu ayarla</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>kodu girin</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>kodu tekrar girin</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>Kodu ayarla</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>Uyarı: Caps Lock açık</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Not: Kod 3 karakterden uzun olmalı ve her iki alanda da aynı olmalıdır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>Erişmek için kodunuzu girin</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>kodunuzu girin</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Yanlış kod. Lütfen tekrar deneyin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Güvenlik denetimini atlayıp devam etmek istiyor musunuz?   </translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>Ağ bekleniyor…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>Açık bir WhatsApp penceresi yok</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>Hatırlatıcı</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>Hatırlatıcı: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>Güncelleme mevcut</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 kullanılabilir. İndirme sayfasını açmak için tıklayın.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| Hata</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>Ayarlara erişmek için kilidi açın.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>Ayarlar modülü başlatılamıyor.
 WebEngine başlatılmadı.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | İşlem gerekli</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>Devam etmek için sayfanın yeniden yüklenmesi gerekiyor.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>Yeni sohbet</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>Ülke kodu ile geçerli bir WhatsApp numarası girin (örn. +90XXXXXXXXXX)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>Uygulamayı değerlendir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Lütfen önce ayarlardan parolayı belirleyin.
 Ayarlar şimdi açılsın mı?</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>Sistem tepsisine k&amp;üçült</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>&amp;Geri yükle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>Yeniden &amp;yükle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>&amp;Kilitle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>Sesi &amp;kapat</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>Yakınlaştır</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>Uzaklaştır</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>Yakınlaştırmayı sıfırla</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ayarlar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>Zamanlanmış &amp;mesajlar…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>&amp;Temayı değiştir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>Sekmeli görünüm</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>Izgara görünümü</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>Komut paleti</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>&amp;Hakkında</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>&amp;Çıkış</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>Yeniden yükle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>Sistem tepsisine küçült</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>Kilitle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>Sesi kapat</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>Yeni sohbet / URL aç</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>Temayı değiştir</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>Çıkış</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>Yeniden adlandır…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>Hesabı kaldır</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>Hesaba geç: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>Hesap ekle…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>Ekle: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 okunmamış</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>Başka hesap ekle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>Geri yükle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>mesaj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>mesaj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>Hesap ekle</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>Yeni hesabın adı:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>Hesap %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>Hesabı yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>Hesap adı:</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>Hesap 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>Uygulamayı yeniden yüklemek için kilidi açın.</translation>
     </message>
@@ -623,10 +779,12 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -641,22 +800,27 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>Kimlik doğrulama gerekli</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>Simge</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>Bilgi</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>Kullanıcı adı:</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>Parola:</translation>
     </message>
@@ -664,14 +828,17 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>Özellik</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
@@ -679,22 +846,27 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>Kapalı</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>Sohbet listesi</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>Açık sohbet</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>Sohbet listesi ve sohbet</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>Fotoğraflar dahil her şey</translation>
     </message>
@@ -702,10 +874,13 @@ Ayarlar şimdi açılsın mı?</translation>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>Hata ayıklama bilgilerini göster</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Ayarlar şimdi açılsın mı?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>Hata ayıklama bilgilerini gizle</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>&quot;%1&quot; kaynağından taşınacak bir şey yok — zaten taşınmış ya da veri bulunamadı.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>Kopyalanacak:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>Kopyalandı:</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>Kopyalamayı gerçekleştirmek için --dry-run olmadan yeniden çalıştırın.</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>Qt WebEngine tabanlı, özellik dolu WhatsApp Web istemcisi</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>Komut satırı seçeneklerinin yardımını gösterir</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>Çalışan bir örneğinde ayarları açar: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>Çalışan bir örneğini kilitler: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>Çalışan bir örneğinde «Hakkında» penceresini açar: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>Çalışan bir örnekte zamanlanmış mesajlar iletişim kutusunu açar </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>Çalışan bir örneğinde açık ve koyu tema arasında geçiş yapar: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>Çalışan bir örneğinde uygulamayı yeniden yükler: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>Çalışan bir örneğinde yeni sohbet penceresini açar: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kendi oturumu ve ayarlarıyla, kendi penceresinde ayrı bir hesap olarak çalıştır&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>Çalışan örneğin ana penceresini gösterir: </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>Önceki bir kurulumdan (örn. eski &quot;whatsie&quot; sürümü) ayarları ve oturum açılmış oturumu buraya kopyala, sonra çık</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>--migrate-from ile yalnızca nelerin kopyalanacağını bildir</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>Geçerli okunmamış mesaj sayısını yazdır ve çık</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>Uygulama kilidi yapılandırılmamış.
 Lütfen önce ayarlardan parolayı belirleyin.</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>Yeniden yükleniyor...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>Kurulum kipi</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>Kaynak dalı</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>Commit özeti</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>Derleme tarihi</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Çalışma zamanı Qt sürümü</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Derleme Qt sürümü</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>Mimari</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>İstisna</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> bir sorunla karşılaştı.</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> yeniden başlatılması gerekebilir. Lütfen hatayı geliştiriciye bildirin.</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>&apos;tar&apos; çalıştırılamadı</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>Yedeklenecek bir şey yok</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>%1 oluşturulamıyor</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>%1 kopyalanamıyor</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>Geçici dizin oluşturulamıyor</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>Ayarlar dosyası geri yüklenemedi</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>%1 yazılamıyor</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>Açık temaya geç</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>Koyu temaya geç</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>Sohbetleri göster</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>Sohbetleri bulanıklaştır</translation>
@@ -898,42 +1123,53 @@ Lütfen önce ayarlardan parolayı belirleyin.</translation>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>Bu uygulamayı değerlendir</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bu uygulamayı beğendiyseniz, değerlendirmek için bir dakikanızı ayırır mısınız?&lt;/p&gt;&lt;p&gt;Bir dakikadan fazla sürmeyecek. Desteğiniz için teşekkürler!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  Mağazada değerlendir</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>Veya</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>GitHub deposuna yıldız ver</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>PayPal ile bağış yap </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>OpenCollective ile bağış yap</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>Daha sonra</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  Zaten yaptım  </translation>
     </message>
@@ -941,34 +1177,42 @@ Lütfen önce ayarlardan parolayı belirleyin.</translation>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>Mesajın gönderilmesi beklenirken zaman aşımına uğradı</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>Günlük</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>Hafta içi</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>Haftalık</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>Bir kez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>Gönderildi</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>Başarısız</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>Bekliyor</translation>
     </message>
@@ -976,90 +1220,117 @@ Lütfen önce ayarlardan parolayı belirleyin.</translation>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>Zamanlanmış mesajlar</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>Kime</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>Ne zaman</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>Uluslararası biçimde telefon numarası, örn. 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>İsteğe bağlı etiket</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>Bir kez</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>Günlük</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>Hafta içi</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>Haftalık</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>Yinele</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>Göndermek yerine bana hatırlat (bildir, mesaj gönderme)</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>Gönderilecek mesaj</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>Uygulama, planlanan saatte çalışıyor ve WhatsApp oturumu açık olmalıdır. Kapalıysa mesaj, uygulamayı bir sonraki açışınızda gönderilir. Gönderme, alıcının sohbetini açar.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>Zamanla</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>Seçileni kaldır</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>Gönderilenleri/başarısızları temizle</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>Bir telefon numarası ve bir mesaj girin.</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>Zaman geçmişte — bu mesaj şimdi gönderilsin mi?</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Lütfen önce ayarlardan parolayı belirleyin.</translation>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>Arayüz yazı tipi boyutu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uygulamanın kendi arayüzünün — menüler, ayarlar ve iletişim kutuları — punto boyutu. Bu, WhatsApp Web&apos;in metnini etkilemez; bunun için yakınlaştırmayı kullanın.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Görünüm teması</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>Çökme sonrası otomatik olarak yeniden yükle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web&apos;in sayfa süreci çökerse, önce sormak yerine otomatik olarak yeniden yükle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>Genel ayarlar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>Bileşen stili</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>Bileşen teması</translation>
+        <translation type="vanished">Bileşen teması</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sisteminizin saat dilimine ve konumuna göre.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>Otomatik</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>Koyu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>Açık</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Masaüstünün açık/koyu tercihine uyar ve onunla birlikte değişir. Manuel temayı ve otomatik gün doğumu/batımı geçişini geçersiz kılar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>Sistemin açık/koyu temasını izle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>Yerel bildirim</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>Özelleştirilmiş bildirim</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  Dene</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>Bildirim türü</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>Bildirim açılır penceresini devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>Açılır pencere süresi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> sn</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>Bildirim gönderimi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>Linux&apos;ta yerel bildirimlerin nasıl gönderileceği. Otomatik seçeneği, Flatpak korumalı alanı içinde masaüstü portalını, aksi durumda sistem hizmetini kullanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>Günlük sessiz dönemde bildirim açılır pencerelerini gizler. Okunmadı rozetleri yine de güncellenir; yalnızca açılır pencere tutulur.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>Rahatsız Etme</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>Başlangıç</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>Bitiş</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>Anahtar sözcükleri vurgula</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>Rahatsız Etme sırasında bile her zaman bildirim gönderen, virgülle ayrılmış sözcükler (büyük/küçük harfe duyarsız).</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>örn. acil, patron, fatura</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>Yerel dosya iletişim kutusunu kullan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>Sayfa sesini kapat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>Medyanın otomatik oynatılmasını devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>Başlangıçta sistem tepsisine küçültülmüş başlat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>Tepsi simgesine tıklayınca göster/gizle (destekleniyorsa)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Başka bir yere tıkladığınızda emoji, GIF ve çıkartma panelini kapatır. Aksi hâlde WhatsApp Web, düğmeye tekrar basılana kadar paneli açık tutar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>Dışına tıklayınca emoji/çıkartma panelini kapat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>Arayüz dili</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whatly arayüzünün dili. Uygulama yeniden başlatıldığında etkili olur. Sohbetlerin dili WhatsApp Web&apos;den gelir ve buradan değiştirilemez.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp kenar çubuğuna, profil fotoğrafınızın hemen üstüne bir açık/koyu düğmesi ekler.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp kenar çubuğunda tema düğmesi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp kenar çubuğuna, Ayarları açmadan sohbetlerinizi tek tıkla bulanıklaştıran ve gösteren bir düğme ekler.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp kenar çubuğunda bulanıklaştırma düğmesi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp&apos;ın yeşil simgesi yerine, panelinizin geri kalanıyla uyumlu tek renkli bir tepsi simgesi kullanır. WhatsApp bağlı değilken simge ayrıca soluklaşır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>Tek renkli tepsi simgesi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Satır satır atlamak yerine kaydırmayı animasyonlu yapar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>Yumuşak kaydırma</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>Özel CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web&apos;in stilini değiştirmek için bir .css dosyası yükleyin — topluluk stil sayfaları (catppuccin ve benzerleri) burada çalışır. Sohbet temasının üzerine uygulanır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>Dosya seç…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>Temizle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sistem tepsisi simgesini tamamen kaldırır. Geri getirilecek tepsi olmadığında pencereyi kapatmak uygulamayı gizlemek yerine kapatır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>Tepsi simgesini gizle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>Yazı tipi ailesi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web metnini sisteminizde yüklü bir yazı tipiyle gösterir. Emoji, simgeler ve tek aralıklı mesaj biçimlendirmesi değiştirilmeden bırakılır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Durum/Güncellemeler panelindeki &quot;Sessize alınan güncellemeler&quot; bölümünü gizler; böylece sessize aldığınız kişilerin durumları hiç görünmez.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>Sessize alınmış durum güncellemelerini gizle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Yazarken yanlış yazılan kelimelerin altını çizer ve sağ tık menüsünde düzeltmeler sunar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>Yazarken yazımı denetle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Denetimin yapılacağı dil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>Gizlilik bulanıklığı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ekrana göz atan biri okuyamasın diye, üzerine gelene kadar sohbetlerinizi bulanıklaştırır. Bir satırın üzerine gelmek yalnızca o satırı gösterir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>Sohbet teması</translation>
+        <translation type="vanished">Sohbet teması</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>Sohbet renk tonu</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp Web&apos;in kendisini yeniden renklendirir. Fotoğraflar, avatarlar ve çıkartmalar kendi renklerini korur. Hangisi etkinse açık ya da koyu temanın üzerinde çalışır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>Sohbet duvar kâğıdı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WhatsApp&apos;ın Android&apos;de yaptığı gibi, sohbet bölmesinin arka planı olarak kendi görsellerinizden birini kullanın. Görsel Whatly içinde saklanır, hiçbir yere yüklenmez ve yalnızca siz görürsünüz.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>Görsel seç…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Yeni oturum açmalar, telefonunuzun bağlı cihazlar listesinde «Google Chrome (Linux)» yerine «Whatly for Linux» (veya ilgili platform) olarak görünür. Ad, bir cihaz bağlanırken telefona kaydedilir; bu nedenle bunu değiştirmek yalnızca gelecekteki bağlantıları etkiler — mevcut bir oturumu yeniden adlandırmak için çıkış yapıp yeniden bağlanın.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>Bağlı cihazlarda Whatly olarak tanımlan</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>Kullanıcı aracısı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gelişmiş — ne yaptığınızı tam olarak bilmiyorsanız buna dokunmayın. Standart olmayan bir user agent WhatsApp'ın yüklenmesini engelleyebilir ve olağan dışı değerler WhatsApp hesabınızın işaretlenmesine veya kara listeye alınmasına yol açabilir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  Uygula</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>Varsayılana sıfırla</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>Normal penceredeki yakınlaştırma oranı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>Uzaklaştır</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>Yakınlaştır</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>sıfırla</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>Büyütülmüş/tam ekrandaki yakınlaştırma oranı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>Sistem tepsisine küçült</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>Çıkış</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>Genel kısayollar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>Kapat düğmesi eylemi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  Kısayolları göster</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>İzinler</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  İzinleri göster</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kilit ekranını etkinleştir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>Başlangıçta uygulama kilidini etkinleştir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pencere sistem tepsisine gizlendiğinde parola ile kilitle. Bir parola ayarlanmış olmalıdır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>Tepsiye gizlenince kilitle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>Masaüstü oturumu kilitlendiğinde Whatly’yi de kilitle. Bir parola ayarlanmış olmalıdır. (Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>Ekran kilitlendiğinde kilitle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>Mevcut parola</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>Parolayı değiştir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>Değiştir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>Şu süre sonra otomatik kilitle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>Sıfırla</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>Parolayı göster</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>Varsayılan indirme konumu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>İndirme konumunu değiştir</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>Depolama </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>Özellik</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  Temizle (yeniden başlatma gerekir)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kalıcı veriler; kalıcı çerezleri, HTML5 yerel depolamayı ve ziyaret edilen bağlantıları içerir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>Kalıcı veriler</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>HTTP/medya önbelleği. Temizlenmesi güvenlidir — gerektiğinde yeniden indirilir.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>Önbellek</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  Önbelleği temizle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>Eylem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>Yedekleme</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>Bu hesabı (ayarlar, oturum ve eklentiler) bir .tar.gz arşivine kaydedin. Arşiv, oturum açmış oturumunuzu içerir — gizli tutun.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>Profili dışa aktar…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>Bir hesabı .tar.gz arşivinden geri yükleyin. Bu, mevcut verilerin üzerine yazar ve yeniden başlatma gerektirir.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>Profili içe aktar…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>Performans &amp; Gizlilik</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>İşleme motorunda ince ayar yapın. Varsayılanlar çoğu sistemde güvenlidir; pencere boşsa veya uygulama başlangıçta çöküyorsa ya da takılıyorsa bunları değiştirmeyi deneyin. Değişiklikler yeniden başlatmadan sonra geçerli olur.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>Tamamen CPU üzerinde işle (--disable-gpu). Bazı GPU/sürücü yapılandırmalarında boş pencereleri ve başlangıç çökmelerini düzeltir. Linux&apos;ta varsayılan.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>GPU hızlandırmayı devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>Sayfayı CPU üzerinde birleştir (--disable-gpu-compositing). Bazı sürücülerde eski kare titremesini önler.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>GPU birleştirmeyi devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>GPU VSync&apos;i devre dışı bırak (--disable-gpu-vsync). Görüntü yırtılması pahasına giriş gecikmesini azaltabilir.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>GPU VSync&apos;i devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>GPU işlemini ana işlemin içinde çalıştır (--in-process-gpu). Bazı yalıtılmış yapılandırmalar için bir geçici çözüm.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>GPU&apos;yu işlem içinde çalıştır</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>Sürücü engelleme listesinde olsa bile hızlandırmayı zorla (--ignore-gpu-blocklist). GPU&apos;yu yeniden açmak için bunu deneyin.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>GPU engelleme listesini yoksay</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>Her şeyi tek bir işlemde çalıştır (--single-process). Daha az bellek kullanır ancak daha az kararlıdır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>Tek işlem modu (daha az bellek)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>Site başına tek bir işleyici işlemi paylaş (--process-per-site). Bellek kullanımını azaltır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>Site başına bir işlem (daha az bellek)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>Sohbet listesindeki kişi adlarını ve mesaj önizlemelerini gizler (birini görmek için üzerine gelin). Ekran paylaşırken kullanışlıdır. Açık sohbet değişmez.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>Odak modu (sohbet önizlemelerini gizle)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>Medya düzenleyicide fotoğraf ve videoları varsayılan olarak HD kalitede kullan. WhatsApp Web&apos;in düzenine bağlıdır; bir WhatsApp güncellemesi bunu bozarsa kapatın.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>Fotoğraf ve videoları varsayılan olarak HD gönder</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>WebRTC&apos;nin yerel IP adresinizi proxy kullanılmayan bağlantılar üzerinden ifşa etmesini engelleyin.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>WebRTC IP sızıntısını önle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript bellek sınırı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>JavaScript yığınını sınırla (V8 --max-old-space-size). 0 = otomatik. Uygulama çok fazla RAM kullanıyorsa düşürün.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP önbelleği</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>HTTP önbelleğinin nerede tutulacağı. Bellek çıkışta temizlenir; Yok önbelleklemeyi devre dışı bırakır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>En büyük boyut</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>En büyük disk önbelleği boyutu. 0 = otomatik.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>Ağ &amp; Başlangıç</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>Masaüstü oturumunuza giriş yaptığınızda Whatly&apos;yi otomatik olarak başlatın.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>Giriş yaptığımda Whatly&apos;yi başlat</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>Sistem pencere kenarlığını Whatly&apos;nin kendi ince başlık çubuğuyla değiştirin. Yeniden başlattıktan sonra uygulanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>Özel bir pencere çerçevesi kullan (yeniden başlatma gerektirir)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>Yeni bir sürüm için GitHub&apos;ı günde bir kez denetler ve sizi bilgilendirir. Whatly kendi başına hiçbir şey indirmez veya kurmaz.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>Güncellemeleri otomatik olarak denetle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>Arayüz ölçeği</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>Tüm pencereyi ve sayfayı ölçekleyin (QT_SCALE_FACTOR). Otomatik, masaüstünü izler. Ayarlanmışsa bir QT_SCALE_FACTOR ortam değişkeni bunu geçersiz kılar. Yeniden başlatmadan sonra uygulanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>Vekil sunucu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Whatly&apos;nin ağa nasıl bağlanacağı. Sistem, işletim sistemini izler; Yok doğrudan bağlanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>Ana bilgisayar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>Bağlantı noktası</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>Kullanıcı adı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>İsteğe bağlı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>Parola</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>Özel JavaScript eklentileri</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>WhatsApp Web üzerinde çalıştırmak için .js dosyaları yükleyin. Her eklenti kendi kum havuzunda çalışır, böylece bozuk bir eklenti diğerlerini veya sayfayı çökertemez. Bir eklentiyi kaldırmadan devre dışı bırakmak için işaretini kaldırın. Değişiklikler yeniden başlatmadan sonra uygulanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>Eklenti ekle…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>Kaldır</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>Kayıtlı yanıtlar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>Sık gönderdiğiniz kısa metinler. Komut paletinden (Ctrl+K) birini ekleyin — &quot;Ekle&quot; yazıp seçin; metin mesaj kutusuna yazılır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>Yanıt ekle…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>Klavye kısayolları</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>Bir alana tıklayın ve tuş bileşimine basın. Kısayolu kaldırmak için alanı temizleyin. Değişiklikler yeniden başlatmadan sonra uygulanır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>Bu, kalıcı verileri (kalıcı çerezler ve önbellek dahil) silecek ve uygulamayı kapatacaktır.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>Çerezler silinsin ve uygulama kapatılsın mı?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| Hata</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>Boş bir User-Agent dizesi ayarlanamaz.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>Tema elle değiştirildiği için otomatik tema değişimi devre dışı bırakıldı.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>Uygulama kilidi yapılandırılmadı.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>Uygulama kilidini şimdi ayarlamak ister misiniz?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>Özellik izinleri</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>Bir sohbet duvar kâğıdı seçin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>Görseller (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>Bu görsel kullanılamadı: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>Bir CSS dosyası seçin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>Stil sayfaları (*.css);;Tüm dosyalar (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>Bu dosya okunamadı: %1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>Disk</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>Yok (doğrudan)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Masaüstü portalı (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>Sistem hizmeti (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>Yanıt ekle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>Eklenecek metin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>Bir JavaScript dosyası seçin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;Tüm dosyalar (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>Eklenti eklenemedi</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>Eklentiyi kaldır</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>&quot;%1&quot; eklentisi kaldırılsın mı? Bu, dosyasını siler.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>Yazım denetleyici (yüklü sözlük yok)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>Yok</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>Temel</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>Bildirimler</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>Sohbet</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Gizlilik ve kilit</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Pencere ve yakınlaştırma</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>Gelişmiş</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>Kısayol kullanımda</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>Bu kısayol zaten başka bir işlem tarafından kullanılıyor.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>Önbelleği temizle</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>Önbellek şimdi temizlensin mi? Gerektiğinde yeniden indirilecektir.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>Profili dışa aktar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>Arşiv, oturum açmış WhatsApp oturumunuzu içerecek. Gizli tutun. Devam edilsin mi?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>Arşivler (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>Profil dışa aktarıldı.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>Profili içe aktar</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>Bu, mevcut hesabın verilerinin üzerine arşivi yazar, ardından Whatly&apos;nin yeniden başlatılması gerekir. Devam edilsin mi?</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>Profil içe aktarıldı. Lütfen Whatly&apos;yi yeniden başlatın.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 dil</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp varsayılanı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>Sistem varsayılanı</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>Arayüz dili %1 yeniden başlatıldığında değişecek.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>Uygulama Kilidi Kurulumu</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>Lütfen önce uygulama kilidi parolasını ayarlayın.</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>İndirme klasörünü seçin</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ Bu, mevcut oturumunuzu kapatacaktır.
 Uygulamanın tamamen yeniden başlatılması da gerekebilir!</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>Devam etmek istiyor musunuz?</translation>
     </message>
@@ -1972,58 +2544,73 @@ Uygulamanın tamamen yeniden başlatılması da gerekebilir!</translation>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>Whatly&apos;ye hoş geldiniz</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>Masaüstü için hızlı, yerel bir WhatsApp Web istemcisi. Hadi birkaç ayarı yapalım — bunların tümünü daha sonra Ayarlar&apos;dan değiştirebilirsiniz.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly, sohbetlerinizi tepsi simgesi, bildirimler, temalar ve birden fazla hesapla birlikte gerçek bir masaüstü penceresinde tutar.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>Birkaç tercih</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>Makul varsayılanlar; zevkinize göre ayarlayın.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>Sistemin açık/koyu temasıyla eşleştir</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>Giriş yaptığımda Whatly&apos;yi başlat</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>Bildirim iletimi:</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>Otomatik</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>Masaüstü portalı (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>Sistem hizmeti (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>Her şey hazır</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>Kullanmaya hazırsınız. Oturum açmak için QR kodunu telefonunuzla tarayın.</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>Fikrinizi değiştirirseniz buradaki her şey Ayarlar&apos;da bulunuyor.</translation>
     </message>
@@ -2031,6 +2618,7 @@ Uygulamanın tamamen yeniden başlatılması da gerekebilir!</translation>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>En son sürüm okunamadı</translation>
     </message>
@@ -2038,82 +2626,104 @@ Uygulamanın tamamen yeniden başlatılması da gerekebilir!</translation>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>Ekranınızı paylaşın</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>Neyi paylaşacağınızı seçin:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>Adsız</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>Ekran: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>Pencere: </translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>%1 konum bilgilerinize erişsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>%1 mikrofonunuza erişsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>%1 kameranıza erişsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>%1 mikrofonunuza ve kameranıza erişsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>%1 fare imlecinizi kilitlesin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>%1 masaüstünüzün videosunu kaydetsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>%1 masaüstünüzün sesini ve videosunu kaydetsin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>%1 masaüstünüzde bildirim göstersin mi?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>%1 panonuzu okusun mu? Bu, sohbete resim yapıştırmak için gereklidir.</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>%1 sisteminizde yüklü yazı tiplerini görsün mü?</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>İzin isteği</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>Sertifika hatası</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>%2 üzerindeki «%1» için kullanıcı adı ve parola girin</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>«%1» proxy&apos;sine şununla bağlan:</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>%1 tüm %2 bağlantılarını açsın mı?</translation>
     </message>
@@ -2121,22 +2731,27 @@ Uygulamanın tamamen yeniden başlatılması da gerekebilir!</translation>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>Oluşturma süreci normal şekilde sonlandı</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>Oluşturma süreci anormal şekilde sonlandı</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>Oluşturma süreci çöktü</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>Oluşturma süreci sonlandırıldı</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>Oluşturma süreci şu kodla sonlandı: %1

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -4,10 +4,12 @@
 <context>
     <name>About</name>
     <message>
+        <location filename="../about.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="117"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -17,58 +19,73 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="135"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.ui" line="171"/>
         <source>Donate PayPal</source>
         <translation>通过 PayPal 捐赠</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="178"/>
         <source>Ko-fi</source>
         <translation>Ko-fi</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="185"/>
         <source>Wise</source>
         <translation>Wise</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="192"/>
         <source>Rate in Store</source>
         <translation>在商店中评分</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="203"/>
         <source>More Applications</source>
         <translation>更多应用</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="210"/>
         <source>Source Code</source>
         <translation>源代码</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="217"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;将下方的调试信息复制到剪贴板并打开问题追踪器，以便直接粘贴到报告中。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
         <source>Report a Bug</source>
         <translation>报告问题</translation>
     </message>
     <message>
+        <location filename="../about.ui" line="229"/>
         <source>Debug Info</source>
         <translation>调试信息</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="88"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="145"/>
         <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
         <translation>调试信息太长，浏览器无法传递，已复制到剪贴板。请将其粘贴到问题中。</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="152"/>
         <source> | About</source>
         <translation> | 关于</translation>
     </message>
@@ -76,34 +93,45 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>AutomaticTheme</name>
     <message>
+        <location filename="../automatictheme.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="27"/>
         <source>Sunrise</source>
         <translation>日出</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="34"/>
         <source>Sunset</source>
         <translation>日落</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="55"/>
         <source>  Refresh </source>
         <translation>  刷新 </translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="70"/>
         <source>Disable and Close</source>
         <translation>禁用并关闭</translation>
     </message>
     <message>
+        <location filename="../automatictheme.ui" line="94"/>
         <source>  Enable and Close</source>
         <translation>  启用并关闭</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="95"/>
         <source>Invalid Geo-Coordinates.
 
 Please try again.</source>
@@ -112,6 +140,7 @@ Please try again.</source>
 请重试。</translation>
     </message>
     <message>
+        <location filename="../automatictheme.cpp" line="104"/>
         <source>Invalid configuration.
 
 Sunrise and Sunset time cannot have similar values.
@@ -127,18 +156,22 @@ Please try again.</source>
 <context>
     <name>CertificateErrorDialog</name>
     <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>对话框</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
         <source>Icon</source>
         <translation>图标</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
 
 Do you wish to override the security check and continue ?   </source>
@@ -150,58 +183,72 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>ChatTheme</name>
     <message>
+        <location filename="../chattheme.cpp" line="156"/>
         <source>WhatsApp (default)</source>
         <translation>WhatsApp（默认）</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="158"/>
         <source>Barbie pink</source>
         <translation>芭比粉</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="160"/>
         <source>Dusty rose</source>
         <translation>灰玫瑰色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="162"/>
         <source>Lavender</source>
         <translation>薰衣草色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="164"/>
         <source>Violet</source>
         <translation>紫罗兰色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="166"/>
         <source>Sky blue</source>
         <translation>天蓝色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="168"/>
         <source>Deep ocean</source>
         <translation>深海蓝</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="170"/>
         <source>Teal</source>
         <translation>青色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="172"/>
         <source>Mint</source>
         <translation>薄荷绿</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="174"/>
         <source>Coral</source>
         <translation>珊瑚色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="176"/>
         <source>Peach</source>
         <translation>桃色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="178"/>
         <source>Gold</source>
         <translation>金色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="180"/>
         <source>Crimson</source>
         <translation>深红色</translation>
     </message>
     <message>
+        <location filename="../chattheme.cpp" line="182"/>
         <source>Graphite</source>
         <translation>石墨灰</translation>
     </message>
@@ -209,18 +256,22 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CommandPalette</name>
     <message>
+        <location filename="../commandpalette.cpp" line="46"/>
         <source>Command palette</source>
         <translation>命令面板</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="54"/>
         <source>Type a command…</source>
         <translation>输入命令…</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="56"/>
         <source>Command search</source>
         <translation>命令搜索</translation>
     </message>
     <message>
+        <location filename="../commandpalette.cpp" line="59"/>
         <source>Matching commands</source>
         <translation>匹配的命令</translation>
     </message>
@@ -228,14 +279,17 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>CustomTitleBar</name>
     <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
         <source>Minimise</source>
         <translation>最小化</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
         <source>Maximise</source>
         <translation>最大化</translation>
     </message>
     <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -243,34 +297,42 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadManagerWidget</name>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
         <source>Downloads</source>
         <translation>下载</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
         <source>No downloads</source>
         <translation>无下载</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
         <source>Clear download list</source>
         <translation>清空下载列表</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
         <source>Clear all</source>
         <translation>全部清空</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
         <source>Open download directory in file manager</source>
         <translation>在文件管理器中打开下载目录</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
         <source>Open Download directory</source>
         <translation>打开下载目录</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
         <source>File with same name already exist!</source>
         <translation>已存在同名文件！</translation>
     </message>
     <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
         <source>Save file with a new name?</source>
         <translation>用新名称保存文件？</translation>
     </message>
@@ -278,54 +340,68 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>DownloadWidget</name>
     <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.ui" line="63"/>
         <source>Open file using system application</source>
         <translation>使用系统应用打开文件</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
         <source>%L1 KiB</source>
         <translation>%L1 KiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
         <source>%L1 MiB</source>
         <translation>%L1 MiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
         <source>%L1 GiB</source>
         <translation>%L1 GiB</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
         <source>%p% - %1 of %2 downloaded - %3/s</source>
         <translation>%p% - 已下载 %1 / %2 - %3/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
         <source>unknown size - %1 downloaded - %2/s</source>
         <translation>大小未知 - 已下载 %1 - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
         <source>completed - %1 downloaded - %2/s</source>
         <translation>已完成 - 已下载 %1 - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
         <source>cancelled - %1 downloaded - %2/s</source>
         <translation>已取消 - 已下载 %1 - %2/秒</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
         <source>interrupted: %1</source>
         <translation>已中断：%1</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
         <source>Stop downloading</source>
         <translation>停止下载</translation>
     </message>
     <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
         <source>Remove from list</source>
         <translation>从列表中移除</translation>
     </message>
@@ -333,46 +409,58 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>Lock</name>
     <message>
+        <location filename="../lock.ui" line="20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="199"/>
         <source>Set lock passcode</source>
         <translation>设置锁定密码</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="224"/>
         <source>enter passcode</source>
         <translation>输入密码</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="243"/>
         <source>enter passcode again</source>
         <translation>再次输入密码</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="256"/>
         <source>Set Pass Code</source>
         <translation>设置密码</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="269"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
         <source>Warning: Caps Lock is On</source>
         <translation>警告：大写锁定已开启</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="346"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;注意：密码必须超过 3 个字符，且两个字段必须一致。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="597"/>
         <source>Enter your passcode to get access</source>
         <translation>输入密码以获取访问权限</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="622"/>
         <source>enter your passcode</source>
         <translation>输入您的密码</translation>
     </message>
     <message>
+        <location filename="../lock.ui" line="639"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;密码错误，请重试。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -380,68 +468,88 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="391"/>
         <source>Waiting for network…</source>
         <translation>正在等待网络…</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="91"/>
         <source>No WhatsApp window is open</source>
         <translation>没有打开的 WhatsApp 窗口</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder</source>
         <translation>提醒</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="96"/>
         <source>Reminder: %1</source>
         <translation>提醒：%1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Update available</source>
         <translation>有可用更新</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>Whatly %1 is available. Click to open the download page.</source>
         <translation>Whatly %1 已发布。点击打开下载页面。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="777"/>
+        <location filename="../mainwindow.cpp" line="783"/>
+        <location filename="../mainwindow_webengine.cpp" line="350"/>
+        <location filename="../mainwindow_webengine.cpp" line="353"/>
         <source>| Error</source>
         <translation>| 错误</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="778"/>
         <source>Unlock to access Settings.</source>
         <translation>请解锁以访问设置。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Unable to initialize settings module.
 Webengine is not initialized.</source>
         <translation>无法初始化设置模块。
 WebEngine 未初始化。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source> | Action required</source>
         <translation> | 需要操作</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Page needs to be reloaded to continue.</source>
         <translation>需要重新加载页面才能继续。</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1028"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
+        <location filename="../mainwindow_tray.cpp" line="20"/>
         <source>New Chat</source>
         <translation>新建聊天</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1039"/>
         <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
         <translation>请输入带国家代码的有效 WhatsApp 号码（例如 +86XXXXXXXXXXX）</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1069"/>
         <source>Rate Application</source>
         <translation>为应用评分</translation>
     </message>
     <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.
 
@@ -452,170 +560,218 @@ Open Settings now?</source>
 现在打开设置吗？</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="25"/>
+        <location filename="../mainwindow_tray.cpp" line="151"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="31"/>
         <source>Mi&amp;nimize to tray</source>
         <translation>最小化到托盘(&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="39"/>
         <source>&amp;Restore</source>
         <translation>还原(&amp;R)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="43"/>
         <source>Re&amp;load</source>
         <translation>重新加载(&amp;L)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="49"/>
         <source>Loc&amp;k</source>
         <translation>锁定(&amp;K)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="54"/>
         <source>&amp;Mute audio</source>
         <translation>静音(&amp;M)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="63"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="69"/>
         <source>Zoom out</source>
         <translation>缩小</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="74"/>
+        <location filename="../mainwindow_tray.cpp" line="153"/>
         <source>Reset zoom</source>
         <translation>重置缩放</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="79"/>
         <source>&amp;Settings</source>
         <translation>设置(&amp;S)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="85"/>
         <source>Scheduled &amp;messages…</source>
         <translation>定时消息…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="90"/>
         <source>&amp;Toggle theme</source>
         <translation>切换主题(&amp;T)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="101"/>
         <source>Tabbed view</source>
         <translation>标签页视图</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="108"/>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="119"/>
+        <location filename="../mainwindow_tray.cpp" line="157"/>
         <source>Command palette</source>
         <translation>命令面板</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="125"/>
         <source>&amp;About</source>
         <translation>关于(&amp;A)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="134"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
         <source>Reload</source>
         <translation>重新加载</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="148"/>
         <source>Minimise to tray</source>
         <translation>最小化到托盘</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="149"/>
         <source>Lock</source>
         <translation>锁定</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="150"/>
         <source>Mute audio</source>
         <translation>静音</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="152"/>
         <source>New chat / open URL</source>
         <translation>新建聊天 / 打开 URL</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="154"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="155"/>
         <source>Toggle theme</source>
         <translation>切换主题</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="158"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="113"/>
         <source>Rename…</source>
         <translation>重命名…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="114"/>
         <source>Remove account</source>
         <translation>移除账号</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="148"/>
         <source>Switch to account: %1</source>
         <translation>切换到账户：%1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="151"/>
         <source>Add account…</source>
         <translation>添加账户…</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="156"/>
         <source>Insert: %1</source>
         <translation>插入：%1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="234"/>
         <source>%1 — %2 unread</source>
         <translation>%1 — %2 条未读</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="337"/>
         <source>Add another account</source>
         <translation>添加另一个账号</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="356"/>
+        <location filename="../mainwindow_accounts.cpp" line="361"/>
         <source>Restore</source>
         <translation>还原</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>messages</source>
         <translation>条消息</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="357"/>
         <source>message</source>
         <translation>条消息</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="401"/>
         <source>Add account</source>
         <translation>添加账号</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="402"/>
         <source>Name for the new account:</source>
         <translation>新账号的名称：</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="403"/>
+        <location filename="../mainwindow_accounts.cpp" line="478"/>
         <source>Account %1</source>
         <translation>账号 %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Rename account</source>
         <translation>重命名账号</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="421"/>
         <source>Account name:</source>
         <translation>账号名称：</translation>
     </message>
     <message>
+        <location filename="../mainwindow_accounts.cpp" line="474"/>
         <source>Account 1</source>
         <translation>账号 1</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="348"/>
         <source>Unlock to Reload the App.</source>
         <translation>请解锁以重新加载应用。</translation>
     </message>
@@ -623,10 +779,12 @@ Open Settings now?</source>
 <context>
     <name>MoreApps</name>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
         <source>... ... ... ...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,6 +792,7 @@ Open Settings now?</source>
 <context>
     <name>NotificationPopup</name>
     <message>
+        <location filename="../notificationpopup.h" line="52"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -641,22 +800,27 @@ Open Settings now?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
+        <location filename="../passworddialog.ui" line="14"/>
         <source>Authentication Required</source>
         <translation>需要身份验证</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="20"/>
         <source>Icon</source>
         <translation>图标</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="36"/>
         <source>Info</source>
         <translation>信息</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="46"/>
         <source>Username:</source>
         <translation>用户名：</translation>
     </message>
     <message>
+        <location filename="../passworddialog.ui" line="56"/>
         <source>Password:</source>
         <translation>密码：</translation>
     </message>
@@ -664,14 +828,17 @@ Open Settings now?</source>
 <context>
     <name>PermissionDialog</name>
     <message>
+        <location filename="../permissiondialog.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="24"/>
         <source>Feature</source>
         <translation>功能</translation>
     </message>
     <message>
+        <location filename="../permissiondialog.ui" line="29"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
@@ -679,22 +846,27 @@ Open Settings now?</source>
 <context>
     <name>PrivacyBlur</name>
     <message>
+        <location filename="../privacyblur.cpp" line="85"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="87"/>
         <source>Chat list</source>
         <translation>聊天列表</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="89"/>
         <source>Open conversation</source>
         <translation>打开的对话</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="91"/>
         <source>Chat list and conversation</source>
         <translation>聊天列表和对话</translation>
     </message>
     <message>
+        <location filename="../privacyblur.cpp" line="94"/>
         <source>Everything, photos included</source>
         <translation>全部，包括照片</translation>
     </message>
@@ -702,10 +874,13 @@ Open Settings now?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
         <source>Show Debug Info</source>
         <translation>显示调试信息</translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="129"/>
         <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
 
 
@@ -713,183 +888,233 @@ Open Settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../about.cpp" line="177"/>
         <source>Hide Debug Info</source>
         <translation>隐藏调试信息</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="182"/>
         <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
         <translation>没有可从“%1”迁移的内容 — 已迁移，或未找到数据。</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Would copy:</source>
         <translation>将复制：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="187"/>
         <source>Copied:</source>
         <translation>已复制：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="191"/>
         <source>Run again without --dry-run to perform the copy.</source>
         <translation>不带 --dry-run 重新运行以执行复制。</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="462"/>
         <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
         <translation>基于 Qt WebEngine 的功能丰富的 WhatsApp Web 客户端</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="469"/>
         <source>Displays help on commandline options</source>
         <translation>显示命令行选项的帮助</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="474"/>
         <source>Opens Settings dialog in a running instance of </source>
         <translation>在正在运行的实例中打开设置：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="479"/>
         <source>Locks a running instance of </source>
         <translation>锁定正在运行的实例：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="485"/>
         <source>Opens About dialog in a running instance of </source>
         <translation>在正在运行的实例中打开“关于”窗口：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="490"/>
         <source>Opens the scheduled messages dialog in a running instance of </source>
         <translation>在正在运行的实例中打开定时消息对话框 </translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="497"/>
         <source>Toggle between dark &amp; light theme in a running instance of </source>
         <translation>在正在运行的实例中切换深色与浅色主题：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="504"/>
         <source>Reload the app in a running instance of </source>
         <translation>在正在运行的实例中重新加载应用：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="510"/>
         <source>Open new chat prompt in a running instance of </source>
         <translation>在正在运行的实例中打开新建聊天窗口：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="523"/>
         <source>Run as a separate account with its own session and settings, in its own window</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;以拥有独立会话和设置的独立账号运行，使用独立窗口&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="530"/>
         <source>Show main window of running instance of </source>
         <translation>显示正在运行实例的主窗口：</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="537"/>
         <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
         <translation>将设置和已登录的会话从之前的安装（例如旧的“whatsie”版本）复制到此处，然后退出</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="544"/>
         <source>With --migrate-from, only report what would be copied</source>
         <translation>使用 --migrate-from 时，仅报告将要复制的内容</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="561"/>
         <source>Print the current unread message count and exit</source>
         <translation>打印当前未读消息数并退出</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="635"/>
         <source>App lock is not configured, 
 Please setup the password in the Settings first.</source>
         <translation>尚未配置应用锁。
 请先在设置中设置密码。</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="345"/>
         <source>Reloading...</source>
         <translation>正在重新加载...</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
         <source>Install mode</source>
         <translation>安装模式</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="333"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="335"/>
         <source>Source Branch</source>
         <translation>源代码分支</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="337"/>
         <source>Commit Hash</source>
         <translation>提交哈希</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="339"/>
         <source>Build Datetime</source>
         <translation>构建时间</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="341"/>
         <source>Qt Runtime Version</source>
         <translation>Qt 运行时版本</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="343"/>
         <source>Qt Compiled Version</source>
         <translation>Qt 编译版本</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="345"/>
         <source>System</source>
         <translation>系统</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="347"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="490"/>
         <source>Exception</source>
         <translation>异常</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="493"/>
         <source> has encountered a problem.</source>
         <translation> 遇到了问题。</translation>
     </message>
     <message>
+        <location filename="../utils.cpp" line="496"/>
         <source> may need to Restart. Please report the error to developer.</source>
         <translation> 可能需要重新启动。请将该错误报告给开发者。</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="17"/>
         <source>Could not run &apos;tar&apos;</source>
         <translation>无法运行 &apos;tar&apos;</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="36"/>
         <source>Nothing to back up</source>
         <translation>没有可备份的内容</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
         <source>Cannot create %1</source>
         <translation>无法创建 %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="74"/>
         <source>Cannot copy %1</source>
         <translation>无法复制 %1</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
         <source>Cannot create a temporary directory</source>
         <translation>无法创建临时目录</translation>
     </message>
     <message>
+        <location filename="../backup.cpp" line="119"/>
         <source>Could not restore the settings file</source>
         <translation>无法恢复设置文件</translation>
     </message>
     <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
         <source>Cannot write %1</source>
         <translation>无法写入 %1</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="341"/>
         <source>Switch to light theme</source>
         <comment>WebTweaks</comment>
         <translation>切换到浅色主题</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="342"/>
         <source>Switch to dark theme</source>
         <comment>WebTweaks</comment>
         <translation>切换到深色主题</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="343"/>
         <source>Show the chats</source>
         <comment>WebTweaks</comment>
         <translation>显示聊天</translation>
     </message>
     <message>
+        <location filename="../webtweaks.cpp" line="344"/>
         <source>Blur the chats</source>
         <comment>WebTweaks</comment>
         <translation>模糊聊天</translation>
@@ -898,42 +1123,53 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>RateApp</name>
     <message>
+        <location filename="../rateapp.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="43"/>
         <source>Rate this app</source>
         <translation>为此应用评分</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;如果您喜欢这款应用，能否花点时间为它评分？&lt;/p&gt;&lt;p&gt;用不了一分钟。感谢您的支持！&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="73"/>
         <source>  Rate in Store</source>
         <translation>  在商店中评分</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
         <source>Or</source>
         <translation>或</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="119"/>
         <source>Star rate Github repo</source>
         <translation>为 GitHub 仓库点星</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="130"/>
         <source>Donate via PayPal </source>
         <translation>通过 PayPal 捐赠 </translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="176"/>
         <source>Donate via OpenCollective</source>
         <translation>通过 OpenCollective 捐赠</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="187"/>
         <source>Later</source>
         <translation>稍后</translation>
     </message>
     <message>
+        <location filename="../rateapp.ui" line="210"/>
         <source>  Already Done  </source>
         <translation>  已完成  </translation>
     </message>
@@ -941,34 +1177,42 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessages</name>
     <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
         <source>Timed out waiting for the message to send</source>
         <translation>等待消息发送超时</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
         <source>Daily</source>
         <translation>每天</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
         <source>Weekdays</source>
         <translation>工作日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
         <source>Weekly</source>
         <translation>每周</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
         <source>Once</source>
         <translation>一次</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
         <source>Sent</source>
         <translation>已发送</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
         <source>Failed</source>
         <translation>失败</translation>
     </message>
     <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
         <source>Pending</source>
         <translation>待处理</translation>
     </message>
@@ -976,90 +1220,117 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>ScheduledMessagesDialog</name>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
         <source>Scheduled messages</source>
         <translation>定时消息</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
         <source>To</source>
         <translation>收件人</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
         <source>When</source>
         <translation>时间</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
         <source>Message</source>
         <translation>消息</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
         <source>Phone number, international format e.g. 447700900000</source>
         <translation>国际格式电话号码，例如 447700900000</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
         <source>Optional label</source>
         <translation>可选标签</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
         <source>Once</source>
         <translation>一次</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
         <source>Daily</source>
         <translation>每天</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
         <source>Weekdays</source>
         <translation>工作日</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
         <source>Weekly</source>
         <translation>每周</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
         <source>Repeat</source>
         <translation>重复</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
         <source>Remind me instead of sending (notify, don&apos;t message)</source>
         <translation>提醒我而不是发送（仅通知，不发送消息）</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
         <source>Message to send</source>
         <translation>要发送的消息</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
         <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
         <translation>在计划时间应用必须处于运行状态且 WhatsApp 已登录。如果已关闭，消息将在您下次打开应用时发送。发送会打开收件人的聊天。</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
         <source>Schedule</source>
         <translation>定时</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
         <source>Remove selected</source>
         <translation>删除所选</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
         <source>Clear sent/failed</source>
         <translation>清除已发送/失败</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
         <source>Enter a phone number and a message.</source>
         <translation>请输入电话号码和消息。</translation>
     </message>
     <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
         <source>The time is in the past — send this message now?</source>
         <translation>该时间已过——现在发送这条消息吗？</translation>
     </message>
@@ -1067,894 +1338,1194 @@ Please setup the password in the Settings first.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
+        <location filename="../settingswidget.ui" line="603"/>
         <source>Interface font size</source>
         <translation>界面字体大小</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="613"/>
         <source> pt</source>
         <translation> pt</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="610"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;应用自身界面（菜单、设置和对话框）的磅值大小。这不会影响 WhatsApp Web 的文本；那请使用缩放。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>显示主题</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="629"/>
         <source>Reload automatically after a crash</source>
         <translation>崩溃后自动重新加载</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="626"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;如果 WhatsApp Web 的页面进程崩溃，则自动重新加载，而不是先询问。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="78"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="106"/>
         <source>General settings</source>
         <translation>常规设置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="114"/>
         <source>Widget Style</source>
         <translation>控件样式</translation>
     </message>
     <message>
         <source>Widget Theme</source>
-        <translation>控件主题</translation>
+        <translation type="vanished">控件主题</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="166"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;根据您系统的时区和位置。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1569"/>
+        <location filename="../settingswidget.ui" line="1613"/>
+        <location filename="../settingswidget.ui" line="1682"/>
+        <location filename="../settingswidget.cpp" line="1309"/>
         <source>Automatic</source>
         <translation>自动</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="177"/>
         <source>Dark</source>
         <translation>深色</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="186"/>
         <source>Light</source>
         <translation>浅色</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;跟随桌面的浅色/深色偏好并随之变化。覆盖手动主题和日出/日落自动切换。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="201"/>
         <source>Follow system light/dark theme</source>
         <translation>跟随系统浅色/深色主题</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="238"/>
         <source>Native notification</source>
         <translation>系统通知</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="247"/>
         <source>Customized notification</source>
         <translation>自定义通知</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="265"/>
         <source>  Try</source>
         <translation>  试用</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="276"/>
         <source>Notification type</source>
         <translation>通知类型</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="283"/>
         <source>Disable Notifications Popup</source>
         <translation>禁用通知弹窗</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="290"/>
         <source>Popup timeout</source>
         <translation>弹窗显示时长</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1152"/>
         <source> Secs</source>
         <translation> 秒</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="310"/>
         <source>Notification delivery</source>
         <translation>通知投递方式</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="317"/>
         <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
         <translation>在 Linux 上发送原生通知的方式。“自动”在 Flatpak 沙箱内使用桌面门户，否则使用系统服务。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="324"/>
         <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
         <translation>在每日的免打扰时段内隐藏通知弹窗。未读标记仍会更新，仅弹窗被暂停显示。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="327"/>
         <source>Do Not Disturb</source>
         <translation>勿扰模式</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="336"/>
         <source>From</source>
         <translation>从</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
         <source>HH:mm</source>
         <translation>HH:mm</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="350"/>
         <source>to</source>
         <translation>到</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="379"/>
         <source>Highlight keywords</source>
         <translation>高亮关键词</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="386"/>
         <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
         <translation>以逗号分隔的词语，即使在勿扰模式下也始终发出通知（不区分大小写）。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="389"/>
         <source>e.g. urgent, boss, invoice</source>
         <translation>例如：紧急、老板、发票</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="425"/>
         <source>Use Native File Dialog</source>
         <translation>使用系统文件对话框</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="432"/>
         <source>Mute Audio from Page</source>
         <translation>静音页面音频</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="439"/>
         <source>Disable Auto Playback of Media</source>
         <translation>禁用媒体自动播放</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="446"/>
         <source>Minimize in tray on start</source>
         <translation>启动时最小化到托盘</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="453"/>
         <source>Show/Hide on clicking tray Icon (if supported)</source>
         <translation>点击托盘图标时显示/隐藏（如果支持）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="460"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;点击其他位置时关闭表情、GIF 和贴纸面板。否则 WhatsApp Web 会保持其打开，直到再次按下按钮。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="463"/>
         <source>Close emoji/sticker panel when clicking outside</source>
         <translation>点击面板外部时关闭表情/贴纸面板</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="470"/>
         <source>Interface language</source>
         <translation>界面语言</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whatly 自身界面的语言。重启应用后生效。聊天本身的语言来自 WhatsApp Web，无法在此更改。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在 WhatsApp 侧边栏你的头像正上方添加一个明/暗按钮。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="487"/>
         <source>Theme button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp 侧边栏中的主题按钮</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="494"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在 WhatsApp 侧边栏添加一个按钮，一键模糊或显示你的聊天，无需打开设置。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="497"/>
         <source>Blur button in WhatsApp&apos;s sidebar</source>
         <translation>WhatsApp 侧边栏中的模糊按钮</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="504"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;使用与面板其余部分一致的单色托盘图标，而非绿色的 WhatsApp 图标。WhatsApp 未连接时图标还会变暗。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="507"/>
         <source>Monochrome tray icon</source>
         <translation>单色托盘图标</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;让滚动带有动画效果，而不是逐行跳动。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="517"/>
         <source>Smooth scrolling</source>
         <translation>平滑滚动</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <location filename="../settingswidget.cpp" line="1112"/>
         <source>Custom CSS</source>
         <translation>自定义 CSS</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="533"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;加载 .css 文件以重新设计 WhatsApp Web —— 社区样式表（如 catppuccin 等）可在此使用。应用在聊天主题之上。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="536"/>
         <source>Choose file…</source>
         <translation>选择文件…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="543"/>
+        <location filename="../settingswidget.ui" line="683"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="552"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;完全移除系统托盘图标。没有可恢复的托盘时，关闭窗口将退出应用而不是隐藏它。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="555"/>
         <source>Hide tray icon</source>
         <translation>隐藏托盘图标</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="562"/>
         <source>Font family</source>
         <translation>字体</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;使用系统中安装的字体显示 WhatsApp Web 的文字。表情符号、图标和等宽消息格式保持不变。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="576"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;隐藏&quot;状态/动态&quot;面板中的&quot;已静音的更新&quot;部分，这样被你静音的联系人的状态将完全不显示。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="579"/>
         <source>Hide muted status updates</source>
         <translation>隐藏已静音的状态更新</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="586"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在你输入时为拼写错误的词加下划线，并在右键菜单中提供更正建议。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <location filename="../settingswidget.cpp" line="1555"/>
         <source>Check spelling as I type</source>
         <translation>输入时检查拼写</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="596"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;用于检查的语言。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="636"/>
         <source>Privacy blur</source>
         <translation>隐私模糊</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="643"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在你悬停之前一直模糊你的聊天，这样瞥一眼屏幕的人无法阅读。悬停某一行只会显示该行。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Chat theme</source>
-        <translation>聊天主题</translation>
+        <translation type="vanished">聊天主题</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="650"/>
+        <source>Chat colour Tint</source>
+        <translation>聊天色调</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="657"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;重新为 WhatsApp Web 本身上色。照片、头像和贴纸保留原有颜色。可在当前启用的浅色或深色主题之上运行。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="664"/>
+        <location filename="../settingswidget.cpp" line="1088"/>
         <source>Chat wallpaper</source>
         <translation>聊天壁纸</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="673"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;像 WhatsApp 在 Android 上那样，使用你自己的图片作为聊天窗格的背景。图片存储在 Whatly 内部，不会上传到任何地方，仅你可见。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="676"/>
         <source>Choose image…</source>
         <translation>选择图片…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="692"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;新登录将在您手机的已关联设备列表中显示为“Whatly for Linux”（或对应平台），而不是“Google Chrome (Linux)”。该名称在关联设备时保存到手机上，因此更改此项仅影响以后的关联——若要重命名现有会话，请退出登录并重新关联。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="695"/>
         <source>Identify as Whatly in linked devices</source>
         <translation>在已关联设备中标识为 Whatly</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="709"/>
         <source>User Agent</source>
         <translation>用户代理</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;高级 — 除非你完全清楚自己在做什么，否则请勿改动此项。非标准的 user agent 可能导致 WhatsApp 无法加载，异常的取值有可能使你的 WhatsApp 账号被标记或列入黑名单。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="722"/>
         <source>  Set</source>
         <translation>  应用</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="733"/>
         <source>Reset to default</source>
         <translation>重置为默认值</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="756"/>
         <source>Zoom factor when normal</source>
         <translation>普通窗口下的缩放比例</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="784"/>
+        <location filename="../settingswidget.ui" line="919"/>
         <source>Zoom Out</source>
         <translation>缩小</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="823"/>
+        <location filename="../settingswidget.ui" line="958"/>
         <source>Zoom In</source>
         <translation>放大</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="868"/>
+        <location filename="../settingswidget.ui" line="1003"/>
         <source>reset</source>
         <translation>重置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="891"/>
         <source>Zoom factor when maximized/fullscreen</source>
         <translation>最大化/全屏下的缩放比例</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1026"/>
         <source>Minimize to tray</source>
         <translation>最小化到托盘</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1035"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1047"/>
         <source>Global shortcuts</source>
         <translation>全局快捷键</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1054"/>
         <source>Close button action</source>
         <translation>关闭按钮的行为</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1061"/>
         <source>  Show shortcuts</source>
         <translation>  显示快捷键</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1072"/>
         <source>Permissions</source>
         <translation>权限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1079"/>
         <source>  Show permissions</source>
         <translation>  显示权限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1094"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;启用锁定屏幕。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1097"/>
         <source>Enable App lock on start</source>
         <translation>启动时启用应用锁</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1104"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;当窗口隐藏到系统托盘时，用密码锁定。需要已设置密码。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1107"/>
         <source>Lock when hidden to tray</source>
         <translation>隐藏到托盘时锁定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1114"/>
         <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
         <translation>桌面会话锁定时也锁定 Whatly。需要先设置密码。(Linux)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1117"/>
         <source>Lock when the screen locks</source>
         <translation>屏幕锁定时锁定</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1124"/>
         <source>Current Password</source>
         <translation>当前密码</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1131"/>
+        <location filename="../settingswidget.ui" line="1165"/>
         <source>Change password</source>
         <translation>更改密码</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <location filename="../settingswidget.ui" line="1243"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1145"/>
         <source>Enable auto locking after</source>
         <translation>启用自动锁定，延迟</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1168"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1200"/>
         <source>View password</source>
         <translation>查看密码</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1227"/>
         <source>Default Download location</source>
         <translation>默认下载位置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1240"/>
         <source>Change Download Location</source>
         <translation>更改下载位置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1259"/>
         <source>Storage </source>
         <translation>存储 </translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1279"/>
         <source>Property</source>
         <translation>属性</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1286"/>
         <source>  Clear (requires restart)</source>
         <translation>  清除（需要重启）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1297"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;持久化数据包括持久化 Cookie、HTML5 本地存储和访问过的链接。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1300"/>
         <source>Persistent data</source>
         <translation>持久化数据</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1307"/>
+        <location filename="../settingswidget.ui" line="1327"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1317"/>
         <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
         <translation>HTTP/媒体缓存。清除它是安全的 — 需要时会重新下载。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1320"/>
         <source>Cache</source>
         <translation>缓存</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1337"/>
         <source>  Clear cache</source>
         <translation>  清除缓存</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1360"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1382"/>
         <source>Action</source>
         <translation>操作</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1396"/>
         <source>Backup</source>
         <translation>备份</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1403"/>
         <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
         <translation>将此账户（设置、会话和附加组件）保存到 .tar.gz 归档文件。该归档文件包含你已登录的会话 — 请妥善保管。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1406"/>
         <source>Export profile…</source>
         <translation>导出配置文件…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1413"/>
         <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
         <translation>从 .tar.gz 归档文件恢复账户。此操作会覆盖当前数据，并需要重新启动。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1416"/>
         <source>Import profile…</source>
         <translation>导入配置文件…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1441"/>
         <source>Performance &amp; Privacy</source>
         <translation>性能与隐私</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1447"/>
         <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
         <translation>微调渲染引擎。默认设置在大多数系统上都是安全的；如果窗口空白、应用启动时崩溃或出现卡顿，可尝试更改这些设置。更改将在重启后生效。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1457"/>
         <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
         <translation>完全在 CPU 上渲染（--disable-gpu）。可修复某些 GPU/驱动配置下的空白窗口和启动崩溃。Linux 上的默认设置。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1460"/>
         <source>Disable GPU acceleration</source>
         <translation>禁用 GPU 加速</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1467"/>
         <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
         <translation>在 CPU 上合成页面（--disable-gpu-compositing）。可避免某些驱动上的残帧闪烁。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1470"/>
         <source>Disable GPU compositing</source>
         <translation>禁用 GPU 合成</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1477"/>
         <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
         <translation>禁用 GPU 垂直同步（--disable-gpu-vsync）。可减少输入延迟，但可能出现画面撕裂。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1480"/>
         <source>Disable GPU VSync</source>
         <translation>禁用 GPU 垂直同步</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1487"/>
         <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
         <translation>在主进程内运行 GPU 进程（--in-process-gpu）。用于解决某些沙盒环境的临时方案。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1490"/>
         <source>Run GPU in-process</source>
         <translation>在进程内运行 GPU</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1497"/>
         <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
         <translation>即使驱动被列入黑名单也强制启用加速（--ignore-gpu-blocklist）。可尝试此项重新启用 GPU。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1500"/>
         <source>Ignore GPU blocklist</source>
         <translation>忽略 GPU 黑名单</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1507"/>
         <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
         <translation>在单个进程中运行所有内容（--single-process）。占用内存更少，但稳定性较差。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1510"/>
         <source>Single-process mode (lower memory)</source>
         <translation>单进程模式（更低内存）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1517"/>
         <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
         <translation>每个站点共用一个渲染进程（--process-per-site）。可降低内存占用。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1520"/>
         <source>One process per site (lower memory)</source>
         <translation>每个站点一个进程（更低内存）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1527"/>
         <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
         <translation>隐藏聊天列表中的联系人姓名和消息预览（悬停可显示其中一条）。共享屏幕时很有用。已打开的对话不受影响。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1530"/>
         <source>Focus mode (hide chat-list previews)</source>
         <translation>专注模式（隐藏聊天列表预览）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1537"/>
         <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
         <translation>在媒体编辑器中默认将照片和视频设为 HD 画质。此功能依赖于 WhatsApp Web 的布局；如果某次 WhatsApp 更新导致其失效，请将其关闭。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1540"/>
         <source>Send photos and videos in HD by default</source>
         <translation>默认以 HD 发送照片和视频</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1547"/>
         <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
         <translation>阻止 WebRTC 通过非代理连接暴露您的本地 IP 地址。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1550"/>
         <source>Prevent WebRTC IP leak</source>
         <translation>防止 WebRTC IP 泄露</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1559"/>
         <source>JavaScript memory limit</source>
         <translation>JavaScript 内存限制</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1566"/>
         <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
         <translation>限制 JavaScript 堆大小（V8 --max-old-space-size）。0 = 自动。如果应用占用过多 RAM，请调低此值。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1572"/>
+        <location filename="../settingswidget.ui" line="1616"/>
         <source> MB</source>
         <translation> MB</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1589"/>
         <source>HTTP cache</source>
         <translation>HTTP 缓存</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1596"/>
         <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
         <translation>HTTP 缓存的存放位置。内存缓存会在退出时清除；“无”则禁用缓存。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1603"/>
         <source>Max size</source>
         <translation>最大大小</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1610"/>
         <source>Maximum on-disk cache size. 0 = automatic.</source>
         <translation>磁盘缓存的最大大小。0 = 自动。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1634"/>
         <source>Network &amp; Startup</source>
         <translation>网络与启动</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1640"/>
         <source>Launch Whatly automatically when you log in to your desktop session.</source>
         <translation>登录桌面会话时自动启动 Whatly。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1643"/>
         <source>Start Whatly when I log in</source>
         <translation>登录时启动 Whatly</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1650"/>
         <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
         <translation>用 Whatly 自带的纤薄标题栏替换系统窗口边框。重启后生效。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1653"/>
         <source>Use a custom window frame (requires restart)</source>
         <translation>使用自定义窗口边框（需要重启）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1660"/>
         <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
         <translation>每天检查一次 GitHub 是否有新版本并通知你。Whatly 绝不会自行下载或安装任何内容。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1663"/>
         <source>Check for updates automatically</source>
         <translation>自动检查更新</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1672"/>
         <source>Interface scale</source>
         <translation>界面缩放</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1679"/>
         <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
         <translation>缩放整个窗口和页面（QT_SCALE_FACTOR）。自动则跟随桌面设置。若已设置 QT_SCALE_FACTOR 环境变量，则以其为准。重启后生效。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1715"/>
         <source>Proxy</source>
         <translation>代理</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1722"/>
         <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
         <translation>Whatly 连接网络的方式。系统跟随操作系统设置；无则直接连接。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1747"/>
         <source>Host</source>
         <translation>主机</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1754"/>
         <source>127.0.0.1</source>
         <translation>127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1761"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1775"/>
         <source>Username</source>
         <translation>用户名</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1782"/>
+        <location filename="../settingswidget.ui" line="1799"/>
         <source>Optional</source>
         <translation>可选</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1789"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1812"/>
         <source>Custom JavaScript addons</source>
         <translation>自定义 JavaScript 插件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1818"/>
         <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
         <translation>加载 .js 文件以在 WhatsApp Web 上运行。每个插件都在各自的沙箱中运行，因此某个插件出错不会影响其他插件或页面。取消勾选可停用插件而无需将其移除。更改将在重启后生效。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1840"/>
         <source>Add addon…</source>
         <translation>添加插件…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1847"/>
+        <location filename="../settingswidget.ui" line="1907"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1872"/>
         <source>Saved replies</source>
         <translation>已保存的回复</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1878"/>
         <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
         <translation>你经常发送的简短文本。可从命令面板 (Ctrl+K) 插入 — 输入 &quot;插入&quot; 并选择，文本会被输入到消息框中。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1900"/>
         <source>Add reply…</source>
         <translation>添加回复…</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1932"/>
         <source>Keyboard shortcuts</source>
         <translation>键盘快捷键</translation>
     </message>
     <message>
+        <location filename="../settingswidget.ui" line="1938"/>
         <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
         <translation>点击某个字段并按下组合键。清空字段可移除该快捷键。更改将在重启后生效。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="762"/>
         <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
         <translation>这将删除持久数据（包括持久 Cookie 和缓存）并退出应用程序。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="767"/>
         <source>Delete Cookies and Quit Application?</source>
         <translation>删除 Cookie 并退出应用程序？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="869"/>
         <source>| Error</source>
         <translation>| 错误</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="870"/>
         <source>Cannot set an empty UserAgent String.</source>
         <translation>无法设置空的 User-Agent 字符串。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="921"/>
         <source>Automatic theme switching was disabled due to manual theme toggle.</source>
         <translation>由于手动切换了主题，自动主题切换已被禁用。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="960"/>
         <source>App lock is not configured.</source>
         <translation>未配置应用锁。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="964"/>
         <source>Do you want to setup App lock now?</source>
         <translation>现在设置应用锁吗？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1006"/>
         <source>Feature permissions</source>
         <translation>功能权限</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1079"/>
         <source>Choose a chat wallpaper</source>
         <translation>选择聊天壁纸</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1081"/>
         <source>Images (%1)</source>
         <translation>图片 (%1)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1089"/>
         <source>Could not use that image: %1</source>
         <translation>无法使用该图片：%1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1104"/>
         <source>Choose a CSS file</source>
         <translation>选择 CSS 文件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1106"/>
         <source>Stylesheets (*.css);;All files (*)</source>
         <translation>样式表 (*.css);;所有文件 (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1113"/>
         <source>Could not read that file: %1</source>
         <translation>无法读取该文件：%1</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1178"/>
         <source>Disk</source>
         <translation>磁盘</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1179"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1282"/>
         <source>System</source>
         <translation>系统</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1283"/>
         <source>None (direct)</source>
         <translation>无（直接连接）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1284"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1285"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1311"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>桌面门户 (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1313"/>
         <source>System service (libnotify)</source>
         <translation>系统服务 (libnotify)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Add reply</source>
         <translation>添加回复</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1410"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1414"/>
         <source>Text to insert</source>
         <translation>要插入的文本</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1431"/>
         <source>Choose a JavaScript file</source>
         <translation>选择一个 JavaScript 文件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1432"/>
         <source>JavaScript (*.js);;All files (*)</source>
         <translation>JavaScript (*.js);;所有文件 (*)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1437"/>
         <source>Could not add addon</source>
         <translation>无法添加插件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1450"/>
         <source>Remove addon</source>
         <translation>移除插件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1451"/>
         <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
         <translation>移除插件 &quot;%1&quot;？这将删除其文件。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1554"/>
         <source>Spell checker (no dictionaries installed)</source>
         <translation>拼写检查器（未安装词典）</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1180"/>
+        <location filename="../settingswidget.cpp" line="1606"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="396"/>
+        <source>Basics</source>
+        <translation>基本</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="403"/>
+        <source>Appearance</source>
+        <translation>外观</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="418"/>
+        <source>Notifications</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="422"/>
+        <source>Chatting</source>
+        <translation>聊天</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="431"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>隐私与锁定</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="437"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>窗口与缩放</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="445"/>
+        <source>Advanced</source>
+        <translation>高级</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="679"/>
         <source>Shortcut in use</source>
         <translation>快捷键已被占用</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="680"/>
         <source>That shortcut is already used by another action.</source>
         <translation>该快捷键已被另一个操作使用。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="692"/>
         <source>Clear cache</source>
         <translation>清除缓存</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="693"/>
         <source>Clear the cache now? It will be re-downloaded as needed.</source>
         <translation>现在清除缓存吗？需要时会重新下载。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="703"/>
+        <location filename="../settingswidget.cpp" line="709"/>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <location filename="../settingswidget.cpp" line="721"/>
         <source>Export profile</source>
         <translation>导出配置文件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="704"/>
         <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
         <translation>该归档文件将包含你已登录的 WhatsApp 会话。请妥善保管。是否继续？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="711"/>
+        <location filename="../settingswidget.cpp" line="726"/>
         <source>Archives (*.tar.gz)</source>
         <translation>归档文件 (*.tar.gz)</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="719"/>
         <source>Profile exported.</source>
         <translation>配置文件已导出。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="726"/>
+        <location filename="../settingswidget.cpp" line="730"/>
+        <location filename="../settingswidget.cpp" line="738"/>
+        <location filename="../settingswidget.cpp" line="741"/>
         <source>Import profile</source>
         <translation>导入配置文件</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="731"/>
         <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
         <translation>此操作会用归档文件覆盖当前账户的数据，随后必须重新启动 Whatly。是否继续？</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="739"/>
         <source>Profile imported. Please restart Whatly.</source>
         <translation>配置文件已导入。请重新启动 Whatly。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1610"/>
         <source>%1 languages</source>
         <translation>%1 种语言</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1676"/>
         <source>WhatsApp default</source>
         <translation>WhatsApp 默认</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1715"/>
         <source>System default</source>
         <translation>系统默认</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1750"/>
         <source>The interface language will change when you restart %1.</source>
         <translation>重启 %1 后界面语言将会更改。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1764"/>
         <source>App Lock Setup</source>
         <translation>应用锁设置</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1765"/>
         <source>Please setup the App lock password first.</source>
         <translation>请先设置应用锁密码。</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1874"/>
+        <location filename="../settingswidget.cpp" line="1885"/>
         <source>Select download directory</source>
         <translation>选择下载目录</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1925"/>
         <source>You are about to change your current app lock password!
 
 This will LogOut your current session.
@@ -1965,6 +2536,7 @@ You may also require a complete restart of Application!</source>
 您可能还需要完全重启应用程序！</translation>
     </message>
     <message>
+        <location filename="../settingswidget.cpp" line="1931"/>
         <source>Do you want to proceed?</source>
         <translation>要继续吗？</translation>
     </message>
@@ -1972,58 +2544,73 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>SetupWizard</name>
     <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
         <source>Welcome to Whatly</source>
         <translation>欢迎使用 Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="31"/>
         <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
         <translation>一款快速、原生的桌面版 WhatsApp Web 客户端。我们先来做几项设置 — 这些之后都可以在设置中随时更改。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="36"/>
         <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
         <translation>Whatly 将你的聊天放入独立的桌面窗口，并提供托盘图标、通知、主题以及多账户支持。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="46"/>
         <source>A few preferences</source>
         <translation>几项偏好设置</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="47"/>
         <source>Sensible defaults; tweak to taste.</source>
         <translation>合理的默认设置，可按喜好微调。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="50"/>
         <source>Match the system light/dark theme</source>
         <translation>跟随系统浅色/深色主题</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="55"/>
         <source>Start Whatly when I log in</source>
         <translation>登录时启动 Whatly</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="61"/>
         <source>Notification delivery:</source>
         <translation>通知方式：</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="64"/>
         <source>Automatic</source>
         <translation>自动</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="65"/>
         <source>Desktop portal (Flatpak)</source>
         <translation>桌面门户 (Flatpak)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="67"/>
         <source>System service (libnotify)</source>
         <translation>系统服务 (libnotify)</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="77"/>
         <source>All set</source>
         <translation>全部就绪</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="78"/>
         <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
         <translation>一切准备就绪。用手机扫描 QR 码即可登录。</translation>
     </message>
     <message>
+        <location filename="../setupwizard.cpp" line="82"/>
         <source>Everything here lives in Settings if you change your mind.</source>
         <translation>如果你改变主意，这里的所有设置都可以在设置中找到。</translation>
     </message>
@@ -2031,6 +2618,7 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>UpdateChecker</name>
     <message>
+        <location filename="../updatechecker.cpp" line="111"/>
         <source>Could not read the latest release</source>
         <translation>无法读取最新版本</translation>
     </message>
@@ -2038,82 +2626,104 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebEnginePage</name>
     <message>
+        <location filename="../webenginepage.cpp" line="51"/>
         <source>Share your screen</source>
         <translation>共享您的屏幕</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="53"/>
         <source>Choose what to share:</source>
         <translation>选择要共享的内容：</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="65"/>
         <source>Untitled</source>
         <translation>无标题</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="69"/>
         <source>Screen: </source>
         <translation>屏幕：</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="70"/>
         <source>Window: </source>
         <translation>窗口：</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="149"/>
         <source>Allow %1 to access your location information?</source>
         <translation>允许 %1 访问您的位置信息吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="151"/>
         <source>Allow %1 to access your microphone?</source>
         <translation>允许 %1 访问您的麦克风吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="153"/>
         <source>Allow %1 to access your webcam?</source>
         <translation>允许 %1 访问您的摄像头吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="155"/>
         <source>Allow %1 to access your microphone and webcam?</source>
         <translation>允许 %1 访问您的麦克风和摄像头吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="157"/>
         <source>Allow %1 to lock your mouse cursor?</source>
         <translation>允许 %1 锁定您的鼠标指针吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="159"/>
         <source>Allow %1 to capture video of your desktop?</source>
         <translation>允许 %1 录制您桌面的视频吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="161"/>
         <source>Allow %1 to capture audio and video of your desktop?</source>
         <translation>允许 %1 录制您桌面的音频和视频吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="164"/>
         <source>Allow %1 to show notification on your desktop?</source>
         <translation>允许 %1 在您的桌面上显示通知吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="166"/>
         <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
         <translation>允许 %1 读取您的剪贴板吗？将图片粘贴到聊天中需要此权限。</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="169"/>
         <source>Allow %1 to see the fonts installed on your system?</source>
         <translation>允许 %1 查看您系统中已安装的字体吗？</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
         <source>Permission Request</source>
         <translation>权限请求</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
         <source>Certificate Error</source>
         <translation>证书错误</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="355"/>
         <source>Enter username and password for &quot;%1&quot; at %2</source>
         <translation>请输入 %2 上“%1”的用户名和密码</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="385"/>
         <source>Connect to proxy &quot;%1&quot; using:</source>
         <translation>使用以下方式连接到代理“%1”：</translation>
     </message>
     <message>
+        <location filename="../webenginepage.cpp" line="404"/>
         <source>Allow %1 to open all %2 links?</source>
         <translation>允许 %1 打开所有 %2 链接吗？</translation>
     </message>
@@ -2121,22 +2731,27 @@ You may also require a complete restart of Application!</source>
 <context>
     <name>WebView</name>
     <message>
+        <location filename="../webview.cpp" line="37"/>
         <source>Render process normal exit</source>
         <translation>渲染进程正常退出</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="40"/>
         <source>Render process abnormal exit</source>
         <translation>渲染进程异常退出</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="43"/>
         <source>Render process crashed</source>
         <translation>渲染进程已崩溃</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="46"/>
         <source>Render process killed</source>
         <translation>渲染进程已被终止</translation>
     </message>
     <message>
+        <location filename="../webview.cpp" line="69"/>
         <source>Render process exited with code: %1
 Do you want to reload the page ?</source>
         <translation>渲染进程退出，代码：%1

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -18,6 +18,13 @@
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QCheckBox>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGroupBox>
+#include <QScrollBar>
+#include <QTimer>
+#include <QPropertyAnimation>
 
 #include "automatictheme.h"
 #include "chattheme.h"
@@ -74,6 +81,13 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                                QString enginePersistentStoragePath)
     : QWidget(parent), ui(new Ui::SettingsWidget) {
   ui->setupUi(this);
+
+#ifdef Q_OS_WIN
+  // The Qt "widget style" chooser is a Linux desktop-theming nicety; on Windows
+  // the native style is expected, so the control is hidden there.
+  ui->label_8->hide();
+  ui->styleComboBox->hide();
+#endif
 
   this->engineCachePath = engineCachePath;
   this->enginePersistentStoragePath = enginePersistentStoragePath;
@@ -222,14 +236,14 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           .settings()
           .value("minimizeOnTrayIconClick", false)
           .toBool());
-  ui->defaultDownloadLocation->setText(
+  ui->defaultDownloadLocation->setText(QDir::toNativeSeparators(
       SettingsManager::instance()
           .settings()
           .value("defaultDownloadLocation",
                  QStandardPaths::writableLocation(
                      QStandardPaths::DownloadLocation) +
-                     QDir::separator() + QApplication::applicationDisplayName())
-          .toString());
+                     QLatin1Char('/') + QApplication::applicationDisplayName())
+          .toString()));
 
   ui->styleComboBox->blockSignals(true);
   ui->styleComboBox->addItems(QStyleFactory::keys());
@@ -296,6 +310,251 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     if (!screenRect.contains(this->pos())) {
       this->move(screenRect.center() - this->rect().center());
     }
+  }
+
+  // ── Re-section "General settings" + collapsible accordion ───────────────────
+  // The single "General settings" group had grown overwhelming, so its controls
+  // are redistributed into themed sub-sections. Every sub-section — and each
+  // pre-existing group below it — becomes a collapsible row with an arrow header
+  // (▸ collapsed / ▾ open); toggling hides/shows the WHOLE group as one widget,
+  // so a collapsed section shrinks to just its header instead of an empty box.
+  // Only the first row is open on launch.
+  if (auto *outer =
+          qobject_cast<QVBoxLayout *>(ui->scrollAreaWidgetContents->layout())) {
+    QWidget *host = ui->scrollAreaWidgetContents;
+
+    // An empty titled sub-section, ready to receive controls.
+    const auto newSection = [host](const QString &title) {
+      auto *g = new QGroupBox(title, host);
+      auto *v = new QVBoxLayout(g);
+      v->setContentsMargins(12, 6, 6, 6);
+      v->setSpacing(6);
+      return g;
+    };
+    const auto body = [](QGroupBox *g) {
+      return qobject_cast<QVBoxLayout *>(g->layout());
+    };
+    // Move a whole nested layout, detaching it from its current parent layout.
+    const auto moveLayout = [](QVBoxLayout *dst, QLayout *inner) {
+      if (!dst || !inner)
+        return;
+      if (auto *p = qobject_cast<QLayout *>(inner->parent()))
+        p->removeItem(inner);
+      dst->addLayout(inner);
+    };
+    // Move one control (detached from its source layout) onto its own row.
+    const auto moveWidget = [](QVBoxLayout *dst, QWidget *w, QLayout *src) {
+      if (!dst || !w)
+        return;
+      if (src)
+        src->removeWidget(w);
+      dst->addWidget(w);
+    };
+    // Move a label + field pair onto a single row.
+    const auto moveRow = [](QVBoxLayout *dst, QWidget *a, QWidget *b,
+                            QLayout *src) {
+      if (!dst)
+        return;
+      auto *h = new QHBoxLayout;
+      h->setContentsMargins(0, 0, 0, 0);
+      if (a) {
+        if (src)
+          src->removeWidget(a);
+        h->addWidget(a);
+      }
+      if (b) {
+        if (src)
+          src->removeWidget(b);
+        h->addWidget(b, 1);
+      }
+      dst->addLayout(h);
+    };
+    // Move a label + a nested control-layout pair onto a single row.
+    const auto moveRowL = [](QVBoxLayout *dst, QWidget *a, QLayout *sub,
+                             QLayout *srcOfA) {
+      if (!dst)
+        return;
+      auto *h = new QHBoxLayout;
+      h->setContentsMargins(0, 0, 0, 0);
+      if (a) {
+        if (srcOfA)
+          srcOfA->removeWidget(a);
+        h->addWidget(a);
+      }
+      if (sub) {
+        if (auto *p = qobject_cast<QLayout *>(sub->parent()))
+          p->removeItem(sub);
+        h->addLayout(sub, 1);
+      }
+      dst->addLayout(h);
+    };
+
+    QLayout *G = ui->gridLayout;    // the old loose grab-bag grid
+    QLayout *G6 = ui->gridLayout_6; // close-button / shortcuts / permissions
+
+    // ── Basics ──────────────────────────────────────────────
+    auto *basics = newSection(tr("Basics"));
+    moveRow(body(basics), ui->languageLabel, ui->languageComboBox, G);
+    moveLayout(body(basics), ui->gridLayout_7); // default download location
+    moveWidget(body(basics), ui->useNativeFileDialog, G);
+    moveWidget(body(basics), ui->identifyInLinkedDevicesCheckBox, G);
+
+    // ── Appearance ──────────────────────────────────────────
+    auto *appearance = newSection(tr("Appearance"));
+    moveLayout(body(appearance), ui->gridLayout_5);     // display theme block
+    moveLayout(body(appearance), ui->horizontalLayout); // widget style (Linux)
+    moveRow(body(appearance), ui->chatThemeLabel, ui->chatThemeComboBox, G);
+    moveRowL(body(appearance), ui->chatWallpaperLabel, ui->chatWallpaperLayout,
+             G);
+    moveRow(body(appearance), ui->fontFamilyLabel, ui->fontFamilyComboBox, G);
+    moveRow(body(appearance), ui->interfaceFontSizeLabel,
+            ui->interfaceFontSizeSpinBox, G);
+    moveRowL(body(appearance), ui->customCssLabel, ui->customCssLayout, G);
+    moveWidget(body(appearance), ui->themeToggleButtonCheckBox, G);
+    moveWidget(body(appearance), ui->smoothScrollingCheckBox, G);
+    moveWidget(body(appearance), ui->monochromeTrayIconCheckBox, G);
+
+    // ── Notifications ───────────────────────────────────────
+    auto *notifications = newSection(tr("Notifications"));
+    moveLayout(body(notifications), ui->gridLayout_8); // whole notice block
+
+    // ── Chatting ────────────────────────────────────────────
+    auto *chatting = newSection(tr("Chatting"));
+    moveRow(body(chatting), ui->spellCheckCheckBox,
+            ui->spellCheckLanguageComboBox, G);
+    moveWidget(body(chatting), ui->muteAudioCheckBox, G);
+    moveWidget(body(chatting), ui->autoPlayMediaCheckBox, G);
+    moveWidget(body(chatting), ui->dismissEmojiPanelCheckBox, G);
+    moveWidget(body(chatting), ui->hideMutedStatusCheckBox, G);
+
+    // ── Privacy & Lock ──────────────────────────────────────
+    auto *privacy = newSection(tr("Privacy & Lock"));
+    moveRow(body(privacy), ui->privacyBlurLabel, ui->privacyBlurComboBox, G);
+    moveWidget(body(privacy), ui->privacyBlurButtonCheckBox, G);
+    moveLayout(body(privacy), ui->gridLayout_3); // app-lock block
+
+    // ── Window & zoom ───────────────────────────────────────
+    auto *window = newSection(tr("Window && zoom"));
+    moveRow(body(window), ui->label, ui->closeButtonActionComboBox, G6);
+    moveWidget(body(window), ui->startMinimized, G);
+    moveWidget(body(window), ui->minimizeOnTrayIconClick, G);
+    moveWidget(body(window), ui->hideTrayIconCheckBox, G);
+    moveLayout(body(window), ui->gridLayout_9); // zoom block
+
+    // ── Advanced ────────────────────────────────────────────
+    auto *advanced = newSection(tr("Advanced"));
+    moveLayout(body(advanced), ui->horizontalLayout_3); // user agent
+    moveWidget(body(advanced), ui->autoRestartCheckBox, G);
+    moveRow(body(advanced), ui->label_9, ui->showShortcutsButton, G6);
+    moveRow(body(advanced), ui->label_10, ui->showPermissionsButton, G6);
+
+    // The emptied "General settings" shell (and its leftover separator lines)
+    // are no longer needed; the arrow headers separate the sections now.
+    outer->removeWidget(ui->groupBox_8);
+    delete ui->groupBox_8;
+
+    // Place the everyday sub-sections above the pre-existing groups, in reading
+    // order; "Advanced" is pushed to the very bottom of the whole list.
+    outer->insertWidget(0, basics);
+    outer->insertWidget(1, appearance);
+    outer->insertWidget(2, notifications);
+    outer->insertWidget(3, chatting);
+    outer->insertWidget(4, privacy);
+    outer->insertWidget(5, window);
+    outer->addWidget(advanced);
+
+    QScrollArea *scrollArea = ui->scrollArea;
+    const auto makeCollapsible = [outer, scrollArea](QGroupBox *box,
+                                                     bool open) {
+      if (!box)
+        return;
+      const int idx = outer->indexOf(box);
+      if (idx < 0)
+        return;
+      delete outer->takeAt(idx); // detach the bare group from the column
+
+      auto *section = new QWidget(box->parentWidget());
+      auto *sv = new QVBoxLayout(section);
+      sv->setContentsMargins(0, 0, 0, 0);
+      sv->setSpacing(0);
+
+      auto *header = new QToolButton(section);
+      header->setText(box->title());
+      header->setCheckable(true);
+      header->setChecked(open);
+      header->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+      header->setArrowType(open ? Qt::DownArrow : Qt::RightArrow);
+      header->setAutoRaise(true);
+      header->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+      header->setStyleSheet("QToolButton { border: none; font-weight: bold; "
+                            "text-align: left; padding: 3px 6px; }");
+
+      box->setTitle(QString()); // the header shows the title now
+      box->setStyleSheet("QGroupBox { border: none; margin-top: 0px; }");
+      box->setVisible(open);
+
+      QObject::connect(
+          header, &QToolButton::toggled, box,
+          [box, header, section, scrollArea](bool on) {
+            box->setVisible(on);
+            header->setArrowType(on ? Qt::DownArrow : Qt::RightArrow);
+            if (!on || !scrollArea)
+              return;
+            // Newly revealed content may extend past the bottom of the window;
+            // nudge the view down just enough to bring this section's last item
+            // back on screen (never scrolls up).
+            QTimer::singleShot(0, scrollArea, [scrollArea, section]() {
+              QWidget *content = scrollArea->widget();
+              if (!content)
+                return;
+              if (QLayout *l = content->layout())
+                l->activate(); // settle geometry before measuring
+              const int sectionBottom =
+                  section->mapTo(content, QPoint(0, section->height())).y();
+              QScrollBar *vsb = scrollArea->verticalScrollBar();
+              const int need = sectionBottom - scrollArea->viewport()->height();
+              if (need <= vsb->value())
+                return;
+              // Ease the scroll over ~1.5 s (reusing one animation per scrollbar
+              // so rapid toggles don't fight) so the jump is easy to follow
+              // rather than an instant snap.
+              auto *anim = vsb->findChild<QPropertyAnimation *>();
+              if (!anim) {
+                anim = new QPropertyAnimation(vsb, "value", vsb);
+                anim->setEasingCurve(QEasingCurve::InOutCubic);
+              }
+              anim->stop();
+              anim->setDuration(1500);
+              anim->setStartValue(vsb->value());
+              anim->setEndValue(qMin(need, vsb->maximum()));
+              anim->start();
+            });
+          });
+
+      sv->addWidget(header);
+      sv->addWidget(box); // reparents the group into the section
+      outer->insertWidget(idx, section);
+    };
+
+    makeCollapsible(basics, true); // open on launch
+    makeCollapsible(appearance, false);
+    makeCollapsible(notifications, false);
+    makeCollapsible(chatting, false);
+    makeCollapsible(privacy, false);
+    makeCollapsible(window, false);
+    makeCollapsible(advanced, false);
+    makeCollapsible(ui->groupBox_7, false);          // Storage
+    makeCollapsible(ui->groupBoxPerformance, false); // Performance & Privacy
+    makeCollapsible(ui->groupBoxNetwork, false);     // Network & Startup
+    makeCollapsible(ui->groupBoxJsAddons, false);    // JS Addons
+    makeCollapsible(ui->groupBoxCanned, false);      // Canned responses
+    makeCollapsible(ui->groupBoxShortcuts, false);   // Shortcuts
+
+    // Stack the section headers directly beneath one another with about one
+    // character of breathing room, instead of letting the column stretch them
+    // apart to fill the window height.
+    outer->setSpacing(this->fontMetrics().averageCharWidth());
+    outer->addStretch(1);
   }
 }
 
@@ -1310,11 +1569,12 @@ void SettingsWidget::populateSpellCheck() {
   }
   auto *model = new QStandardItemModel(combo);
   for (const QString &dictionary : available) {
-    // "es_ES" reads better as "Español (España)".
+    // Build from the language alone so "es_ES" reads "Español", not "Español
+    // de España" — the code in parentheses already disambiguates the territory.
     const QLocale locale(dictionary);
     const QString name = locale.language() == QLocale::C
                              ? dictionary
-                             : locale.nativeLanguageName() +
+                             : QLocale(locale.language()).nativeLanguageName() +
                                    QStringLiteral(" (") + dictionary +
                                    QStringLiteral(")");
     auto *item = new QStandardItem(name);
@@ -1326,8 +1586,7 @@ void SettingsWidget::populateSpellCheck() {
   }
   combo->setModel(model);
   connect(model, &QStandardItemModel::itemChanged, this,
-          [this](QStandardItem *) { saveSpellCheckLanguages(); },
-          Qt::UniqueConnection);
+          [this](QStandardItem *) { saveSpellCheckLanguages(); });
   // The view's items are toggled by a click that must not dismiss the popup.
   if (combo->view() && !combo->view()->viewport()->property("whatlyFilter").toBool()) {
     combo->view()->viewport()->installEventFilter(this);
@@ -1461,8 +1720,10 @@ void SettingsWidget::populateLanguages() {
     const QString code = file.completeBaseName(); // e.g. es_ES
     const QLocale locale(code);
     // Name the language in itself — an Italian speaker looks for "Italiano",
-    // not for whatever the current interface language calls it.
-    QString label = locale.nativeLanguageName();
+    // not for whatever the current interface language calls it. Build from the
+    // language alone (not the full locale) so it reads "Español", not "Español
+    // de España" — the code in parentheses already disambiguates the territory.
+    QString label = QLocale(locale.language()).nativeLanguageName();
     if (label.isEmpty())
       label = code;
     else

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -150,7 +150,7 @@ background:transparent;
             <item row="0" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>Widget Theme</string>
+               <string>Display theme</string>
               </property>
              </widget>
             </item>
@@ -647,7 +647,7 @@ background:transparent;
             <item row="8" column="0">
              <widget class="QLabel" name="chatThemeLabel">
               <property name="text">
-               <string>Chat theme</string>
+               <string>Chat colour Tint</string>
               </property>
              </widget>
             </item>
@@ -702,8 +702,14 @@ background:transparent;
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
              <widget class="QLabel" name="label_4">
+              <property name="styleSheet">
+               <string notr="true">color: #c0392b; font-weight: bold;</string>
+              </property>
               <property name="text">
                <string>User Agent</string>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Reworks the settings window from one long scrolling form into a collapsible accordion, and reorganises the overgrown "General settings" group.

**UI**
- Every section is a collapsible row with an arrow header (▸/▾); only the first is open on launch. Expanding a section near the bottom animates it into view so its last item isn't hidden under the window edge.
- "General settings" is split into themed sub-sections: **Basics, Appearance, Notifications, Chatting, Privacy & Lock, Window & zoom**, with **Advanced** last. No settings were dropped in the move; only the decorative separator lines were removed (the headers separate sections now).
- Clearer labels: **"Widget Theme" → "Display theme"**, **"Chat theme" → "Chat colour Tint"**.
- The **User Agent** field is marked advanced: red label + a tooltip warning that non-standard values can make WhatsApp refuse to load or get the account flagged/blacklisted.
- The Qt **"Widget Style"** chooser is hidden on Windows (a Linux desktop-theming nicety); it still shows on Linux.
- Language names show by language only — e.g. **"Español"** rather than "Español de España".
- Download location is shown with native path separators.
- Drops a no-op `Qt::UniqueConnection` on a lambda `connect` (silences a benign runtime warning; the model is rebuilt each call so there was never a duplicate to guard against).

**Translations**
- `lupdate`-synced all 15 `.ts` files and translated the new/renamed strings (Display theme, Chat colour Tint, the seven section titles, the User Agent warning) in every language. Most of the line count here is `lupdate`'s own reformatting.

Happy to split this into smaller PRs (e.g. the label/i18n cleanups separate from the accordion) if you'd rather take it piecemeal — just say the word.
