### PR TITLE
fix(tests): build the logic suite on Windows (timegm)

### DIFF
--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -66,6 +66,14 @@
 
 #include <QNetworkProxy>
 
+#ifdef Q_OS_WIN
+// MSVC has no timegm(); _mkgmtime is the same function under another name.
+// Without this the whole logic suite fails to compile on Windows, so none of it
+// runs there at all — ctest just reports "Not Run".
+#include <ctime>
+#define timegm _mkgmtime
+#endif
+
 // ─────────────────────────────────────────────────────────────────────────────
 class TstUtils : public QObject {
   Q_OBJECT


### PR DESCRIPTION
## The logic test suite has never run on Windows

`tests/tst_logic.cpp` calls POSIX `timegm()` (twice, in the sun-clock tests). MSVC does not provide it, so the whole `tst_logic` executable fails to compile on Windows — and because the binary is then simply missing, `ctest` reports it as **"Not Run"** rather than as a failure, which is easy to scroll past.

`_mkgmtime` is the same function under another name; this aliases it on Windows only.

### Result

Before: `logic` is "Not Run" on Windows.
After: all three suites pass there.

```
1/3 Test #1: ui_assets ........................   Passed
2/3 Test #2: logic ............................   Passed
3/3 Test #3: settings .........................   Passed
100% tests passed, 0 tests failed out of 3
```

Verified on Windows 10, MSVC 14.44 / Qt 6.11. No effect on Linux or macOS — the alias is inside `#ifdef Q_OS_WIN`.

### Unrelated note for anyone running the suite on Windows

The test executables are not deployed with the Qt DLLs, so `ctest` needs Qt's `bin` on `PATH` or every test dies with exit code `0xc0000135` (STATUS_DLL_NOT_FOUND), which also looks like a test failure rather than an environment gap. Not changed here — just noting it.
