### PR TITLE
fix(tests): stop the suite writing into the real settings

### DIFF
--- a/src/networkproxy.cpp
+++ b/src/networkproxy.cpp
@@ -6,9 +6,15 @@
 namespace NetworkProxy {
 
 QSettings &settings() {
-  // Same machine-wide store as the rest of the global settings.
+  // Same machine-wide store as the rest of the global settings, and for the same
+  // reason it ignores the application name — see Performance::settings(). The
+  // WHATLY_SETTINGS_APP escape hatch keeps the test suite out of the developer's
+  // real proxy configuration.
   static QSettings s(QSettings::NativeFormat, QSettings::UserScope,
-                     QStringLiteral("shakaran"), QStringLiteral("whatly"));
+                     QStringLiteral("shakaran"),
+                     qEnvironmentVariableIsEmpty("WHATLY_SETTINGS_APP")
+                         ? QStringLiteral("whatly")
+                         : qEnvironmentVariable("WHATLY_SETTINGS_APP"));
   return s;
 }
 

--- a/src/performance.cpp
+++ b/src/performance.cpp
@@ -30,8 +30,16 @@ namespace Performance {
 
 QSettings &settings() {
   // Machine-wide: always the default profile's file, whatever account is active.
+  // The names are literals rather than QCoreApplication's because this store is
+  // first read from setChromiumFlags(), before QApplication exists to carry
+  // them. That also means setting an application name cannot redirect it — so
+  // without the escape hatch below, running the test suite rewrites the
+  // developer's own settings (see tests/CMakeLists.txt).
   static QSettings s(QSettings::NativeFormat, QSettings::UserScope,
-                     QStringLiteral("shakaran"), QStringLiteral("whatly"));
+                     QStringLiteral("shakaran"),
+                     qEnvironmentVariableIsEmpty("WHATLY_SETTINGS_APP")
+                         ? QStringLiteral("whatly")
+                         : qEnvironmentVariable("WHATLY_SETTINGS_APP"));
   return s;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,11 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(tst_logic PRIVATE Qt${QT_VERSION_MAJOR}::DBus)
 endif()
 add_test(NAME logic COMMAND tst_logic)
-set_tests_properties(logic PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+# WHATLY_SETTINGS_APP: Performance:: and NetworkProxy:: use a machine-wide store
+# that ignores the application name, so without this the tests write into the
+# developer's own settings — the interface scale and the proxy in particular.
+set_tests_properties(logic PROPERTIES ENVIRONMENT
+    "QT_QPA_PLATFORM=offscreen;WHATLY_SETTINGS_APP=whatly-test")
 
 # ── SettingsWidget in-process test ──────────────────────────────────────────
 # SettingsWidget is coupled to MainWindow (a qobject_cast), so it links the whole
@@ -93,4 +97,4 @@ if(UNIX AND NOT APPLE)
 endif()
 add_test(NAME settings COMMAND tst_settings)
 set_tests_properties(settings PROPERTIES ENVIRONMENT
-    "QT_QPA_PLATFORM=offscreen;QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox --disable-gpu")
+    "QT_QPA_PLATFORM=offscreen;QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox --disable-gpu;WHATLY_SETTINGS_APP=whatly-test")

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2358,6 +2358,12 @@ int main(int argc, char *argv[]) {
   // Keep the (headless) QWebEngineProfile used by the install() test happy on CI
   // runners: no sandbox, no GPU. Must be set before QApplication.
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--no-sandbox --disable-gpu");
+  // Performance:: and NetworkProxy:: keep a machine-wide store that ignores both
+  // the application name and QStandardPaths test mode — on Windows it is the
+  // registry, which test mode does not redirect at all. Without this the proxy
+  // tests below leave their fixture host, port, user and password in the
+  // developer's real configuration.
+  qputenv("WHATLY_SETTINGS_APP", "whatly-test");
   QApplication app(argc, argv);
   QCoreApplication::setOrganizationName(QStringLiteral("shakaran"));
   QCoreApplication::setApplicationName(QStringLiteral("whatly-test"));

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -15,6 +15,7 @@
 #include <QPushButton>
 #include <QSlider>
 #include <QSpinBox>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QTimer>
 #include <QToolButton>
@@ -26,8 +27,18 @@ class TstSettings : public QObject {
   QTimer m_modalCloser;
 private slots:
   void initTestCase() {
+    // Performance:: and NetworkProxy:: keep a machine-wide store that ignores
+    // the application name, so setting it below is not enough to keep this test
+    // out of the developer's real settings — exerciseEveryControl() drives every
+    // spin box to its maximum and every combo through every value. ctest sets
+    // this too; doing it here as well covers running the binary directly.
+    qputenv("WHATLY_SETTINGS_APP", "whatly-test");
     QCoreApplication::setOrganizationName(QStringLiteral("shakaran"));
     QCoreApplication::setApplicationName(QStringLiteral("whatly-test"));
+    // As tst_logic already does: redirects the per-account settings too, on the
+    // platforms where QSettings is a file (it cannot redirect the Windows
+    // registry, which is what the variable above is for).
+    QStandardPaths::setTestModeEnabled(true);
     m_modalCloser.setInterval(25);
     connect(&m_modalCloser, &QTimer::timeout, [] {
       for (QWidget *w : QApplication::topLevelWidgets())


### PR DESCRIPTION
## Running the test suite rewrites the developer's own settings  `Performance::settings()` and `NetworkProxy::settings()` deliberately keep a **machine-wide** store, so that `--profile` accounts share performance and proxy configuration. They address it with hard-coded org/app names because it is first read from `setChromiumFlags()`, before `QApplication` exists to carry them.  That has a side effect: the store ignores the application name the tests set, and `QStandardPaths::setTestModeEnabled()` cannot redirect it either — on Windows it is the registry, which test mode does not touch at all.  So running `ctest` reconfigures the app you use every day:  - **`tst_settings::exerciseEveryControl()`** drives every spin box to `maximum()` and every combo through every value. That leaves the **interface scale at 3.0** — the spin box maximum — and `main.cpp` feeds it into `QT_SCALE_FACTOR` and scales the web content to match, so the whole app renders at **300%** from then on. The same sweep leaves the **proxy on the last mode in the list with no host**, which fails every request with `ERR_NO_SUPPORTED_PROXIES` — WhatsApp Web simply stops loading. - **`tst_logic`'s proxy tests** leave their fixture `host`, `port`, `user` and `password` behind on Windows (test mode covers this on Unix, but not the registry).  Both were hit for real, on a Windows machine and a Linux one, and were initially mistaken for pre-existing user misconfiguration — until the values in the config were recognised as the test fixtures themselves (`proxy.example`, port `3128`, user `u`, password `p`).  It goes unnoticed in CI because the container is thrown away; it only bites someone running the tests on a machine they also use Whatly on, which is exactly when it is most confusing.  ## The fix  Give the machine-wide store an escape hatch, `WHATLY_SETTINGS_APP`, and point the tests at a disposable name — from `ctest`, and from the test binaries themselves so that running one directly is covered too. `tst_settings` also gains the `QStandardPaths` test mode that `tst_logic` already sets.  Deriving the names from `QCoreApplication` instead would be the tidier fix, but it cannot work here: the first read happens before the application object exists, so the names would be empty.  ## Verified on Windows  A marker was written into the real store, then the full suite run:  ``` BEFORE: scale=1.75  proxyHost='MARKER-do-not-overwrite' 100% tests passed, 0 tests failed out of 3 AFTER : scale=1.75  proxyHost='MARKER-do-not-overwrite' isolated store proxy host = 'proxy.example' ```  The real settings are untouched and the fixtures land under the disposable name instead.  Rebased onto current `main` (past #14–#17); it applied cleanly, no conflicts. Re-verified after the rebase, this time with `tst_logic` really running on Windows too — #16 has since merged, so it now compiles there:

```
100% tests passed, 0 tests failed out of 3
REAL STORE IDENTICAL - the suite wrote nothing to it
```

## Also verified on Linux

Linux Mint 22, Qt 6.12, native build — patch applied cleanly, 0 errors, all three suites pass, and a marker written into the real `~/.config/shakaran/whatly.conf` survives **byte-for-byte** (identical SHA-256, mtime unchanged) while the run's fixtures land in a disposable `whatly-test` store.

The **unpatched control** was run as well, and it reproduces the damage exactly from a clean marker:

```
BEFORE: interfaceScaleFactor=1.75   host=MARKER-do-not-overwrite
AFTER : interfaceScaleFactor=3      mode=http   port=65535
```

So the fix is load-bearing rather than merely coincident with a green suite.

One platform difference worth recording: on Linux the damage comes **only** from `tst_settings` — `tst_logic` was already isolated there by `QStandardPaths::setTestModeEnabled(true)`. On Windows that call cannot help, because the store is the registry, which test mode does not redirect; hence the environment variable, which covers both.
