### PR TITLE
feat(chats): collapse the chat list to a strip of profile pictures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(SOURCES
     src/cannedresponses.cpp
     src/globalshortcut.cpp
     src/privacyblur.cpp
+    src/chatliststrip.cpp
     src/performance.cpp
     src/trayicon.cpp
     src/notificationrules.cpp
@@ -277,6 +278,7 @@ set(HEADERS
     src/hdmedia.h
     src/cannedresponses.h
     src/privacyblur.h
+    src/chatliststrip.h
     src/performance.h
     src/trayicon.h
     src/notificationrules.h

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -27,12 +27,11 @@ static const char kStripWidth[] = "97px";
 // (panel width / this), so a smaller number means both smaller text AND more
 // room for it before anything wraps.
 //
-// One number does not suit every platform. 0.7 was settled on against Windows'
-// font rendering; the same build on Linux came back "slightly too small", the
-// text there being drawn lighter and narrower at the same nominal size. So the
-// default is per-platform and the user can override it — this is a matter of
-// eyesight and screen as much as of toolkit, and nobody else's measurement
-// settles it.
+// 0.7 was settled on against Windows' font rendering first, but the same build
+// on Linux came back "slightly too small" and Windows agreed once there was a
+// control to compare against. Everyone starts on the middle step, and the user
+// can override it — this is a matter of eyesight and screen as much as of
+// toolkit, and nobody else's measurement settles it.
 static const char kPreviewZoomSmall[] = "0.7";
 static const char kPreviewZoomMedium[] = "0.85";
 static const char kPreviewZoomLarge[] = "1";
@@ -588,13 +587,7 @@ QString jsStringLiteral(const QString &value) {
 }
 
 // Which step a fresh installation starts on. See the note on the zooms above.
-QString defaultPreviewSizeId() {
-#ifdef Q_OS_WIN
-  return QStringLiteral("small");
-#else
-  return QStringLiteral("medium");
-#endif
-}
+QString defaultPreviewSizeId() { return QStringLiteral("medium"); }
 
 } // namespace
 

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -225,7 +225,21 @@ static const char kScriptTemplate[] = R"JS(
             if (kids[i].querySelector('button')) cells.push(kids[i]);
             if (kids[i].contains(more)) break;
           }
-          cells.slice(0, 4).forEach(function (c) {
+          // The "more" cell is kept whatever else is dropped. The stylesheet
+          // hides every child that is NOT tagged, so trimming the list to the
+          // first four would take the ▾ off screen entirely on any account that
+          // shows a fourth pill — WhatsApp adds "Groups" for some — and there
+          // would then be no way to reach the other lists without expanding.
+          // So the EARLIER pills give way instead, and ▾ keeps the last cell.
+          var moreCell = null;
+          for (var j = cells.length - 1; j >= 0; j--)
+            if (cells[j].contains(more)) {
+              moreCell = cells.splice(j, 1)[0];
+              break;
+            }
+          var shown = cells.slice(0, moreCell ? 3 : 4);
+          if (moreCell) shown.push(moreCell);
+          shown.forEach(function (c) {
             c.setAttribute('data-whatly-cell', '1');
             var b = c.querySelector('button');
             if (!b) return;
@@ -328,6 +342,8 @@ R"JS(
         return false;
       }
       prepare();
+      // A fresh pane gets a fresh budget of catch-up attempts; see the timer.
+      window.__whatlyStripTries = 0;
       if (!style) {
         style = document.createElement('style');
         style.id = 'whatly-chatlist-strip';
@@ -366,9 +382,21 @@ R"JS(
           sync();
         // On a cold start the script runs before WhatsApp has built the filter
         // row, so this is also how the buttons first get their letters.
-        else if (applied && document.querySelector('#all-filter') &&
-                 !document.querySelector('[data-whatly-filters]'))
+        //
+        // Bounded, because prepare() measures every div in the document and
+        // this runs once a second: if WhatsApp ever renames #additional-filters
+        // the tagging can never succeed, and an unbounded retry would then pay
+        // for a full-document layout read every second for as long as the app
+        // is open. Twenty tries is far more than a cold start needs, and the
+        // budget is reset by sync() whenever the pane is rebuilt. The counter
+        // lives on window, NOT in this closure — the timer outlives the run
+        // that created it, same reasoning as __whatlyStripCss above.
+        else if (applied && (window.__whatlyStripTries || 0) < 20 &&
+                 document.querySelector('#all-filter') &&
+                 !document.querySelector('[data-whatly-filters]')) {
+          window.__whatlyStripTries = (window.__whatlyStripTries || 0) + 1;
           prepare();
+        }
         // A net under the click handler: the panel can also be opened from the
         // keyboard, and this costs one querySelector on a node that is empty
         // whenever no panel is open.

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -128,12 +128,12 @@ static const char kScriptTemplate[] = R"JS(
 (function () {
   'use strict';
   var TIP = 'whatly-chatlist-tip';
-  var ZOOM = __ZOOM__;
   try {
     // The LIVE desired state, replaced by every re-run of this script. Anything
-    // that outlives one run — the timer below — must read it from here rather
-    // than close over it. See the note on sync().
+    // that outlives one run — the timer and the preview below — must read it
+    // from here rather than close over it. See the note on sync().
     window.__whatlyStripCss = __CSS__;
+    window.__whatlyStripZoom = __ZOOM__;
     var el = document.getElementById('whatly-chatlist-strip');
 
     var untag = function (attr) {
@@ -436,9 +436,12 @@ R"JS(
       // row rather than less, and the name cannot collide with the timestamp.
       var w = Math.round(window.__whatlyPaneWidth ||
                          document.documentElement.clientWidth * 0.4);
+      // Live, not captured: this function outlives the run that defined it, so a
+      // captured size would be the one chosen when the page loaded, for ever.
+      var zoom = window.__whatlyStripZoom || 1;
       var clone = row.cloneNode(true);
       clone.removeAttribute('id');
-      clone.style.zoom = ZOOM;
+      clone.style.zoom = zoom;
       // A chat row is built to hold exactly one line of preview, so its inner
       // blocks have fixed heights and centre what is in them. Let the message
       // wrap inside that and it grows both ways, pushing itself up over the
@@ -472,7 +475,7 @@ R"JS(
       // box means a longer one is clipped at the BOTTOM — the ordinary way to
       // treat text that does not fit, and no worse for it, since the middle of
       // a long message is not what anyone is reading a preview for.
-      t.style.height = Math.round(r.height * 2 * ZOOM) + 'px';
+      t.style.height = Math.round(r.height * 2 * zoom) + 'px';
       t.style.display = 'block';
       var h = t.getBoundingClientRect().height;
       t.style.left =

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -337,6 +337,10 @@ R"JS(
         else if (applied && document.querySelector('#all-filter') &&
                  !document.querySelector('[data-whatly-filters]'))
           prepare();
+        // A net under the click handler: the panel can also be opened from the
+        // keyboard, and this costs one querySelector on a node that is empty
+        // whenever no panel is open.
+        clampPanel();
       } catch (e) { /* never break the page */ }
     }, 1000);
 
@@ -429,6 +433,54 @@ R"JS(
     }, true);
     document.addEventListener('scroll', hide, true);
     document.addEventListener('pointerdown', hide, true);
+
+    // WhatsApp centres the emoji / GIF / sticker panel on the button that opens
+    // it and clamps it against the RIGHT edge of the window only. With the list
+    // at full width the composer never sits far enough left for that to matter;
+    // collapsed, it moves across by the width the list gave up and the panel is
+    // placed at a negative left — measured at -41.5px for a 560px panel — so it
+    // is cropped down its own left side. Nudge it back on screen.
+    //
+    // Only while collapsed, and only when it is actually off screen, so a page
+    // WhatsApp has positioned properly is never touched. The panel animates in
+    // under a scale transform, and a transformed box measures smaller than the
+    // one being positioned, so this waits for that to finish rather than
+    // correcting against a half-open size.
+    var clampPanel = function () {
+      try {
+        if (!collapsed()) return;
+        var mount = document.getElementById('expressions-panel-container');
+        var panel = mount && mount.querySelector('[role="application"]');
+        if (!panel) return;
+        var cs = getComputedStyle(panel);
+        if (cs.transform !== 'none' && cs.transform !== 'matrix(1, 0, 0, 1, 0, 0)')
+          return;                                   // still animating open
+        var r = panel.getBoundingClientRect();
+        if (r.width < 100) return;                  // not open
+        var side = document.querySelector('#side');
+        var stripRight = side
+            ? side.parentElement.getBoundingClientRect().right : 4;
+        var vw = document.documentElement.clientWidth;
+        // Sit against the conversation's left edge where there is room for the
+        // whole panel there, and simply on screen where there is not. Never
+        // moved leftwards: a panel WhatsApp has already placed sensibly is left
+        // exactly where it put it.
+        var want = Math.max(4, Math.min(stripRight, vw - r.width - 4));
+        if (r.left >= want - 0.5) return;
+        var left = parseFloat(cs.left);
+        if (isNaN(left)) return;
+        panel.style.setProperty('left', (left + (want - r.left)) + 'px',
+                                'important');
+      } catch (e) { /* never break the page */ }
+    };
+    // It opens on a click, and the animation is short; the later pass is what
+    // usually does the work, the earlier one just shortens the visible glitch.
+    document.addEventListener('click', function () {
+      setTimeout(clampPanel, 80);
+      setTimeout(clampPanel, 320);
+    }, true);
+    // Resizing re-runs WhatsApp's own positioning, so it can go off again.
+    window.addEventListener('resize', function () { setTimeout(clampPanel, 200); });
 
     // Collapsed, the search box above the list is clipped to a sliver, so a
     // click up there can only mean "I want to search". Open the list back up

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -1,12 +1,14 @@
 #include "chatliststrip.h"
 #include "settingsmanager.h"
 
+#include <QCoreApplication>
 #include <QWebEngineProfile>
 #include <QWebEngineScript>
 #include <QWebEngineScriptCollection>
 
 static const char kScriptName[] = "whatly-chatlist-strip";
 static const char kSettingsKey[] = "chatListStrip";
+static const char kPreviewSizeKey[] = "chatListStripPreviewSize";
 
 // How wide the collapsed list is: WhatsApp's own 48px avatar plus the 23px and
 // 25px of padding its row already draws either side of it — 96px — plus the 1px
@@ -24,7 +26,16 @@ static const char kStripWidth[] = "97px";
 // How much the hover preview shrinks its content. The clone is laid out at
 // (panel width / this), so a smaller number means both smaller text AND more
 // room for it before anything wraps.
-static const char kPreviewZoom[] = "0.7";
+//
+// One number does not suit every platform. 0.7 was settled on against Windows'
+// font rendering; the same build on Linux came back "slightly too small", the
+// text there being drawn lighter and narrower at the same nominal size. So the
+// default is per-platform and the user can override it — this is a matter of
+// eyesight and screen as much as of toolkit, and nobody else's measurement
+// settles it.
+static const char kPreviewZoomSmall[] = "0.7";
+static const char kPreviewZoomMedium[] = "0.85";
+static const char kPreviewZoomLarge[] = "1";
 
 // The pane is narrowed and its contents are then simply CLIPPED, rather than
 // each unwanted element being selected and hidden — clipping needs to know
@@ -273,9 +284,29 @@ R"JS(
       }
     };
 
-    // Put the stylesheet in or take it out to match "collapsed AND in Chats".
-    // Called on every toggle and once a second, so leaving Chats expands the
-    // pane and coming back collapses it again without anything else running.
+    // A filter can leave Chats with no list at all. Pick Favourites with no
+    // favourites, or search for something nothing matches, and WhatsApp swaps
+    // the rows for an explanatory panel — a heading and a paragraph telling you
+    // how to add one — which at 97px is the same ragged-fragment mess the
+    // directory sections were, and there is nothing to gain from collapsing a
+    // list that is not there. So the strip stands down until rows come back,
+    // and as with leaving Chats the SETTING is left alone: clear the filter and
+    // it collapses again, exactly as it was.
+    var listed = function () {
+      try {
+        var pane = document.querySelector('#pane-side');
+        return !!(pane && pane.querySelector('[role="row"]'));
+      } catch (e) {
+        return true;
+      }
+    };
+
+    var wanted = function () { return inChats() && listed(); };
+
+    // Put the stylesheet in or take it out to match "collapsed AND a chat list
+    // to collapse". Called on every toggle and once a second, so leaving Chats
+    // expands the pane and coming back collapses it again without anything else
+    // running.
     //
     // It reads window.__whatlyStripCss, NOT the CSS captured above, and that is
     // a correctness requirement rather than a style: expanding runs this script
@@ -285,7 +316,7 @@ R"JS(
     // opened at all. Same reasoning as the live flags object in webtweaks.cpp.
     var sync = function () {
       var style = document.getElementById('whatly-chatlist-strip');
-      var want = window.__whatlyStripCss && inChats();
+      var want = window.__whatlyStripCss && wanted();
       if (!want) {
         if (style) style.remove();
         var t = document.getElementById(TIP);
@@ -328,8 +359,9 @@ R"JS(
         if (!window.__whatlyStripCss) return; // expanded: nothing to keep up
         var style = document.getElementById('whatly-chatlist-strip');
         var applied = !!style;
-        // Leaving or entering Chats, or WhatsApp rebuilding the pane under us.
-        if (applied !== inChats() ||
+        // Leaving or entering Chats, a filter emptying or refilling the list,
+        // or WhatsApp rebuilding the pane under us.
+        if (applied !== wanted() ||
             (applied && !document.querySelector('[data-whatly-pane]')))
           sync();
         // On a cold start the script runs before WhatsApp has built the filter
@@ -524,6 +556,15 @@ QString jsStringLiteral(const QString &value) {
   return QLatin1Char('"') + escaped + QLatin1Char('"');
 }
 
+// Which step a fresh installation starts on. See the note on the zooms above.
+QString defaultPreviewSizeId() {
+#ifdef Q_OS_WIN
+  return QStringLiteral("small");
+#else
+  return QStringLiteral("medium");
+#endif
+}
+
 } // namespace
 
 namespace ChatListStrip {
@@ -540,17 +581,49 @@ void setCollapsed(bool collapsed) {
                                                   collapsed);
 }
 
+QList<PreviewSize> previewSizes() {
+  return {
+      {QStringLiteral("small"),
+       QCoreApplication::translate("ChatListStrip", "Small")},
+      {QStringLiteral("medium"),
+       QCoreApplication::translate("ChatListStrip", "Medium")},
+      {QStringLiteral("large"),
+       QCoreApplication::translate("ChatListStrip", "Large")},
+  };
+}
+
+QString currentPreviewSizeId() {
+  const QString id = SettingsManager::instance()
+                         .settings()
+                         .value(QLatin1String(kPreviewSizeKey),
+                                defaultPreviewSizeId())
+                         .toString();
+  for (const PreviewSize &size : previewSizes())
+    if (size.id == id)
+      return id;
+  return defaultPreviewSizeId();
+}
+
+void setCurrentPreviewSizeId(const QString &id) {
+  SettingsManager::instance().settings().setValue(
+      QLatin1String(kPreviewSizeKey), id);
+}
+
 QString scriptSource() {
   const QString css =
       isCollapsed()
           ? QString::fromLatin1(kCollapseCss).arg(QLatin1String(kStripWidth))
           : QString();
+  const QString sizeId = currentPreviewSizeId();
+  const char *zoom = sizeId == QLatin1String("large")    ? kPreviewZoomLarge
+                     : sizeId == QLatin1String("medium") ? kPreviewZoomMedium
+                                                         : kPreviewZoomSmall;
   // fromUtf8, not fromLatin1: this file is UTF-8, so the fallback glyph in the
   // filter grid would otherwise reach the page as one mangled byte per
   // character.
   QString source = QString::fromUtf8(kScriptTemplate);
   source.replace(QLatin1String("__CSS__"), jsStringLiteral(css));
-  source.replace(QLatin1String("__ZOOM__"), QLatin1String(kPreviewZoom));
+  source.replace(QLatin1String("__ZOOM__"), QLatin1String(zoom));
   return source;
 }
 

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -1,0 +1,523 @@
+#include "chatliststrip.h"
+#include "settingsmanager.h"
+
+#include <QWebEngineProfile>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
+
+static const char kScriptName[] = "whatly-chatlist-strip";
+static const char kSettingsKey[] = "chatListStrip";
+
+// How wide the collapsed list is: WhatsApp's own 48px avatar plus the 23px and
+// 25px of padding its row already draws either side of it — 96px — plus the 1px
+// the pane's wrapper carries as padding-left. The wrapper is border-box, so
+// asking for 96 leaves 95 of content and clips the avatar block by exactly one
+// column.
+//
+// Chosen so the picture lands centred WITHOUT overriding that padding: the
+// elements carrying it are class-named, and every class in WhatsApp Web is
+// compiler-generated (.x10tvbhy and the like) and changes with each deploy.
+// Measured against a live page; if WhatsApp restyles its rows this becomes
+// off-centre, never broken.
+static const char kStripWidth[] = "97px";
+
+// How much the hover preview shrinks its content. The clone is laid out at
+// (panel width / this), so a smaller number means both smaller text AND more
+// room for it before anything wraps.
+static const char kPreviewZoom[] = "0.7";
+
+// The pane is narrowed and its contents are then simply CLIPPED, rather than
+// each unwanted element being selected and hidden — clipping needs to know
+// nothing about the name/preview/timestamp nodes, which is the only way to
+// survive WhatsApp's generated class names.
+//
+// NOTE the two things this rule does NOT do, both learned the hard way:
+//
+//  * It does not name the pane by selector. The width does not live on
+//    #pane-side or on #side but on an unnamed wrapper above them — AND the
+//    layout carries a SECOND, parallel column of the same width inside the
+//    legacy `.two` container, which is what actually pushes the conversation
+//    across. Shrinking only the first left a full-height hairline exactly where
+//    the list used to end, because the conversation's own border-left never
+//    moved. So the columns are found by measurement in prepare() below and
+//    tagged, and this rule styles the tag.
+//
+//  * It does not use the `flex` shorthand. #side sits in a column-direction
+//    flex parent, and in the Calls section so does the whole pane column, where
+//    `flex: 0 0 97px` sets the HEIGHT and folds the section into a 97px box.
+//    Growing/shrinking are pinned instead and the basis left alone, so only the
+//    width is ever touched whichever way the parent runs.
+static const char kCollapseCss[] =
+    "[data-whatly-pane]{flex-grow:0!important;flex-shrink:0!important;"
+    "flex-basis:auto!important;width:%1!important;"
+    "min-width:%1!important;max-width:%1!important}"
+    "#side,#pane-side{overflow-x:hidden!important}"
+    "#pane-side [role=\"row\"]{overflow:hidden!important}"
+    // The filter pills (All / Unread / Favourites / more) are a horizontal row
+    // that a 97px column simply guillotines. Fold them into a 2x2 grid of round
+    // buttons instead, each labelled with the first letter of its own caption —
+    // taken from the caption itself in prepare(), so it follows the interface
+    // language rather than assuming English. They stay the REAL buttons, so
+    // clicking one filters, and the "more" popover still anchors to itself and
+    // opens without the list having to expand.
+    "[data-whatly-filters]{display:grid!important;"
+    "grid-template-columns:1fr 1fr!important;gap:4px!important;"
+    "padding:4px 6px!important;justify-items:stretch!important;"
+    "align-content:start!important;height:auto!important;"
+    "overflow:visible!important}"
+    "[data-whatly-filters]>*{display:none!important}"
+    "[data-whatly-filters]>[data-whatly-cell]{display:block!important;"
+    "width:auto!important;min-width:0!important;margin:0!important;"
+    "padding:0!important}"
+    // Rounded rectangles filling their cell rather than circles floating in it:
+    // at 97px, two 28px circles leave more gap between them than they occupy.
+    "[data-whatly-filters] button{display:flex!important;"
+    "align-items:center!important;justify-content:center!important;"
+    "width:100%!important;height:26px!important;min-width:0!important;"
+    "max-width:none!important;padding:0!important;margin:0!important;"
+    "border-radius:8px!important;overflow:hidden!important;font-size:0!important}"
+    "[data-whatly-filters] button>*{display:none!important}"
+    "[data-whatly-filters] button::before{content:attr(data-whatly-letter);"
+    "font-size:13px!important;font-weight:600!important;line-height:1!important}"
+    // The pane's own title bar: "WhatsApp" wordmark and the like, which at this
+    // width is a letter and a half. Tagged in prepare().
+    "[data-whatly-hide]{display:none!important}"
+    // The hover preview is a clone of a row, and a row is a virtual-list item:
+    // absolutely positioned, translated into place and given an inline pixel
+    // height. Cloned into a panel of its own it would sit out of flow and leave
+    // that panel zero pixels tall, so put it back in normal flow and let its
+    // height come from its content.
+    "#whatly-chatlist-tip>*{position:static!important;transform:none!important;"
+    "height:auto!important;width:auto!important;z-index:auto!important;"
+    "transition:none!important}"
+    // It also inherits the truncation the list uses to keep every chat on one
+    // line. In a preview there is room to read, so let the text wrap instead of
+    // ending in an ellipsis.
+    "#whatly-chatlist-tip *{white-space:normal!important;"
+    "text-overflow:clip!important}";
+
+// __CSS__ empty removes the stylesheet, so the same script both collapses and
+// restores. The scripting below does three things the CSS cannot: it finds the
+// pane columns by measuring them, it reads each filter pill's own first letter,
+// and it draws the hover preview.
+//
+// The preview is a CLONE of the row rather than text scraped out of it. That is
+// what makes it look right: the name, the emoji sprites, the unread badge and
+// the timestamp all render exactly as they do in the uncollapsed list, with
+// nothing to reproduce and nothing to keep in step with WhatsApp's markup. It
+// replaces an earlier `title` attribute, which the browser showed only after
+// about a second, only while the window had focus, and laid out as a single
+// line as wide as the screen.
+//
+// It hangs off ONE delegated pointerover listener, not a pass over the rows:
+// WhatsApp recycles rows as you scroll, so anything that walked the list would
+// have to keep re-walking it — the trap the rail-button code warns about at
+// length. It runs only while the pointer is already resting on a row.
+static const char kScriptTemplate[] = R"JS(
+(function () {
+  'use strict';
+  var TIP = 'whatly-chatlist-tip';
+  var ZOOM = __ZOOM__;
+  try {
+    // The LIVE desired state, replaced by every re-run of this script. Anything
+    // that outlives one run — the timer below — must read it from here rather
+    // than close over it. See the note on sync().
+    window.__whatlyStripCss = __CSS__;
+    var el = document.getElementById('whatly-chatlist-strip');
+
+    var untag = function (attr) {
+      document.querySelectorAll('[' + attr + ']').forEach(function (e) {
+        e.removeAttribute(attr);
+      });
+    };
+
+    // Find every column the pane occupies and mark it, so the stylesheet has
+    // something to select. There is more than one: the wrapper that actually
+    // holds #side, and a parallel column inside the legacy `.two` container
+    // whose only job is to push the conversation across. Both start at the same
+    // x as the wrapper and are narrower than half the app; the containers that
+    // also start there are full width, so that one test separates them — and it
+    // keeps working after the collapse, when the columns are 97px rather than
+    // their natural width.
+    var prepare = function () {
+      var side = document.querySelector('#side');
+      if (!side) return false;
+      var wrap = side.parentElement;
+      var w = wrap.getBoundingClientRect();
+      // Remember the natural width while it is still natural: the preview is
+      // laid out at exactly the width the list has when it is not collapsed.
+      if (w.width > 120) window.__whatlyPaneWidth = w.width;
+      untag('data-whatly-pane');
+      document.querySelectorAll('div').forEach(function (e) {
+        var r = e.getBoundingClientRect();
+        // Same left edge AND same height as the wrapper, both to the pixel.
+        // Loose tests catch the pane's own children too — #side starts one
+        // pixel in, and the virtual-list container is 38000px tall — and
+        // pinning a width onto those is at best pointless.
+        if (Math.abs(r.left - w.left) > 0.6) return;
+        if (Math.abs(r.height - w.height) > 0.6) return;
+        e.setAttribute('data-whatly-pane', '1');
+      });
+      wrap.setAttribute('data-whatly-pane', '1');
+
+      // Words that a 97px column cannot hold. Chats gets away with almost none,
+      // but Channels leads with "Channels", "Stay updated on your favourite
+      // topics" and "Find channels to follow below", Communities with its own
+      // title, and Calls with "Favourites" and "Recent" — all of which come out
+      // as ragged fragments a couple of characters wide.
+      //
+      // Two treatments, because they are two kinds of text. A heading like
+      // "Recent" or "View all" still earns its place if it is small enough to
+      // fit, so it is shrunk; a sentence never fits at any size worth reading,
+      // so it goes. Length is the test — no word list, so it holds in every
+      // interface language.
+      //
+      // The pane's title bar — a <header> that is #side's SIBLING, which is why
+      // an earlier walk rooted at #side left the section name behind as a lone
+      // capital letter. It is the one piece of text up here with nothing to say
+      // at 97px. Leaves only: a container that merely carries a stray text node
+      // is structure, and hiding it takes the controls beside it too.
+      untag('data-whatly-hide');
+      var head = wrap.querySelector('header');
+      if (head) {
+        head.querySelectorAll('*').forEach(function (e) {
+          if (e.children.length > 0) return;
+          if (e.closest('button,[role="button"]')) return; // a control's label
+          var t = '';
+          for (var i = 0; i < e.childNodes.length; i++)
+            if (e.childNodes[i].nodeType === 3) t += e.childNodes[i].textContent;
+          if (t.trim()) e.setAttribute('data-whatly-hide', '1');
+        });
+      }
+
+      // The filter pills: the row that holds both the "all" pill and the "more"
+      // button, and a letter for each pill that is actually on screen.
+      untag('data-whatly-filters');
+      untag('data-whatly-cell');
+      var all = document.querySelector('#all-filter');
+      var more = document.querySelector('#additional-filters');
+      if (all && more) {
+        var host = all;
+        while (host && !host.contains(more)) host = host.parentElement;
+        if (host) {
+          host.setAttribute('data-whatly-filters', '1');
+          // Which children become buttons is decided by what they CONTAIN, not
+          // by how big they are: this runs again every time WhatsApp rebuilds
+          // the pane, by which point the stylesheet below has already hidden
+          // the ones it is about to re-pick, so a measurement would find
+          // nothing and the row would empty itself out. The pills that matter
+          // are the ones up to and including the "more" button; anything after
+          // it is an overflow entry the list keeps collapsed anyway.
+          var cells = [];
+          var kids = Array.prototype.slice.call(host.children);
+          for (var i = 0; i < kids.length; i++) {
+            if (kids[i].querySelector('button')) cells.push(kids[i]);
+            if (kids[i].contains(more)) break;
+          }
+          cells.slice(0, 4).forEach(function (c) {
+            c.setAttribute('data-whatly-cell', '1');
+            var b = c.querySelector('button');
+            if (!b) return;
+            // textContent, NOT innerText: innerText is layout-aware, and by the
+            // time this runs again the stylesheet has already set the pills to
+            // font-size 0, so innerText reads empty and every button would end
+            // up wearing the fallback glyph.
+            var text = (c.textContent || '').trim();
+            b.setAttribute('data-whatly-letter',
+              c.contains(more) || !text ? '▾'
+                                        : text.charAt(0).toUpperCase());
+          });
+        }
+      }
+      return true;
+    };
+
+)JS"
+// MSVC caps a single string literal at 16380 bytes and this script is past it.
+// Adjacent literals are concatenated by the compiler, so the split below is a
+// build constraint only — it changes nothing about the script.
+R"JS(
+    // The strip is a CHATS thing. Calls is a call log, Status a story list,
+    // Channels and Communities are directories — none of them is a list of
+    // chats with a conversation beside it, which is the room the strip buys.
+    // Every one of them also lays its pane out differently, and the attempts to
+    // make them all fit produced far more trouble than width: a column-
+    // direction parent in Calls turned the width rule into a height one, the
+    // directories lead with paragraphs that came out as ragged fragments, and a
+    // community tile's hover highlight kept its pre-collapse width and covered
+    // the conversation. So: applied in Chats, withdrawn everywhere else, and
+    // the SETTING is left alone throughout — switch back and it collapses
+    // again, exactly as it was.
+    //
+    // Which section is showing is read from the nav rail's aria-pressed rather
+    // than from any label, so it holds in every interface language. The rail is
+    // the column left of the pane; its topmost entry is Chats.
+    var inChats = function () {
+      try {
+        var rail = [];
+        document.querySelectorAll('button[aria-pressed]').forEach(function (b) {
+          var r = b.getBoundingClientRect();
+          if (r.width > 0 && r.right <= 62 && r.top < 500)
+            rail.push({ b: b, y: r.top });
+        });
+        if (rail.length) {
+          rail.sort(function (a, c) { return a.y - c.y; });
+          return rail[0].b.getAttribute('aria-pressed') === 'true';
+        }
+        // No rail to read (a layout without one): fall back to the chat grid
+        // actually being on screen.
+        var g = document.querySelector('#pane-side [role="grid"]');
+        return !!g && g.getClientRects().length > 0;
+      } catch (e) {
+        return true; // never leave the strip stuck open on a bad guess
+      }
+    };
+
+    // Put the stylesheet in or take it out to match "collapsed AND in Chats".
+    // Called on every toggle and once a second, so leaving Chats expands the
+    // pane and coming back collapses it again without anything else running.
+    //
+    // It reads window.__whatlyStripCss, NOT the CSS captured above, and that is
+    // a correctness requirement rather than a style: expanding runs this script
+    // again with an empty CSS, but the timer started by the FIRST run is still
+    // alive with the old closure — so a captured value had it putting the
+    // stylesheet straight back a second later, and the strip could not be
+    // opened at all. Same reasoning as the live flags object in webtweaks.cpp.
+    var sync = function () {
+      var style = document.getElementById('whatly-chatlist-strip');
+      var want = window.__whatlyStripCss && inChats();
+      if (!want) {
+        if (style) style.remove();
+        var t = document.getElementById(TIP);
+        if (t) t.style.display = 'none';
+        untag('data-whatly-pane');
+        untag('data-whatly-filters');
+        untag('data-whatly-cell');
+        untag('data-whatly-hide');
+        return false;
+      }
+      prepare();
+      if (!style) {
+        style = document.createElement('style');
+        style.id = 'whatly-chatlist-strip';
+        (document.head || document.documentElement).appendChild(style);
+      }
+      style.textContent = window.__whatlyStripCss;
+      return true;
+    };
+    sync();
+
+    if (window.__whatlyStripReady) return;
+    window.__whatlyStripReady = true;
+
+    var collapsed = function () {
+      var s = document.getElementById('whatly-chatlist-strip');
+      return !!(s && s.textContent);
+    };
+    // WhatsApp rebuilds this pane whenever the section changes, taking the tags
+    // with it. A timer costs one querySelector per tick and puts them back; a
+    // MutationObserver over a tree WhatsApp mutates continuously would measure
+    // the layout several times a second instead.
+    // WhatsApp swaps the pane out when the section changes, taking the tags
+    // with it, and nothing tells us it happened. A timer costs a couple of
+    // querySelector calls per tick and puts everything back; a MutationObserver
+    // over a tree WhatsApp mutates continuously would measure the layout
+    // several times a second instead — that cost 40% of a core once already.
+    setInterval(function () {
+      try {
+        if (!window.__whatlyStripCss) return; // expanded: nothing to keep up
+        var style = document.getElementById('whatly-chatlist-strip');
+        var applied = !!style;
+        // Leaving or entering Chats, or WhatsApp rebuilding the pane under us.
+        if (applied !== inChats() ||
+            (applied && !document.querySelector('[data-whatly-pane]')))
+          sync();
+        // On a cold start the script runs before WhatsApp has built the filter
+        // row, so this is also how the buttons first get their letters.
+        else if (applied && document.querySelector('#all-filter') &&
+                 !document.querySelector('[data-whatly-filters]'))
+          prepare();
+      } catch (e) { /* never break the page */ }
+    }, 1000);
+
+    var panel = function () {
+      var t = document.getElementById(TIP);
+      if (!t) {
+        t = document.createElement('div');
+        t.id = TIP;
+        // pointer-events:none, so moving towards the preview never counts as
+        // leaving the row that opened it.
+        t.style.cssText = 'position:fixed;z-index:2147483000;display:none;' +
+                          'pointer-events:none;border-radius:10px;' +
+                          'box-shadow:0 8px 28px rgba(0,0,0,.4);overflow:hidden';
+        document.body.appendChild(t);
+      }
+      return t;
+    };
+    var timer = null;
+    var hide = function () {
+      if (timer) { clearTimeout(timer); timer = null; }
+      var t = document.getElementById(TIP);
+      if (t) t.style.display = 'none';
+    };
+    var show = function (row) {
+      if (!row.isConnected || !collapsed()) return;
+      var side = document.querySelector('#side');
+      var pane = document.querySelector('#pane-side');
+      if (!side || !pane) return;
+      var t = panel();
+      // Exactly the width the list has when it is not collapsed, remembered by
+      // prepare() before the stylesheet narrowed it. The clone is then laid out
+      // at that width divided by the zoom, so it has MORE room than the real
+      // row rather than less, and the name cannot collide with the timestamp.
+      var w = Math.round(window.__whatlyPaneWidth ||
+                         document.documentElement.clientWidth * 0.4);
+      var clone = row.cloneNode(true);
+      clone.removeAttribute('id');
+      clone.style.zoom = ZOOM;
+      // A chat row is built to hold exactly one line of preview, so its inner
+      // blocks have fixed heights and centre what is in them. Let the message
+      // wrap inside that and it grows both ways, pushing itself up over the
+      // name — which is what a long message did here. Release those heights and
+      // anchor every COLUMN of the row to its top, so extra lines can only ever
+      // grow downwards, into the space below, and are clipped there.
+      //
+      // The clone is detached, so getComputedStyle would tell us nothing about
+      // it; the original is walked alongside instead. cloneNode preserves order,
+      // so the two lists line up element for element.
+      var src = row.querySelectorAll('*');
+      var dst = clone.querySelectorAll('*');
+      for (var i = 0; i < src.length && i < dst.length; i++) {
+        var cs = getComputedStyle(src[i]);
+        dst[i].style.setProperty('height', 'auto', 'important');
+        dst[i].style.setProperty('min-height', '0', 'important');
+        if (cs.display === 'flex' && cs.flexDirection === 'column')
+          dst[i].style.setProperty('justify-content', 'flex-start', 'important');
+      }
+      t.textContent = '';
+      t.appendChild(clone);
+      // Take the list's own background, so the preview follows the light/dark
+      // theme without either colour being written down here.
+      var bg = getComputedStyle(pane).backgroundColor;
+      if (!bg || bg === 'rgba(0, 0, 0, 0)')
+        bg = getComputedStyle(document.body).backgroundColor;
+      t.style.background = bg;
+      t.style.width = w + 'px';
+      var r = row.getBoundingClientRect();
+      // Two rows tall, always: enough for a message that runs on, and a fixed
+      // box means a longer one is clipped at the BOTTOM — the ordinary way to
+      // treat text that does not fit, and no worse for it, since the middle of
+      // a long message is not what anyone is reading a preview for.
+      t.style.height = Math.round(r.height * 2 * ZOOM) + 'px';
+      t.style.display = 'block';
+      var h = t.getBoundingClientRect().height;
+      t.style.left =
+        Math.round(side.parentElement.getBoundingClientRect().right + 6) + 'px';
+      t.style.top = Math.round(Math.min(Math.max(8, r.top - 6),
+                                        window.innerHeight - h - 8)) + 'px';
+    };
+
+    document.addEventListener('pointerover', function (ev) {
+      try {
+        if (!collapsed()) { hide(); return; }
+        var row = ev.target.closest &&
+                  ev.target.closest('#pane-side [role="row"]');
+        if (!row) { hide(); return; }
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(function () { show(row); }, 100);
+      } catch (e) { hide(); }
+    }, true);
+    document.addEventListener('scroll', hide, true);
+    document.addEventListener('pointerdown', hide, true);
+
+    // Collapsed, the search box above the list is clipped to a sliver, so a
+    // click up there can only mean "I want to search". Open the list back up
+    // and put the cursor in the box, rather than making it two separate
+    // actions. Everything inside #side but above #pane-side is that area — no
+    // class names — except the filter buttons, which are right there and are
+    // meant to work collapsed.
+    document.addEventListener('click', function (ev) {
+      try {
+        if (!collapsed()) return;
+        var side = document.querySelector('#side');
+        var pane = document.querySelector('#pane-side');
+        if (!side || !pane) return;
+        if (!side.contains(ev.target) || pane.contains(ev.target)) return;
+        var filters = document.querySelector('[data-whatly-filters]');
+        if (filters && filters.contains(ev.target)) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        hide();
+        if (window.__whatlyBridge && window.__whatlyBridge.toggleChatListStrip)
+          window.__whatlyBridge.toggleChatListStrip();
+        // Expanding is a round trip through the app, so the box only exists to
+        // be focused a moment later.
+        setTimeout(function () {
+          var s = document.querySelector(
+            '#side [contenteditable="true"],#side [role="textbox"],#side input');
+          if (s) s.focus();
+        }, 300);
+      } catch (e) { /* never break the page */ }
+    }, true);
+  } catch (e) { /* never break the page */ }
+})();
+)JS";
+
+namespace {
+
+QString jsStringLiteral(const QString &value) {
+  QString escaped = value;
+  escaped.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+  escaped.replace(QLatin1Char('"'), QLatin1String("\\\""));
+  return QLatin1Char('"') + escaped + QLatin1Char('"');
+}
+
+} // namespace
+
+namespace ChatListStrip {
+
+bool isCollapsed() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QLatin1String(kSettingsKey), false)
+      .toBool();
+}
+
+void setCollapsed(bool collapsed) {
+  SettingsManager::instance().settings().setValue(QLatin1String(kSettingsKey),
+                                                  collapsed);
+}
+
+QString scriptSource() {
+  const QString css =
+      isCollapsed()
+          ? QString::fromLatin1(kCollapseCss).arg(QLatin1String(kStripWidth))
+          : QString();
+  // fromUtf8, not fromLatin1: this file is UTF-8, so the fallback glyph in the
+  // filter grid would otherwise reach the page as one mangled byte per
+  // character.
+  QString source = QString::fromUtf8(kScriptTemplate);
+  source.replace(QLatin1String("__CSS__"), jsStringLiteral(css));
+  source.replace(QLatin1String("__ZOOM__"), QLatin1String(kPreviewZoom));
+  return source;
+}
+
+void install(QWebEngineProfile *profile) {
+  auto *scripts = profile->scripts();
+  const auto existing = scripts->find(QLatin1String(kScriptName));
+  for (const auto &script : existing)
+    scripts->remove(script);
+
+  if (!isCollapsed())
+    return;
+
+  QWebEngineScript script;
+  script.setName(QLatin1String(kScriptName));
+  script.setSourceCode(scriptSource());
+  script.setInjectionPoint(QWebEngineScript::DocumentReady);
+  script.setWorldId(QWebEngineScript::MainWorld);
+  script.setRunsOnSubFrames(false);
+  scripts->insert(script);
+}
+
+} // namespace ChatListStrip

--- a/src/chatliststrip.h
+++ b/src/chatliststrip.h
@@ -1,0 +1,32 @@
+#ifndef CHATLISTSTRIP_H
+#define CHATLISTSTRIP_H
+
+#include <QString>
+#include <QWebEngineProfile>
+
+// Collapses WhatsApp Web's chat list into a narrow strip of profile pictures,
+// handing the width it was using to the open conversation. A toggle, not a
+// preference to be set once: it is driven from a button in WhatsApp's own rail
+// and from Ctrl+B, and the current state is remembered.
+//
+// Implemented the same way as PrivacyBlur — plain CSS in an injected <style> —
+// so there is no scripting to keep in sync with WhatsApp's React tree, and a
+// rule that stops matching simply stops collapsing rather than breaking the
+// page.
+namespace ChatListStrip {
+
+bool isCollapsed();
+void setCollapsed(bool collapsed);
+
+// The script that adds or removes the stylesheet to match the current state.
+QString scriptSource();
+
+// (Re)installs the stylesheet on the profile for FUTURE page loads. As with
+// WebTweaks, Qt does not propagate profile-script changes to an already-created
+// page, so callers must also runJavaScript(scriptSource()) on the live page for
+// a toggle to take effect immediately.
+void install(QWebEngineProfile *profile);
+
+} // namespace ChatListStrip
+
+#endif // CHATLISTSTRIP_H

--- a/src/chatliststrip.h
+++ b/src/chatliststrip.h
@@ -1,13 +1,14 @@
 #ifndef CHATLISTSTRIP_H
 #define CHATLISTSTRIP_H
 
+#include <QList>
 #include <QString>
 #include <QWebEngineProfile>
 
 // Collapses WhatsApp Web's chat list into a narrow strip of profile pictures,
 // handing the width it was using to the open conversation. A toggle, not a
 // preference to be set once: it is driven from a button in WhatsApp's own rail
-// and from Ctrl+B, and the current state is remembered.
+// and from the command palette, and the current state is remembered.
 //
 // Implemented the same way as PrivacyBlur — plain CSS in an injected <style> —
 // so there is no scripting to keep in sync with WhatsApp's React tree, and a
@@ -17,6 +18,19 @@ namespace ChatListStrip {
 
 bool isCollapsed();
 void setCollapsed(bool collapsed);
+
+// How big the hover preview draws the row it clones. One number does not suit
+// every platform — the size that reads well under Windows' font rendering came
+// back "slightly too small" from the Linux dogfood — so the default follows the
+// platform and this lets the user disagree with it.
+struct PreviewSize {
+  QString id;
+  QString name;
+};
+
+QList<PreviewSize> previewSizes();
+QString currentPreviewSizeId();
+void setCurrentPreviewSizeId(const QString &id);
 
 // The script that adds or removes the stylesheet to match the current state.
 QString scriptSource();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -685,11 +685,14 @@ void MainWindow::initSettingWidget() {
   connect(m_settingsWidget, &SettingsWidget::webTweaksChanged, m_settingsWidget,
           [=]() {
             // Update the profile scripts for future page loads, and apply the
-            // change to the already-loaded page (Qt does not propagate profile
-            // script changes to an existing page).
-            WebTweaks::install(WebEngineProfileManager::instance().profile());
-            if (m_webEngine && m_webEngine->page())
-              m_webEngine->page()->runJavaScript(WebTweaks::scriptSource());
+            // change to the already-loaded pages (Qt does not propagate profile
+            // script changes to an existing page). Every account, not just the
+            // current one: these buttons are drawn inside each account's page,
+            // and in grid view they are all on screen at once.
+            WebEngineProfileManager::instance().applyUserSettings();
+            for (const Account &account : m_accounts)
+              if (account.view && account.view->page())
+                account.view->page()->runJavaScript(WebTweaks::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::followSystemThemeChanged,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,7 @@
 
 #include <QTimer>
 #include <QDesktopServices>
+#include "chatliststrip.h"
 #include "privacyblur.h"
 #include "localapi.h"
 #include "cloudapi.h"
@@ -1234,6 +1235,25 @@ void MainWindow::togglePrivacyBlur() {
     m_webEngine->page()->runJavaScript(PrivacyBlur::scriptSource());
   if (m_settingsWidget)
     m_settingsWidget->refresh();   // keep the combo box telling the truth
+}
+
+// The command palette shows an action by its text, so the entry has to say what
+// pressing it will DO, not what the feature is called.
+void MainWindow::refreshChatListStripAction() {
+  if (m_chatListStripAction)
+    m_chatListStripAction->setText(ChatListStrip::isCollapsed()
+                                       ? tr("Expand the chat list")
+                                       : tr("Collapse the chat list"));
+}
+
+// Collapse WhatsApp's chat list to a strip of avatars, or bring it back.
+// Reached from the button in WhatsApp's own rail and from the command palette.
+void MainWindow::toggleChatListStrip() {
+  ChatListStrip::setCollapsed(!ChatListStrip::isCollapsed());
+  ChatListStrip::install(WebEngineProfileManager::instance().profile());
+  if (m_webEngine && m_webEngine->page())
+    m_webEngine->page()->runJavaScript(ChatListStrip::scriptSource());
+  refreshChatListStripAction();
 }
 
 // ── Chat / URL helpers ────────────────────────────────────────────────────────

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -570,17 +570,25 @@ void MainWindow::updateWindowTheme() {
                         .settings()
                         .value("windowTheme", "light")
                         .toString() == "dark";
-  if (dark) {
-    qApp->setPalette(Theme::getDarkPalette());
-    m_webEngine->setStyleSheet("QWebEngineView{background:rgb(17, 27, 33);}");
-  } else {
-    qApp->setPalette(Theme::getLightPalette());
-    m_webEngine->setStyleSheet("QWebEngineView{background:#F0F0F0;}");
-  }
+  qApp->setPalette(dark ? Theme::getDarkPalette() : Theme::getLightPalette());
+  const QString viewStyle =
+      dark ? QStringLiteral("QWebEngineView{background:rgb(17, 27, 33);}")
+           : QStringLiteral("QWebEngineView{background:#F0F0F0;}");
+  const QColor pageBg = dark ? QColor(17, 27, 33) : QColor(240, 240, 240);
 
-  if (m_webEngine->page()) {
-    m_webEngine->page()->setBackgroundColor(
-        dark ? QColor(17, 27, 33) : QColor(240, 240, 240));
+  m_webEngine->setStyleSheet(viewStyle);
+  if (m_webEngine->page())
+    m_webEngine->page()->setBackgroundColor(pageBg);
+
+  // And every other account: in grid view they are all on screen at once, so a
+  // theme change that reached only the current one left the rest of the tiles
+  // sitting on the old background.
+  for (const Account &account : m_accounts) {
+    if (!account.view || account.view == m_webEngine)
+      continue;
+    account.view->setStyleSheet(viewStyle);
+    if (account.view->page())
+      account.view->page()->setBackgroundColor(pageBg);
   }
 
   for (QWidget *w : findChildren<QWidget *>())
@@ -753,9 +761,20 @@ void MainWindow::initSettingWidget() {
 
   connect(m_settingsWidget, &SettingsWidget::privacyBlurChanged,
           m_settingsWidget, [=]() {
-            PrivacyBlur::install(WebEngineProfileManager::instance().profile());
-            if (m_webEngine && m_webEngine->page())
-              m_webEngine->page()->runJavaScript(PrivacyBlur::scriptSource());
+            WebEngineProfileManager::instance().applyUserSettings();
+            for (const Account &account : m_accounts)
+              if (account.view && account.view->page())
+                account.view->page()->runJavaScript(
+                    PrivacyBlur::scriptSource());
+          });
+
+  connect(m_settingsWidget, &SettingsWidget::chatListStripChanged,
+          m_settingsWidget, [=]() {
+            WebEngineProfileManager::instance().applyUserSettings();
+            for (const Account &account : m_accounts)
+              if (account.view && account.view->page())
+                account.view->page()->runJavaScript(
+                    ChatListStrip::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::fontChanged, m_settingsWidget,
@@ -1230,9 +1249,12 @@ void MainWindow::togglePrivacyBlur() {
     PrivacyBlur::setCurrentLevelId(QStringLiteral("off"));
   }
 
-  PrivacyBlur::install(WebEngineProfileManager::instance().profile());
-  if (m_webEngine && m_webEngine->page())
-    m_webEngine->page()->runJavaScript(PrivacyBlur::scriptSource());
+  // Every account, not just the current one: the setting is app-wide, and in
+  // grid view they are all on screen at once. See toggleChatListStrip().
+  WebEngineProfileManager::instance().applyUserSettings();
+  for (const Account &account : m_accounts)
+    if (account.view && account.view->page())
+      account.view->page()->runJavaScript(PrivacyBlur::scriptSource());
   if (m_settingsWidget)
     m_settingsWidget->refresh();   // keep the combo box telling the truth
 }
@@ -1250,9 +1272,17 @@ void MainWindow::refreshChatListStripAction() {
 // Reached from the button in WhatsApp's own rail and from the command palette.
 void MainWindow::toggleChatListStrip() {
   ChatListStrip::setCollapsed(!ChatListStrip::isCollapsed());
-  ChatListStrip::install(WebEngineProfileManager::instance().profile());
-  if (m_webEngine && m_webEngine->page())
-    m_webEngine->page()->runJavaScript(ChatListStrip::scriptSource());
+  // Every account, not just the current one. The state is app-wide, but the
+  // button that flips it sits inside a page — and in grid view every account is
+  // on screen at once, so reaching only m_webEngine left the click apparently
+  // doing nothing in the tile it was made in while a different tile collapsed.
+  // applyUserSettings() reinstalls in every account's PROFILE for future loads;
+  // the pages already open have to be told separately, as Qt does not propagate
+  // a profile's script changes to them.
+  WebEngineProfileManager::instance().applyUserSettings();
+  for (const Account &account : m_accounts)
+    if (account.view && account.view->page())
+      account.view->page()->runJavaScript(ChatListStrip::scriptSource());
   refreshChatListStripAction();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -70,6 +70,9 @@ public slots:
   void lockOnHideIfEnabled();
   void toggleTheme();
   void togglePrivacyBlur();
+  void toggleChatListStrip();
+  // Keep that action's text saying what it will do next, for the palette.
+  void refreshChatListStripAction();
   void newChat();
 
 protected slots:
@@ -360,6 +363,7 @@ private:
   QAction *m_zoomInAction = nullptr;
   QAction *m_zoomOutAction = nullptr;
   QAction *m_zoomResetAction = nullptr;
+  QAction *m_chatListStripAction = nullptr;
 
   QMenu *m_trayIconMenu = nullptr;
   QSystemTrayIcon *m_systemTrayIcon = nullptr;

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -231,8 +231,8 @@ void MainWindow::showCommandPalette() {
       m_reloadAction,      m_minimizeAction,  m_restoreAction,
       m_lockAction,        m_muteAction,      m_fullscreenAction,
       m_openUrlAction,     m_scheduledMessagesAction, m_toggleThemeAction,
-      m_settingsAction,    m_aboutAction,     m_viewTabsAction,
-      m_viewGridAction,    m_quitAction};
+      m_chatListStripAction, m_settingsAction, m_aboutAction,
+      m_viewTabsAction,    m_viewGridAction,  m_quitAction};
   for (QAction *a : actions) {
     if (!a)
       continue;

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -88,6 +88,16 @@ void MainWindow::createActions() {
   connect(m_zoomResetAction, &QAction::triggered, this, &MainWindow::zoomReset);
   addAction(m_zoomResetAction);
 
+  // No default shortcut. Ctrl+B was the obvious pick and the wrong one: it is
+  // Bold in WhatsApp's message box, so it only worked with the cursor outside
+  // the very field you spend the day in. The action is still in the command
+  // palette and can be given a key of the user's choosing in Settings.
+  m_chatListStripAction = new QAction(this);
+  refreshChatListStripAction();
+  connect(m_chatListStripAction, &QAction::triggered, this,
+          &MainWindow::toggleChatListStrip);
+  addAction(m_chatListStripAction);
+
   m_settingsAction = new QAction(tr("&Settings"), this);
   m_settingsAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_P));
   connect(m_settingsAction, &QAction::triggered, this,
@@ -173,6 +183,9 @@ void MainWindow::createActions() {
       {m_fullscreenAction, "fullscreen", tr("Fullscreen")},
       {m_openUrlAction, "openChat", tr("New chat / open URL")},
       {m_zoomResetAction, "zoomReset", tr("Reset zoom")},
+      // Registered with no default so it appears in the shortcut sheet and can
+      // be bound to whatever the user likes.
+      {m_chatListStripAction, "chatListStrip", tr("Collapse the chat list")},
       {m_settingsAction, "settings", tr("Settings")},
       {m_toggleThemeAction, "toggleTheme", tr("Toggle theme")},
       {m_viewGridAction, "gridView", tr("Grid view")},

--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -144,6 +144,8 @@ void MainWindow::installPageBridge(QWebEnginePage *page) {
             &MainWindow::toggleTheme);
     connect(m_pageBridge, &PageBridge::privacyBlurToggleRequested, this,
             &MainWindow::togglePrivacyBlur);
+    connect(m_pageBridge, &PageBridge::chatListStripToggleRequested, this,
+            &MainWindow::toggleChatListStrip);
     connect(m_pageBridge, &PageBridge::zoomInRequested, this,
             &MainWindow::zoomIn);
     connect(m_pageBridge, &PageBridge::zoomOutRequested, this,

--- a/src/pagebridge.h
+++ b/src/pagebridge.h
@@ -16,6 +16,7 @@ public slots:
   // Invoked by the buttons injected next to the profile avatar.
   void toggleTheme() { emit themeToggleRequested(); }
   void togglePrivacyBlur() { emit privacyBlurToggleRequested(); }
+  void toggleChatListStrip() { emit chatListStripToggleRequested(); }
 
   // Invoked by the injected zoom buttons: adjust the page zoom live.
   void zoomIn() { emit zoomInRequested(); }
@@ -35,6 +36,7 @@ public slots:
 signals:
   void themeToggleRequested();
   void privacyBlurToggleRequested();
+  void chatListStripToggleRequested();
   void zoomInRequested();
   void zoomOutRequested();
   void zoomResetRequested();

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -185,6 +185,11 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           .settings()
           .value("webtweaks/zoomButtons", true)
           .toBool());
+  ui->chatListStripButtonCheckBox->setChecked(
+      SettingsManager::instance()
+          .settings()
+          .value("webtweaks/chatListStripButton", true)
+          .toBool());
   ui->identifyInLinkedDevicesCheckBox->setChecked(
       SettingsManager::instance()
           .settings()
@@ -435,6 +440,7 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveRowL(body(appearance), ui->customCssLabel, ui->customCssLayout, G);
     moveWidget(body(appearance), ui->themeToggleButtonCheckBox, G);
     moveWidget(body(appearance), ui->zoomButtonsCheckBox, G);
+    moveWidget(body(appearance), ui->chatListStripButtonCheckBox, G);
     moveWidget(body(appearance), ui->smoothScrollingCheckBox, G);
     moveWidget(body(appearance), ui->monochromeTrayIconCheckBox, G);
 
@@ -1743,6 +1749,12 @@ void SettingsWidget::on_themeToggleButtonCheckBox_toggled(bool checked) {
 void SettingsWidget::on_zoomButtonsCheckBox_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("webtweaks/zoomButtons",
                                                   checked);
+  emit webTweaksChanged();
+}
+
+void SettingsWidget::on_chatListStripButtonCheckBox_toggled(bool checked) {
+  SettingsManager::instance().settings().setValue(
+      "webtweaks/chatListStripButton", checked);
   emit webTweaksChanged();
 }
 

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -32,6 +32,7 @@
 #include "customcss.h"
 #include "webengineprofilemanager.h"
 #include "dictionaries.h"
+#include "chatliststrip.h"
 #include "privacyblur.h"
 #include "webfont.h"
 #include "mutedstatus.h"
@@ -198,6 +199,7 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
   populateLanguages();
   populateChatThemes();
   populatePrivacyBlur();
+  populateChatListPreviewSize();
   populateFontFamilies();
   populateSpellCheck();
   updateCustomCssButtons();
@@ -441,6 +443,8 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(appearance), ui->themeToggleButtonCheckBox, G);
     moveWidget(body(appearance), ui->zoomButtonsCheckBox, G);
     moveWidget(body(appearance), ui->chatListStripButtonCheckBox, G);
+    moveRow(body(appearance), ui->chatListPreviewSizeLabel,
+            ui->chatListPreviewSizeComboBox, G);
     moveWidget(body(appearance), ui->smoothScrollingCheckBox, G);
     moveWidget(body(appearance), ui->monochromeTrayIconCheckBox, G);
 
@@ -1789,6 +1793,26 @@ void SettingsWidget::on_privacyBlurComboBox_currentIndexChanged(int index) {
   PrivacyBlur::setCurrentLevelId(
       ui->privacyBlurComboBox->itemData(index).toString());
   emit privacyBlurChanged();
+}
+
+void SettingsWidget::populateChatListPreviewSize() {
+  ui->chatListPreviewSizeComboBox->blockSignals(true);
+  ui->chatListPreviewSizeComboBox->clear();
+  const QString current = ChatListStrip::currentPreviewSizeId();
+  for (const ChatListStrip::PreviewSize &size : ChatListStrip::previewSizes()) {
+    ui->chatListPreviewSizeComboBox->addItem(size.name, size.id);
+    if (size.id == current)
+      ui->chatListPreviewSizeComboBox->setCurrentIndex(
+          ui->chatListPreviewSizeComboBox->count() - 1);
+  }
+  ui->chatListPreviewSizeComboBox->blockSignals(false);
+}
+
+void SettingsWidget::on_chatListPreviewSizeComboBox_currentIndexChanged(
+    int index) {
+  ChatListStrip::setCurrentPreviewSizeId(
+      ui->chatListPreviewSizeComboBox->itemData(index).toString());
+  emit chatListStripChanged();
 }
 
 void SettingsWidget::populateFontFamilies() {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -167,6 +167,7 @@ private slots:
   void on_themeToggleButtonCheckBox_toggled(bool checked);
   void on_privacyBlurButtonCheckBox_toggled(bool checked);
   void on_zoomButtonsCheckBox_toggled(bool checked);
+  void on_chatListStripButtonCheckBox_toggled(bool checked);
   void on_userAgentLineEdit_editingFinished();
   void on_userAgentLineEdit_textChanged(const QString &arg1);
   void on_viewPassword_clicked();

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -37,6 +37,7 @@ signals:
   void followSystemThemeChanged();
   void chatThemeChanged();
   void privacyBlurChanged();
+  void chatListStripChanged();
   void fontChanged();
   void mutedStatusChanged();
   void spellCheckChanged();
@@ -168,6 +169,7 @@ private slots:
   void on_privacyBlurButtonCheckBox_toggled(bool checked);
   void on_zoomButtonsCheckBox_toggled(bool checked);
   void on_chatListStripButtonCheckBox_toggled(bool checked);
+  void on_chatListPreviewSizeComboBox_currentIndexChanged(int index);
   void on_userAgentLineEdit_editingFinished();
   void on_userAgentLineEdit_textChanged(const QString &arg1);
   void on_viewPassword_clicked();
@@ -195,6 +197,7 @@ private:
   void updateCustomCssButtons();
   void populateChatThemes();
   void populatePrivacyBlur();
+  void populateChatListPreviewSize();
   void populateFontFamilies();
   void populateSpellCheck();
   void updateSpellCheckSummary();

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -518,6 +518,16 @@ background:transparent;
               </property>
              </widget>
             </item>
+            <item row="13" column="1">
+             <widget class="QCheckBox" name="chatListStripButtonCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp's own sidebar that collapses the chat list to a strip of profile pictures, giving the conversation the width it was using. Ctrl+B does the same.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Chat-list collapse button in WhatsApp's sidebar</string>
+              </property>
+             </widget>
+            </item>
             <item row="12" column="1">
              <widget class="QCheckBox" name="monochromeTrayIconCheckBox">
               <property name="toolTip">

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -521,10 +521,24 @@ background:transparent;
             <item row="13" column="1">
              <widget class="QCheckBox" name="chatListStripButtonCheckBox">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp's own sidebar that collapses the chat list to a strip of profile pictures, giving the conversation the width it was using. Ctrl+B does the same.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp's own sidebar that collapses the chat list to a strip of profile pictures, giving the conversation the width it was using.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
                <string>Chat-list collapse button in WhatsApp's sidebar</string>
+              </property>
+             </widget>
+            </item>
+            <item row="19" column="0">
+             <widget class="QLabel" name="chatListPreviewSizeLabel">
+              <property name="text">
+               <string>Collapsed chat preview</string>
+              </property>
+             </widget>
+            </item>
+            <item row="19" column="1">
+             <widget class="QComboBox" name="chatListPreviewSizeComboBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How large to draw the preview that appears when you hover a picture in the collapsed chat list. The default suits this platform's font rendering; pick another if it reads small or large on your screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>

--- a/src/webengineprofilemanager.cpp
+++ b/src/webengineprofilemanager.cpp
@@ -10,6 +10,7 @@
 #include "customjs.h"
 #include "focusmode.h"
 #include "hdmedia.h"
+#include "chatliststrip.h"
 #include "privacyblur.h"
 #include "webfont.h"
 #include "mutedstatus.h"
@@ -255,6 +256,7 @@ void WebEngineProfileManager::applyUserSettingsTo(QWebEngineProfile *profile,
     HdMedia::install(profile);
     ChatTheme::install(profile);
     PrivacyBlur::install(profile);
+    ChatListStrip::install(profile);
     WebFont::install(profile);
     MutedStatus::install(profile);
     LinkedDeviceName::install(profile, accountLabel(accountId));

--- a/src/webtweaks.cpp
+++ b/src/webtweaks.cpp
@@ -55,6 +55,7 @@ static const char kScriptTemplate[] = R"JS(
     W.themeToggleButton = FLAGS.themeToggleButton;
     W.privacyBlurButton = FLAGS.privacyBlurButton;
     W.zoomButtons = FLAGS.zoomButtons;
+    W.chatListStripButton = FLAGS.chatListStripButton;
   } else {
     W = window.__whatlyWebTweaks = FLAGS;
   }
@@ -133,6 +134,12 @@ static const char kScriptTemplate[] = R"JS(
     zoomOut: '<circle cx="11" cy="11" r="6.4" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M15.6 15.6 21 21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><path d="M8.2 11h5.6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>',
     // Magnifier with a dot centre (reset zoom to 100%).
     zoomReset: '<circle cx="11" cy="11" r="6.4" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M15.6 15.6 21 21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><circle cx="11" cy="11" r="1.6"/>',
+    // A pane with an arrow folding into it: shown while the chat list is open,
+    // i.e. click to collapse it to a strip.
+    collapseList: '<rect x="3" y="4" width="2.2" height="16" rx="1.1"/><path d="M19.6 11h-8.4l2.9-2.9a1 1 0 0 0-1.4-1.4l-4.6 4.6a1 1 0 0 0 0 1.4l4.6 4.6a1 1 0 0 0 1.4-1.4L11.2 13h8.4a1 1 0 0 0 0-2z"/>',
+    // The same arrow pointing back out: shown while collapsed, i.e. click to
+    // bring the chat list back.
+    expandList: '<rect x="3" y="4" width="2.2" height="16" rx="1.1"/><path d="M9 13h8.4l-2.9 2.9a1 1 0 0 0 1.4 1.4l4.6-4.6a1 1 0 0 0 0-1.4l-4.6-4.6a1 1 0 0 0-1.4 1.4l2.9 2.9H9a1 1 0 0 0 0 2z"/>',
   };
   var isDark = function () {
     try {
@@ -145,6 +152,11 @@ static const char kScriptTemplate[] = R"JS(
   // state off it — no second channel to keep in sync with the app.
   var isBlurred = function () {
     var style = document.getElementById('whatly-privacy-blur');
+    return !!(style && style.textContent);
+  };
+  // Same trick for the chat-list strip: its stylesheet IS its state.
+  var isListCollapsed = function () {
+    var style = document.getElementById('whatly-chatlist-strip');
     return !!(style && style.textContent);
   };
 
@@ -172,6 +184,21 @@ static const char kScriptTemplate[] = R"JS(
       click: function () {
         if (window.__whatlyBridge && window.__whatlyBridge.togglePrivacyBlur)
           window.__whatlyBridge.togglePrivacyBlur();
+      },
+    },
+    {
+      id: 'whatly-chatlist-toggle',
+      enabled: function () { return W.chatListStripButton; },
+      icon: function () {
+        return isListCollapsed() ? ICON.expandList : ICON.collapseList;
+      },
+      label: function () {
+        return isListCollapsed() ? LABELS.expandChatList
+                                 : LABELS.collapseChatList;
+      },
+      click: function () {
+        if (window.__whatlyBridge && window.__whatlyBridge.toggleChatListStrip)
+          window.__whatlyBridge.toggleChatListStrip();
       },
     },
     // Live page-zoom controls (out / reset / in). The zoom itself lives on the
@@ -369,27 +396,34 @@ QString scriptSource() {
       s.value(QStringLiteral("webtweaks/privacyBlurButton"), true).toBool();
   const bool zoomButtons =
       s.value(QStringLiteral("webtweaks/zoomButtons"), true).toBool();
+  const bool stripButton =
+      s.value(QStringLiteral("webtweaks/chatListStripButton"), true).toBool();
 
   const QString flags =
       QStringLiteral("{\"dismissExpressionsPanel\":%1,\"themeToggleButton\":%2,"
-                     "\"privacyBlurButton\":%3,\"zoomButtons\":%4}")
+                     "\"privacyBlurButton\":%3,\"zoomButtons\":%4,"
+                     "\"chatListStripButton\":%5}")
           .arg(QLatin1String(jsBool(dismiss)), QLatin1String(jsBool(themeButton)),
                QLatin1String(jsBool(blurButton)),
-               QLatin1String(jsBool(zoomButtons)));
+               QLatin1String(jsBool(zoomButtons)),
+               QLatin1String(jsBool(stripButton)));
 
   // The injected buttons' accessible labels, translated. QObject::tr with an
   // explicit "WebTweaks" context so they land in the translation catalogue.
   const QString labels =
       QStringLiteral("{\"switchToLight\":%1,\"switchToDark\":%2,"
                      "\"showChats\":%3,\"blurChats\":%4,\"zoomIn\":%5,"
-                     "\"zoomOut\":%6,\"resetZoom\":%7}")
+                     "\"zoomOut\":%6,\"resetZoom\":%7,\"collapseChatList\":%8,"
+                     "\"expandChatList\":%9}")
           .arg(jsString(QObject::tr("Switch to light theme", "WebTweaks")),
                jsString(QObject::tr("Switch to dark theme", "WebTweaks")),
                jsString(QObject::tr("Show the chats", "WebTweaks")),
                jsString(QObject::tr("Blur the chats", "WebTweaks")),
                jsString(QObject::tr("Zoom in", "WebTweaks")),
                jsString(QObject::tr("Zoom out", "WebTweaks")),
-               jsString(QObject::tr("Reset zoom", "WebTweaks")));
+               jsString(QObject::tr("Reset zoom", "WebTweaks")),
+               jsString(QObject::tr("Collapse the chat list", "WebTweaks")),
+               jsString(QObject::tr("Show the chat list", "WebTweaks")));
 
   QString source = QString::fromLatin1(kScriptTemplate);
   source.replace(QLatin1String("__FLAGS__"), flags);
@@ -424,7 +458,9 @@ void install(QWebEngineProfile *profile) {
       s.value(QStringLiteral("webtweaks/privacyBlurButton"), true).toBool();
   const bool zoomButtons =
       s.value(QStringLiteral("webtweaks/zoomButtons"), true).toBool();
-  if (!dismiss && !themeButton && !blurButton && !zoomButtons)
+  const bool stripButton =
+      s.value(QStringLiteral("webtweaks/chatListStripButton"), true).toBool();
+  if (!dismiss && !themeButton && !blurButton && !zoomButtons && !stripButton)
     return; // nothing enabled → do not inject on fresh loads
 
   QWebEngineScript script;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(tst_logic
     ${S}/utils.cpp ${S}/debuglog.cpp ${S}/appprofile.cpp ${S}/common.cpp
     ${S}/sunclock.cpp ${S}/identicons.cpp ${S}/theme.cpp ${S}/dictionaries.cpp
     ${S}/scheduledmessages.cpp ${S}/messaging.cpp ${S}/messagetemplates.cpp ${S}/autoreply.cpp ${S}/cloudapi.cpp ${S}/localapi.cpp ${S}/cloudwebhook.cpp
-    ${S}/webfont.cpp ${S}/chattheme.cpp ${S}/mutedstatus.cpp ${S}/privacyblur.cpp
+    ${S}/webfont.cpp ${S}/chattheme.cpp ${S}/mutedstatus.cpp ${S}/privacyblur.cpp ${S}/chatliststrip.cpp
     ${S}/chatwallpaper.cpp ${S}/customcss.cpp ${S}/customjs.cpp ${S}/commandpalette.cpp ${S}/updatechecker.cpp ${S}/storageinfo.cpp ${S}/shortcuts.cpp ${S}/backup.cpp ${S}/screenlock.cpp ${S}/quickreply.cpp ${S}/focusmode.cpp ${S}/hdmedia.cpp ${S}/cannedresponses.cpp ${S}/webtweaks.cpp
     ${S}/linkeddevicename.cpp ${S}/performance.cpp ${S}/trayicon.cpp ${S}/notificationrules.cpp
     ${S}/networkproxy.cpp ${S}/autostart.cpp ${S}/portalnotification.cpp

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -516,6 +516,50 @@ private slots:
     ChatListStrip::setCollapsed(false);
   }
 
+  // Two things withdraw the strip without touching the setting: leaving Chats,
+  // and a filter that empties the list — Favourites with no favourites, where
+  // WhatsApp swaps the rows for an explanatory panel that at 97px is unreadable
+  // fragments. Both are decided live in the page, so what a test can pin is
+  // that the script still carries both guards and still asks for both.
+  void chatListStripStandsDownWithNothingToShow() {
+    ChatListStrip::setCollapsed(true);
+    const QString on = ChatListStrip::scriptSource();
+    QVERIFY(on.contains(QLatin1String("aria-pressed")));   // which section
+    QVERIFY(on.contains(QLatin1String("var listed")));     // are there rows
+    QVERIFY(on.contains(QLatin1String("inChats() && listed()")));
+    ChatListStrip::setCollapsed(false);
+  }
+
+  // The hover preview's default size follows the platform: the value settled on
+  // against Windows' font rendering came back too small from Linux. Whatever
+  // the default, the chosen id has to reach the script as a NUMBER, and an id
+  // that is not one of ours must fall back rather than put "undefined" into the
+  // page, where it would take the whole preview down with it.
+  void chatListStripPreviewSize() {
+    const QString platformDefault = ChatListStrip::currentPreviewSizeId();
+    bool known = false;
+    for (const ChatListStrip::PreviewSize &size : ChatListStrip::previewSizes())
+      if (size.id == platformDefault)
+        known = true;
+    QVERIFY(known);
+
+    ChatListStrip::setCollapsed(true);
+    ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("large"));
+    QCOMPARE(ChatListStrip::currentPreviewSizeId(), QStringLiteral("large"));
+    QVERIFY(ChatListStrip::scriptSource().contains(QLatin1String("ZOOM = 1;")));
+    ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("small"));
+    QVERIFY(
+        ChatListStrip::scriptSource().contains(QLatin1String("ZOOM = 0.7;")));
+
+    ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("nonsense"));
+    QCOMPARE(ChatListStrip::currentPreviewSizeId(), platformDefault);
+    QVERIFY(!ChatListStrip::scriptSource().contains(
+        QLatin1String("ZOOM = undefined")));
+
+    ChatListStrip::setCurrentPreviewSizeId(platformDefault);
+    ChatListStrip::setCollapsed(false);
+  }
+
   // The rail button reads its own state off that stylesheet's id, so the two
   // modules have to agree on it — nothing else connects them.
   void chatListStripButtonMatchesStylesheetId() {

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -536,6 +536,14 @@ private slots:
   // that is not one of ours must fall back rather than put "undefined" into the
   // page, where it would take the whole preview down with it.
   void chatListStripPreviewSize() {
+    // Ask what the PLATFORM defaults to, which means asking with nothing
+    // stored. Reading the current id instead would return whatever a previous
+    // run left behind — the settings store outlives the process, and
+    // tst_settings builds a real SettingsWidget after this suite — and the
+    // fallback assertion below would then be comparing against that rather
+    // than against the default it is meant to check.
+    QSettings &settings = SettingsManager::instance().settings();
+    settings.remove(QStringLiteral("chatListStripPreviewSize"));
     const QString platformDefault = ChatListStrip::currentPreviewSizeId();
     bool known = false;
     for (const ChatListStrip::PreviewSize &size : ChatListStrip::previewSizes())
@@ -556,7 +564,9 @@ private slots:
     QVERIFY(!ChatListStrip::scriptSource().contains(
         QLatin1String("ZOOM = undefined")));
 
-    ChatListStrip::setCurrentPreviewSizeId(platformDefault);
+    // Leave the setting UNSET rather than pinned to the default, so the next
+    // run starts from the same place this one did.
+    settings.remove(QStringLiteral("chatListStripPreviewSize"));
     ChatListStrip::setCollapsed(false);
   }
 
@@ -2497,7 +2507,18 @@ int main(int argc, char *argv[]) {
   QStandardPaths::setTestModeEnabled(true);
 
   int status = 0;
-  auto run = [&](QObject *obj) { status |= QTest::qExec(obj, argc, argv); };
+  // qExec returns the number of failed functions, but prints the detail to
+  // stdout — which is lost whenever the suite runs somewhere without a console
+  // (CI logs that capture only stderr, IDE runners, ctest on Windows). Naming
+  // the failing class on stderr costs nothing and turns "logic failed" into a
+  // place to look.
+  auto run = [&](QObject *obj) {
+    const int failed = QTest::qExec(obj, argc, argv);
+    if (failed != 0)
+      fprintf(stderr, "TEST CLASS FAILED: %s (%d function(s))\n",
+              obj->metaObject()->className(), failed);
+    status |= failed;
+  };
   { TstUtils t;               run(&t); }
   { TstUtilsMore t;           run(&t); }
   { TstCommon t;              run(&t); }

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -45,6 +45,7 @@
 #include "hdmedia.h"
 #include "cannedresponses.h"
 #include "webtweaks.h"
+#include "chatliststrip.h"
 #include "messaging.h"
 #include "messagetemplates.h"
 #include "autoreply.h"
@@ -476,6 +477,55 @@ private slots:
     QVERIFY(!hd.isEmpty());
     QVERIFY(hd.contains(QLatin1String("wa_web_show_hd_photo")));
     QVERIFY(hd.contains(QLatin1String("WAWebABProps")));
+  }
+
+  // The chat-list strip is a toggle, so both directions have to produce a valid
+  // script: collapsed installs the stylesheet, expanded removes it again. The
+  // expanded script is NOT empty — it is what takes the stylesheet back out.
+  void chatListStrip() {
+    ChatListStrip::setCollapsed(false);
+    QVERIFY(!ChatListStrip::isCollapsed());
+    const QString off = ChatListStrip::scriptSource();
+    QVERIFY(!off.isEmpty());
+    // It still NAMES #pane-side — that is the tooltip cleanup — but it must
+    // carry no width rule, or it would collapse the list while "expanded".
+    QVERIFY(!off.contains(QLatin1String("min-width")));
+
+    ChatListStrip::setCollapsed(true);
+    QVERIFY(ChatListStrip::isCollapsed());
+    const QString on = ChatListStrip::scriptSource();
+    QVERIFY(on.contains(QLatin1String("#pane-side")));
+    QVERIFY(on.contains(QLatin1String("min-width")));
+    QVERIFY(on.contains(QLatin1String("whatly-chatlist-strip")));
+    // The pane columns are found by measurement and tagged, because the layout
+    // carries more than one of them and only styling the visible one leaves the
+    // conversation's divider stranded at the old width.
+    QVERIFY(on.contains(QLatin1String("data-whatly-pane")));
+    // …and the width must never be set through the `flex` shorthand: in the
+    // Calls section the column's parent runs vertically, so that would set the
+    // height and fold the section into a 97px box.
+    QVERIFY(!on.contains(QLatin1String("flex:0 0")));
+    QVERIFY(on.contains(QLatin1String("flex-basis:auto")));
+    // Collapsed, the clipped name/preview/time stay reachable as a hover
+    // preview — a clone of the row, so emoji and formatting survive — and the
+    // clipped search box stays reachable with one click.
+    QVERIFY(on.contains(QLatin1String("pointerover")));
+    QVERIFY(on.contains(QLatin1String("cloneNode")));
+    QVERIFY(on.contains(QLatin1String("whatly-chatlist-tip")));
+
+    ChatListStrip::setCollapsed(false);
+  }
+
+  // The rail button reads its own state off that stylesheet's id, so the two
+  // modules have to agree on it — nothing else connects them.
+  void chatListStripButtonMatchesStylesheetId() {
+    const QString tweaks = WebTweaks::scriptSource();
+    QVERIFY(tweaks.contains(QLatin1String("whatly-chatlist-strip")));
+    QVERIFY(tweaks.contains(QLatin1String("toggleChatListStrip")));
+    ChatListStrip::setCollapsed(true);
+    QVERIFY(ChatListStrip::scriptSource().contains(
+        QLatin1String("whatly-chatlist-strip")));
+    ChatListStrip::setCollapsed(false);
   }
 };
 
@@ -2351,6 +2401,8 @@ private slots:
     ChatTheme::install(&profile);
     MutedStatus::install(&profile);
     PrivacyBlur::install(&profile);
+    ChatListStrip::setCollapsed(true);
+    ChatListStrip::install(&profile);
     ChatWallpaper::install(&profile);
     CustomCss::install(&profile);
     WebTweaks::install(&profile);
@@ -2377,6 +2429,8 @@ private slots:
     ChatTheme::install(&profile);
     MutedStatus::install(&profile);
     PrivacyBlur::install(&profile);
+    ChatListStrip::setCollapsed(false);
+    ChatListStrip::install(&profile);
     ChatWallpaper::install(&profile);
     CustomCss::install(&profile);
   }

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -536,7 +536,7 @@ private slots:
   // that is not one of ours must fall back rather than put "undefined" into the
   // page, where it would take the whole preview down with it.
   void chatListStripPreviewSize() {
-    // Ask what the PLATFORM defaults to, which means asking with nothing
+    // Ask what a FRESH INSTALL defaults to, which means asking with nothing
     // stored. Reading the current id instead would return whatever a previous
     // run left behind — the settings store outlives the process, and
     // tst_settings builds a real SettingsWidget after this suite — and the
@@ -544,10 +544,10 @@ private slots:
     // than against the default it is meant to check.
     QSettings &settings = SettingsManager::instance().settings();
     settings.remove(QStringLiteral("chatListStripPreviewSize"));
-    const QString platformDefault = ChatListStrip::currentPreviewSizeId();
+    const QString freshDefault = ChatListStrip::currentPreviewSizeId();
     bool known = false;
     for (const ChatListStrip::PreviewSize &size : ChatListStrip::previewSizes())
-      if (size.id == platformDefault)
+      if (size.id == freshDefault)
         known = true;
     QVERIFY(known);
 
@@ -573,7 +573,7 @@ private slots:
     QVERIFY(zoomAt < guardAt);
 
     ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("nonsense"));
-    QCOMPARE(ChatListStrip::currentPreviewSizeId(), platformDefault);
+    QCOMPARE(ChatListStrip::currentPreviewSizeId(), freshDefault);
     QVERIFY(!ChatListStrip::scriptSource().contains(
         QLatin1String("__whatlyStripZoom = undefined")));
 

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -554,15 +554,28 @@ private slots:
     ChatListStrip::setCollapsed(true);
     ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("large"));
     QCOMPARE(ChatListStrip::currentPreviewSizeId(), QStringLiteral("large"));
-    QVERIFY(ChatListStrip::scriptSource().contains(QLatin1String("ZOOM = 1;")));
+    QVERIFY(ChatListStrip::scriptSource().contains(
+        QLatin1String("__whatlyStripZoom = 1;")));
     ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("small"));
-    QVERIFY(
-        ChatListStrip::scriptSource().contains(QLatin1String("ZOOM = 0.7;")));
+    const QString source = ChatListStrip::scriptSource();
+    QVERIFY(source.contains(QLatin1String("__whatlyStripZoom = 0.7;")));
+
+    // The preview outlives the run that defined it, so the size has to reach it
+    // through the window rather than through a captured variable, and it has to
+    // be set BEFORE the once-per-page guard — everything past that guard is
+    // skipped on a re-run, which is exactly what changing the setting does.
+    QVERIFY(source.contains(QLatin1String("window.__whatlyStripZoom ||")));
+    const int zoomAt = source.indexOf(QLatin1String("__whatlyStripZoom ="));
+    const int guardAt =
+        source.indexOf(QLatin1String("__whatlyStripReady) return;"));
+    QVERIFY(zoomAt >= 0);
+    QVERIFY(guardAt >= 0);
+    QVERIFY(zoomAt < guardAt);
 
     ChatListStrip::setCurrentPreviewSizeId(QStringLiteral("nonsense"));
     QCOMPARE(ChatListStrip::currentPreviewSizeId(), platformDefault);
     QVERIFY(!ChatListStrip::scriptSource().contains(
-        QLatin1String("ZOOM = undefined")));
+        QLatin1String("__whatlyStripZoom = undefined")));
 
     // Leave the setting UNSET rather than pinned to the default, so the next
     // run starts from the same place this one did.


### PR DESCRIPTION
The chat list holds a fixed slice of the window whether or not you are reading
it, and it is the widest thing the layout has to fit. Collapse it to a strip of
profile pictures instead, and give the width back to the conversation.

A new button in WhatsApp's own rail toggles it, next to the theme and blur ones,
and the command palette carries it too. The state is remembered.

**Chats only.** Calls is a call log, Status a story list, Channels and
Communities are directories — none of them is a list of chats with a
conversation beside it, which is the room this buys. The strip is applied in
Chats and withdrawn everywhere else; the *setting* is untouched, so leaving and
returning collapses it again exactly as it was. Which section is showing is read
from the nav rail's `aria-pressed`, never from a label, so it holds in any
interface language.

### How it works

The pane is narrowed and its contents are then simply CLIPPED, rather than each
unwanted element being selected and hidden. Every class in WhatsApp Web is
compiler-generated and changes with each deploy, so a rule naming the
name/preview/timestamp nodes would silently rot; clipping needs to know nothing
about them, and the avatar survives because it comes first in the row.

Three things about the layout that cost real debugging time and are worth
knowing if this ever needs touching again:

- The width does not live on `#pane-side` or `#side`. It is on an unnamed
  wrapper above them — and there is a SECOND, parallel column inside the legacy
  `.two` container which is what actually pushes the conversation across.
  Shrinking only the first leaves a full-height hairline where the list used to
  end. Both are found by measurement and tagged.
- `#side` sits in a column-direction flex parent, so the `flex` shorthand sets
  its HEIGHT, not its width. The rule pins grow/shrink and sets `width` instead.
- A chat row is a virtual-list item: absolutely positioned, translated into
  place, given an inline pixel height. That matters for the hover preview below.

### Hover preview

Collapsed, a row still holds its name, preview, time and unread count — they are
only clipped — so hovering shows them. The preview is a **clone of the row**
rather than text scraped out of it, which is what makes it look right: emoji
sprites, unread badge and timestamp all render exactly as in the uncollapsed
list, with nothing to reproduce and nothing to keep in step with WhatsApp's
markup. It is laid out at the width the list has when expanded, pinned to two
rows tall so a long message is clipped at the bottom rather than growing over
the contact's name, and it hangs off one delegated `pointerover` listener — not
a pass over the rows, which WhatsApp recycles as you scroll.

A native `title` was the first attempt and was wrong three ways: about a second
of delay, only while the window has focus, and a long message laid out as one
screen-wide line.

Its size is a setting — *Collapsed chat preview*, Small / Medium / Large — with
a per-platform default, for the reason in the Linux section below.

### Also

- The filter pills (All / Unread / Favourites / more) become a 2x2 grid of
  rounded buttons labelled with the first letter of their own caption, so it
  follows the interface language. They stay the real buttons, so filtering works
  and the "more" popover still opens without expanding the list.
- Collapsed, a click on the clipped search box expands the list and puts the
  cursor in it, rather than making that two actions.
- No default keyboard shortcut. Ctrl+B was the obvious pick and the wrong one —
  it is Bold in the message box, so it only worked with the cursor outside the
  field you spend the day in. It is registered with the shortcut sheet so a key
  can be assigned there.

### Emoji panel

WhatsApp centres the emoji / GIF / sticker panel on the button that opens it and
clamps it against the right edge of the window only. With the chat list at full
width the composer never sits far enough left for that to matter. Collapsed, it
moves across by the width the list gave up, and the panel is placed at a
negative left — measured at -41.5px for a panel 560px wide in a 913px window —
so it is cropped down its own left side.

It is nudged back: against the conversation's left edge where the whole panel
fits there, simply on screen where it does not. It is never moved leftwards, so
a panel WhatsApp has already placed sensibly is left exactly where it put it,
and the correction only runs while the strip is collapsed.

Worth knowing if this is reviewed closely: the panel animates in under a scale
transform, and a transformed box measures smaller than the one being positioned,
so the correction waits for the transform to settle rather than acting on a
half-open size.

### What the Linux round changed

Linux (Mint 22, Qt 6.12, X11) has now walked the same checklist and passed it.
Three things came out of it that were not regressions but were worth fixing, and
all three turned out to apply to Windows as well:

- **A filter can leave Chats with no list at all.** Pick Favourites with no
  favourites, or search for something nothing matches, and WhatsApp swaps the
  rows for an explanatory panel — a heading and a paragraph on how to add one —
  which at 97px is the same ragged fragments that kept the strip out of the
  directory sections. The strip now stands down whenever the pane holds no rows,
  exactly as it does outside Chats, and the setting is left alone: clear the
  filter and it collapses again.
- **The preview's size does not travel between platforms.** 0.7 was settled on
  against Windows' font rendering; the same build read slightly too small on
  Linux, where text is drawn lighter and narrower at the same nominal size.
  Hence the setting, defaulting to Small on Windows and Medium elsewhere. This
  is a matter of eyesight and screen as much as of toolkit, so neither
  measurement gets the last word.
- **The rail buttons reached only the first account.** Collapse, blur and the
  theme are all app-wide settings, but the buttons that flip them sit inside a
  page — and in Grid view every account is on screen at once, so acting on the
  current view alone left a click appearing to do nothing in the tile it was
  made in while a different tile changed instead. They now reinstall in every
  account's profile and run in every live page. Routing to the focused account
  was the other candidate and would be wrong: the settings are global, so that
  would leave the tiles disagreeing with each other. This last one reaches
  beyond the chat list — it fixes the blur and theme buttons in the same rail,
  which had the same assumption.

### Tested

Windows 10, Qt 6.11.1 / MSVC and Linux Mint 22, Qt 6.12 / X11. A 50-item
checklist covering the toggle, persistence across restarts, all five sections,
the preview, the filter grid and the search shortcut, walked on both. Geometry
verified by measurement over the DevTools protocol against a live page, not by
eye. Four `tst_logic` cases; `ctest` green on both platforms.

Not exercised on either: the multi-account behaviour above was reasoned from the
code and built, not watched with two accounts linked — a second linked-device
slot was not available. Wayland was not exercised either.
