### PR TITLE
fix(tray): never hide the window when there is no tray icon to restore it

### DIFF
--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -34,7 +34,18 @@ void MainWindow::createActions() {
   // shortcut sheet can read it back instead of hardcoding the key.
   m_minimizeAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_W));
   m_minimizeAction->setAutoRepeat(false);
-  connect(m_minimizeAction, &QAction::triggered, this, &QMainWindow::hide);
+  // Same guard as closeEvent: hiding is only safe while the tray icon is there
+  // to bring the window back. With it hidden there is nothing left to click, and
+  // Ctrl+W — which reads as "close tab" in a tabbed app — would strand the
+  // window, so fall back to an ordinary minimise to the taskbar. This also
+  // covers the "minimize in tray on start" setting, which triggers this action.
+  connect(m_minimizeAction, &QAction::triggered, this, [this]() {
+    if (QSystemTrayIcon::isSystemTrayAvailable() && m_systemTrayIcon &&
+        m_systemTrayIcon->isVisible())
+      hide();
+    else
+      showMinimized();
+  });
   addAction(m_minimizeAction);
 
   m_restoreAction = new QAction(tr("&Restore"), this);

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -149,10 +149,14 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                                           .settings()
                                           .value("useNativeFileDialog", true)
                                           .toBool());
+  // Loading must not run the tray mutual-exclusion in the toggled slots, which
+  // would rewrite the saved values in load order rather than by user intent.
+  ui->startMinimized->blockSignals(true);
   ui->startMinimized->setChecked(SettingsManager::instance()
                                      .settings()
                                      .value("startMinimized", false)
                                      .toBool());
+  ui->startMinimized->blockSignals(false);
   ui->dismissEmojiPanelCheckBox->setChecked(
       SettingsManager::instance()
           .settings()
@@ -183,8 +187,10 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
       SettingsManager::instance().settings().value("smoothScrolling", false).toBool());
   ui->monochromeTrayIconCheckBox->setChecked(
       SettingsManager::instance().settings().value("monochromeTrayIcon", false).toBool());
+  ui->hideTrayIconCheckBox->blockSignals(true);
   ui->hideTrayIconCheckBox->setChecked(
       SettingsManager::instance().settings().value("hideTrayIcon", false).toBool());
+  ui->hideTrayIconCheckBox->blockSignals(false);
   ui->hideMutedStatusCheckBox->setChecked(MutedStatus::isEnabled());
   ui->autoRestartCheckBox->setChecked(
       SettingsManager::instance().settings().value("autoRestartOnCrash", false).toBool());
@@ -231,11 +237,13 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           .settings()
           .value("autoLockDuration", defaultAppAutoLockDuration)
           .toInt());
+  ui->minimizeOnTrayIconClick->blockSignals(true);
   ui->minimizeOnTrayIconClick->setChecked(
       SettingsManager::instance()
           .settings()
           .value("minimizeOnTrayIconClick", false)
           .toBool());
+  ui->minimizeOnTrayIconClick->blockSignals(false);
   ui->defaultDownloadLocation->setText(QDir::toNativeSeparators(
       SettingsManager::instance()
           .settings()
@@ -1066,6 +1074,8 @@ void SettingsWidget::on_useNativeFileDialog_toggled(bool checked) {
 
 void SettingsWidget::on_startMinimized_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("startMinimized", checked);
+  if (checked) // needs a tray icon — see on_hideTrayIconCheckBox_toggled
+    ui->hideTrayIconCheckBox->setChecked(false);
 }
 
 void SettingsWidget::on_dismissEmojiPanelCheckBox_toggled(bool checked) {
@@ -1138,6 +1148,14 @@ void SettingsWidget::on_followSystemThemeCheckBox_toggled(bool checked) {
 
 void SettingsWidget::on_hideTrayIconCheckBox_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("hideTrayIcon", checked);
+  // There is nothing to start minimised into, and nothing to click, once the
+  // tray icon is gone — so turning this on quietly turns those two off instead
+  // of leaving settings that silently do nothing. Each of them turns this one
+  // back off the same way; the chain stops because only enabling excludes.
+  if (checked) {
+    ui->startMinimized->setChecked(false);
+    ui->minimizeOnTrayIconClick->setChecked(false);
+  }
   emit trayIconChanged();
 }
 
@@ -1785,6 +1803,8 @@ void SettingsWidget::on_resetAppAutoLockPushButton_clicked() {
 void SettingsWidget::on_minimizeOnTrayIconClick_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("minimizeOnTrayIconClick",
                                                   checked);
+  if (checked) // needs a tray icon — see on_hideTrayIconCheckBox_toggled
+    ui->hideTrayIconCheckBox->setChecked(false);
 }
 
 void SettingsWidget::on_styleComboBox_currentTextChanged(const QString &arg1) {


### PR DESCRIPTION
## Never hide the window when there is no tray icon to bring it back

`closeEvent` already guards this case explicitly:

> Hiding to the tray is only safe while the tray icon is actually there to bring the window back; with it hidden, honour the close as a real quit.

The **minimize** path had no such guard — `m_minimizeAction` was connected straight to `QMainWindow::hide()`. So with **Hide tray icon** enabled the window disappears and there is nothing left to click: the app keeps running with no visible surface. `hide()` also removes the taskbar button, which is what separates this from an ordinary minimise.

Two ways to reach it:

1. **Ctrl+W** — bound to this action, and added to both the main window and the web view. In a tabbed app that reads as "close tab", so it is easy to press by accident.
2. **"Minimize in tray on start"** — guarded by `isSystemTrayAvailable()` but not by `hideTrayIcon`, so tray-available + icon-hidden + start-minimized brings the app up **completely invisible**.

It is recoverable — a relaunch falls through to `alreadyRunning()` → `show()` — but nothing tells the user that, and case 2 makes a first launch look like the app is simply broken.

### Changes

- **`mainwindow_tray.cpp`** — hide only while a tray icon is actually visible; otherwise fall back to an ordinary minimise to the taskbar. This fixes case 2 for free, since `runMinimized()` triggers the same action.
- **`settingswidget.cpp`** — make the conflicting settings mutually exclusive, so the broken state cannot be built in the first place. Enabling **Hide tray icon** clears **Minimize in tray on start** and **Show/Hide on clicking tray Icon**; enabling either of those clears **Hide tray icon**. Only *enabling* excludes, so the chain terminates on its own (Qt emits nothing when `setChecked` does not change the value). The three load sites block signals, so a previously stored combination is never rewritten in `.ui` load order rather than by user intent.
- **`tests/tst_settings.cpp`** — new `trayOptionsAreMutuallyExclusive` case covering both directions of the exclusion and asserting the cleared values reach the settings store, not just the checkboxes.

No new translatable strings, so no `lupdate` cycle is needed.

### Tested

Verified on **both platforms** with an instrumented build that logged every settings toggle and every minimize decision, so the behaviour below is read off a recorded session rather than remembered.

**Windows 10** (MSVC, Qt 6.11) and **Linux Mint 22, X11 / Cinnamon** (Qt 6.12, native build — applied cleanly, 0 warnings, 0 errors):

| Behaviour | Result |
|---|---|
| Enabling "Hide tray icon" clears the two tray-dependent settings | pass, both platforms |
| Enabling either of those clears "Hide tray icon" | pass, both platforms |
| Ctrl+W **with** a tray icon → hides into the tray | pass, both platforms |
| Ctrl+W **without** a tray icon → minimises to the taskbar, still restorable *(the bug)* | pass, both platforms |

Unit tests: `tst_settings` 5/5 on Linux including the new case; the same suite passes on Windows.

A note for anyone re-testing: Qt delivers a hide event for **both** the tray-hide and the taskbar-minimise (on X11 `showMinimized()` iconifies by unmapping the window). `isMinimized()` is what distinguishes them — a hide event alone does not mean the window was stranded.

### Not covered

`QSystemTrayIcon::isSystemTrayAvailable()` returned true throughout on both machines, so the branch where **no tray host exists at all** has not been exercised. It is the simplest path through the guard — it falls through to the same `showMinimized()` — but it is untested rather than verified.
