### PR TITLE
fix(windows): survive being launched from the system directory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,6 +402,23 @@ int main(int argc, char *argv[]) {
   SingleApplication instance(argc, argv, true, SingleApplication::Mode::User,
                              1000, AppProfile::id());
   instance.setQuitOnLastWindowClosed(false);
+
+#ifdef Q_OS_WIN
+  // Started from the Windows system directory — what a bare shell prompt hands
+  // you — Qt WebEngine resolves Chromium's DLLs against the wrong copies and
+  // aborts before the first page loads (EXCEPTION_BREAKPOINT, 0x80000003).
+  // Launching from the executable's own directory is reliable, so correct only
+  // that one case. Any other working directory is left exactly as it was, so
+  // relative paths given on the command line (`--send --attach ./photo.jpg`)
+  // still resolve against the directory the user ran the command from.
+  {
+    const QString systemRoot = qEnvironmentVariable("SystemRoot");
+    if (!systemRoot.isEmpty() &&
+        QDir(QDir::currentPath()) ==
+            QDir(systemRoot + QStringLiteral("/System32")))
+      QDir::setCurrent(QCoreApplication::applicationDirPath());
+  }
+#endif
   instance.setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // The machine name is lowercase — it is the leaf of every QStandardPaths
   // location (~/.local/share/shakaran/whatly, ~/.config/shakaran/whatly.conf)


### PR DESCRIPTION
## Launching from the Windows system directory crashes at startup

Run `whatly.exe` from a shell whose working directory is `C:\Windows\System32` — which is what a bare prompt hands you — and Qt WebEngine resolves Chromium's DLLs against the wrong copies and aborts before the first page loads (`EXCEPTION_BREAKPOINT`, `0x80000003`). Launching from the executable's own directory is reliable.

The installed app is unaffected: its shortcut sets *Start in* to the install directory. This bites when running the binary from a terminal, which is mostly a developer path — hence a narrow fix rather than a broad one.

### Why it only corrects that one case

The obvious version is `QDir::setCurrent(QCoreApplication::applicationDirPath())` unconditionally at startup. That would be a regression: it silently changes the meaning of every relative path given on the command line, so `whatly --send --attach ./photo.jpg` would look for the attachment next to the executable instead of in the directory the user was standing in.

So this only moves out of the system directory, and leaves every other working directory untouched.

### Tested

Windows 10, Qt 6.11.1. Launched with the working directory set to `C:\Windows\System32`: the app starts and reaches a live window instead of aborting. Launches from ordinary directories are unchanged.

Being straightforward about the limits of that: the crash is intermittent, and I verified the after state rather than re-proving the before state in this run — the working-directory cause was established earlier by an A/B on the same machine. The change is `#ifdef Q_OS_WIN` and cannot affect other platforms.
