### PR TITLE
fix(proxy): treat a manual proxy with no host as no proxy

### DIFF
--- a/src/networkproxy.cpp
+++ b/src/networkproxy.cpp
@@ -46,6 +46,15 @@ void applyToApplication() {
   }
   if (m == QLatin1String("socks5") || m == QLatin1String("http")) {
     QNetworkProxyFactory::setUseSystemConfiguration(false);
+    // A manual mode with no host is an unfinished configuration, not a request
+    // to proxy through "". Installing that proxy fails every single request with
+    // ERR_NO_SUPPORTED_PROXIES — WhatsApp Web never loads and the only symptom
+    // is "This site can't be reached", with nothing pointing at the proxy
+    // setting. Connect directly instead, which is what "no host" means.
+    if (host().trimmed().isEmpty()) {
+      QNetworkProxy::setApplicationProxy(QNetworkProxy(QNetworkProxy::NoProxy));
+      return;
+    }
     QNetworkProxy proxy(m == QLatin1String("socks5")
                             ? QNetworkProxy::Socks5Proxy
                             : QNetworkProxy::HttpProxy,

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2071,6 +2071,23 @@ private slots:
     QCOMPARE(QNetworkProxy::applicationProxy().type(), QNetworkProxy::NoProxy);
   }
 
+  // A manual mode with no host must not install an unusable proxy: doing so
+  // fails every request with ERR_NO_SUPPORTED_PROXIES, which looks like the
+  // network is down rather than like a settings problem.
+  void applyManualWithoutHostGivesNoProxy() {
+    NetworkProxy::setMode(QStringLiteral("http"));
+    NetworkProxy::setHost(QString());
+    NetworkProxy::setPort(65535);
+    NetworkProxy::applyToApplication();
+    QCOMPARE(QNetworkProxy::applicationProxy().type(), QNetworkProxy::NoProxy);
+
+    // Same for socks5, and for a host that is only whitespace.
+    NetworkProxy::setMode(QStringLiteral("socks5"));
+    NetworkProxy::setHost(QStringLiteral("   "));
+    NetworkProxy::applyToApplication();
+    QCOMPARE(QNetworkProxy::applicationProxy().type(), QNetworkProxy::NoProxy);
+  }
+
   void applyManualGivesManualProxy() {
     NetworkProxy::setMode(QStringLiteral("http"));
     NetworkProxy::setHost(QStringLiteral("proxy.example"));


### PR DESCRIPTION
## A manual proxy with no host bricks every request  Choosing **http** or **socks5** in Settings → Proxy but leaving the host blank made `applyToApplication()` install an application-wide `QNetworkProxy` pointing at `""`. Every request then fails with `ERR_NO_SUPPORTED_PROXIES`: WhatsApp Web never loads and the only thing the user sees is **"This site can't be reached"**, with nothing anywhere pointing back at the proxy setting.  Two things make it worse than a normal misconfiguration:  - `NetworkProxy::settings()` is the machine-wide store, so `--profile` cannot isolate it — a fresh throwaway profile inherits the broken proxy too. - The app otherwise looks completely healthy, so it reads as "the network is down", not "a setting is wrong".  An empty host is an unfinished configuration, not a request to proxy through nowhere. This connects directly instead. Whitespace-only hosts count as empty.  ### Found how  Hit for real while testing #13 on Linux Mint: a stale `[proxy] mode=http` with an empty host in `~/.config/shakaran/whatly.conf` made every page fail until the cause was tracked down.  ### Tested  New `tst_logic` case `applyManualWithoutHostGivesNoProxy`, covering both `http` and `socks5` and a whitespace-only host. Confirmed meaningful rather than merely green: with the fix reverted and the test kept, the `logic` suite **fails**; with the fix in place it passes.  Note the new test only runs on Windows once #16 lands (`tst_logic` does not currently compile there); it runs everywhere else today, and it was verified on Windows with that fix applied locally.
