### PR TITLE
build: find qwebengine_convert_dict on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,11 @@ if(WHATLY_SPELLCHECK)
 
 find_program(QWEBENGINE_CONVERT_DICT
     NAMES qwebengine_convert_dict
-    HINTS "${QT6_INSTALL_PREFIX}/libexec" /usr/lib/qt6/libexec
+    # Qt keeps this tool in libexec/ on Linux but in bin/ on Windows (and in the
+    # bin/ of a macOS Qt install), so without that hint the search finds nothing
+    # there and the FATAL_ERROR below stops the build outright.
+    HINTS "${QT6_INSTALL_PREFIX}/libexec" "${QT6_INSTALL_PREFIX}/bin"
+          /usr/lib/qt6/libexec
           /usr/lib/x86_64-linux-gnu/qt6/libexec /usr/lib64/qt6/libexec
 )
 


### PR DESCRIPTION
## Spell-check configuration fails on Windows

`qwebengine_convert_dict` is searched for under `libexec/` only, which is where Qt keeps it on Linux. On Windows it ships in **`bin/`**, so `find_program` finds nothing and the `FATAL_ERROR` immediately below stops configuration:

```
qwebengine_convert_dict was not found.
```

The error text then offers only apt/dnf/pacman instructions and `-DQWEBENGINE_CONVERT_DICT=/path/...`, so a Windows builder has to already know where Qt hides the tool — or turn the spell checker off — to get past it.

This adds the Qt prefix's `bin/` to the hints. The existing Linux paths keep their order and priority, so nothing changes there.

### Verified

On Windows (Qt 6.11.1 msvc2022_64), a fresh configure with **no** `-DQWEBENGINE_CONVERT_DICT` override now resolves it:

```
QWEBENGINE_CONVERT_DICT:FILEPATH=C:/Qt/6.11.1/msvc2022_64/bin/qwebengine_convert_dict.exe
```

The same layout applies to a macOS Qt install, which also keeps it in `bin/`.
