### PR TITLE
feat(window): optional account strip, and an option to hide the title bar

### DIFF
--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -11,24 +11,35 @@
 
 namespace {
 const char kSettingsKey[] = "customWindowFrame";
+const char kTabsKey[] = "tabsInTitleBar";
 } // namespace
 
-CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent)
+CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     : QWidget(parent), m_window(window) {
   setObjectName(QStringLiteral("customTitleBar"));
-  setAutoFillBackground(true);
-  setFixedHeight(34);
 
   auto *layout = new QHBoxLayout(this);
   layout->setContentsMargins(8, 0, 4, 0);
   layout->setSpacing(6);
 
-  m_icon = new QLabel(this);
-  m_icon->setPixmap(window->windowIcon().pixmap(18, 18));
-  layout->addWidget(m_icon);
+  if (mode == Mode::Standalone) {
+    setAutoFillBackground(true);
+    setFixedHeight(34);
 
-  m_title = new QLabel(window->windowTitle(), this);
-  layout->addWidget(m_title, 1);
+    m_icon = new QLabel(this);
+    m_icon->setPixmap(window->windowIcon().pixmap(18, 18));
+    layout->addWidget(m_icon);
+
+    m_title = new QLabel(window->windowTitle(), this);
+    layout->addWidget(m_title, 1);
+  } else {
+    // No fixed height and no background of its own: the tab strip beside it
+    // sets the row's height and draws the row's background, and anything else
+    // here would either clip the tabs or paint a band that does not match them.
+    // The empty space left of the buttons is what the window is dragged by.
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    layout->addStretch(1);
+  }
 
   const QStyle *st = style();
   auto makeButton = [&](QStyle::StandardPixmap pm, const QString &tip) {
@@ -73,6 +84,21 @@ void CustomTitleBar::setEnabled(bool enabled) {
                                                   enabled);
 }
 
+bool CustomTitleBar::tabsInTitleBar() {
+  // There is no native frame to merge into, so this only means anything once
+  // the custom frame is on. Guarding here rather than at the two call sites
+  // keeps a stale stored value from producing a window with no way to close it.
+  return isEnabled() && SettingsManager::instance()
+                            .settings()
+                            .value(QLatin1String(kTabsKey), false)
+                            .toBool();
+}
+
+void CustomTitleBar::setTabsInTitleBar(bool enabled) {
+  SettingsManager::instance().settings().setValue(QLatin1String(kTabsKey),
+                                                  enabled);
+}
+
 void CustomTitleBar::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton && m_window->windowHandle()) {
     // Hand the drag to the compositor; the only portable way on Wayland.
@@ -110,9 +136,10 @@ void CustomTitleBar::refreshMaximizeIcon() {
 
 bool CustomTitleBar::eventFilter(QObject *watched, QEvent *event) {
   if (watched == m_window) {
-    if (event->type() == QEvent::WindowTitleChange)
+    // Merged mode has neither label — the tabs say which window this is.
+    if (event->type() == QEvent::WindowTitleChange && m_title)
       m_title->setText(m_window->windowTitle());
-    else if (event->type() == QEvent::WindowIconChange)
+    else if (event->type() == QEvent::WindowIconChange && m_icon)
       m_icon->setPixmap(m_window->windowIcon().pixmap(18, 18));
     else if (event->type() == QEvent::WindowStateChange)
       refreshMaximizeIcon();

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -15,12 +15,25 @@ class QToolButton;
 class CustomTitleBar : public QWidget {
   Q_OBJECT
 public:
+  // Standalone is the bar described above: its own row, with the icon and the
+  // window title. Merged drops both and keeps only the window buttons, so it
+  // can sit at the right-hand end of the account tab strip and let the tabs
+  // themselves be the title bar — Chrome-style, one row instead of two.
+  enum class Mode { Standalone, Merged };
+
   // `window` is the top-level window this bar decorates.
-  explicit CustomTitleBar(QWidget *window, QWidget *parent = nullptr);
+  explicit CustomTitleBar(QWidget *window, QWidget *parent = nullptr,
+                          Mode mode = Mode::Standalone);
 
   // Whether the custom-frame mode is enabled in settings.
   static bool isEnabled();
   static void setEnabled(bool enabled);
+
+  // Whether the account tabs share the title bar's row. A refinement of the
+  // custom frame rather than a mode of its own, so it is only ever true when
+  // isEnabled() is.
+  static bool tabsInTitleBar();
+  static void setTabsInTitleBar(bool enabled);
 
 protected:
   void mousePressEvent(QMouseEvent *event) override;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -71,6 +71,14 @@ public slots:
   void toggleTheme();
   void togglePrivacyBlur();
   void newChat();
+  // Whether the account strip stays up with only one account, where it is a row
+  // of chrome carrying a single tab. Off by default; the "+" it holds is also
+  // on Ctrl+K, the command palette and the Add-account action.
+  static bool alwaysShowAccountTabs();
+  static void setAlwaysShowAccountTabs(bool enabled);
+  int accountCount() const { return m_accounts.size(); }
+  // Re-run the strip's visibility and labels after that setting changes.
+  void refreshAccountStrip();
 
 protected slots:
   void closeEvent(QCloseEvent *event) override;

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -54,6 +54,20 @@ static QString unreadCountFile() {
   return dir + QStringLiteral("/whatly-unread") + AppProfile::suffix();
 }
 
+bool MainWindow::alwaysShowAccountTabs() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QStringLiteral("alwaysShowAccountTabs"), false)
+      .toBool();
+}
+
+void MainWindow::setAlwaysShowAccountTabs(bool enabled) {
+  SettingsManager::instance().settings().setValue(
+      QStringLiteral("alwaysShowAccountTabs"), enabled);
+}
+
+void MainWindow::refreshAccountStrip() { refreshAccountTabs(); }
+
 void MainWindow::buildAccountArea() {
   m_focusOrder.append(nullptr); // the main window starts as the focused ("main") one
 
@@ -69,8 +83,11 @@ void MainWindow::buildAccountArea() {
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
 
-  // Optional client-side title bar (frameless mode). Sits above everything.
-  if (CustomTitleBar::isEnabled())
+  // Optional client-side title bar (frameless mode). Sits above everything —
+  // unless the tabs are to share its row, in which case it is built further
+  // down, beside them.
+  const bool tabsInTitleBar = CustomTitleBar::tabsInTitleBar();
+  if (CustomTitleBar::isEnabled() && !tabsInTitleBar)
     layout->addWidget(new CustomTitleBar(this, central));
 
   m_accountBar = new AccountTabBar(central);
@@ -115,7 +132,21 @@ void MainWindow::buildAccountArea() {
   m_displayStack->addWidget(m_accountStack);   // page 0: tabs
   m_displayStack->addWidget(m_gridScroll);     // page 1: grid (scrollable)
 
-  layout->addWidget(m_accountBar);
+  if (tabsInTitleBar) {
+    // Chrome-style: the tab strip IS the title bar, which buys back the whole
+    // 34px the separate bar was costing. The two stay separate widgets on
+    // purpose — Grid view hides the strip, and a window still needs its
+    // minimise/maximise/close buttons when it does.
+    auto *titleRow = new QHBoxLayout;
+    titleRow->setContentsMargins(0, 0, 0, 0);
+    titleRow->setSpacing(0);
+    titleRow->addWidget(m_accountBar, 0);
+    titleRow->addWidget(
+        new CustomTitleBar(this, central, CustomTitleBar::Mode::Merged), 1);
+    layout->addLayout(titleRow);
+  } else {
+    layout->addWidget(m_accountBar);
+  }
   layout->addWidget(m_displayStack);
 
   // In frameless mode there is no native resize edge, so give the window a
@@ -832,10 +863,13 @@ void MainWindow::refreshAccountTabs() {
   m_accountBar->setTabData(plus, QVariant()); // no data marks the "+" tab
   m_accountBar->setTabToolTip(plus, tr("Add another account"));
 
-  // Always show the strip in tabbed mode (Grid hides it separately), even for a
-  // single account, so the trailing "+" is a visible, discoverable way to add
-  // another account — otherwise the only entry point was Ctrl+K.
-  m_accountBar->setVisible(viewMode() != ViewMode::Grid);
+  // With more than one account the strip is the only way to reach the others,
+  // so it is always up in tabbed mode (Grid hides it separately). With a single
+  // account it is a row of chrome showing one tab, and the "+" it carries is
+  // reachable from Ctrl+K, the command palette and the Add-account action — so
+  // it stays out of the way unless asked for.
+  m_accountBar->setVisible(viewMode() != ViewMode::Grid &&
+                           (docked.size() > 1 || alwaysShowAccountTabs()));
   m_accountBar->setCurrentIndex(activeTab);
 
   refreshDetachedStrips(); // keep every detached window's strip in step too

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -464,6 +464,12 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(window), ui->minimizeOnTrayIconClick, G);
     moveWidget(body(window), ui->rememberWindowLayoutCheckBox, G);
     moveWidget(body(window), ui->hideTrayIconCheckBox, G);
+    // These three shape the window's own chrome, so they belong here rather
+    // than under "Network & Startup", where the frame checkbox had ended up
+    // next to the autostart one and was not where anyone looked for it.
+    moveWidget(body(window), ui->alwaysShowAccountTabsCheckBox, G);
+    moveWidget(body(window), ui->customWindowFrameCheckBox, G);
+    moveWidget(body(window), ui->tabsInTitleBarCheckBox, G);
     moveLayout(body(window), ui->gridLayout_9); // zoom block
 
     // ── Advanced ────────────────────────────────────────────
@@ -1308,9 +1314,12 @@ void SettingsWidget::loadNetworkSettings() {
     ui->autostartCheckBox->blockSignals(false);
   }
 
-  ui->customWindowFrameCheckBox->blockSignals(true);
-  ui->customWindowFrameCheckBox->setChecked(CustomTitleBar::isEnabled());
-  ui->customWindowFrameCheckBox->blockSignals(false);
+  ui->alwaysShowAccountTabsCheckBox->blockSignals(true);
+  ui->alwaysShowAccountTabsCheckBox->setChecked(
+      MainWindow::alwaysShowAccountTabs());
+  ui->alwaysShowAccountTabsCheckBox->blockSignals(false);
+
+  updateTitleBarOptionState(); // both window-frame boxes
 
   ui->checkUpdatesCheckBox->blockSignals(true);
   ui->checkUpdatesCheckBox->setChecked(UpdateChecker::isEnabled());
@@ -1584,8 +1593,40 @@ void SettingsWidget::on_interfaceScaleSpinBox_valueChanged(double arg1) {
   Performance::setInterfaceScaleFactor(arg1);
 }
 
+// Hiding the title bar means drawing the window's chrome ourselves, so it needs
+// the custom frame. Rather than greying the option out until the user has found
+// and understood the other one — which reads as the app refusing a setting for
+// no stated reason — turning this on turns that on too.
+void SettingsWidget::updateTitleBarOptionState() {
+  ui->customWindowFrameCheckBox->blockSignals(true);
+  ui->customWindowFrameCheckBox->setChecked(CustomTitleBar::isEnabled());
+  ui->customWindowFrameCheckBox->blockSignals(false);
+  ui->tabsInTitleBarCheckBox->blockSignals(true);
+  ui->tabsInTitleBarCheckBox->setChecked(CustomTitleBar::tabsInTitleBar());
+  ui->tabsInTitleBarCheckBox->blockSignals(false);
+}
+
 void SettingsWidget::on_customWindowFrameCheckBox_toggled(bool checked) {
   CustomTitleBar::setEnabled(checked);
+  // Switching the frame off leaves the stored "hide the title bar" value alone,
+  // so switching it back on restores what the user actually chose — but the
+  // checkbox has to stop claiming a hidden title bar in the meantime.
+  updateTitleBarOptionState();
+}
+
+void SettingsWidget::on_tabsInTitleBarCheckBox_toggled(bool checked) {
+  CustomTitleBar::setTabsInTitleBar(checked);
+  if (checked)
+    CustomTitleBar::setEnabled(true);
+  updateTitleBarOptionState();
+}
+
+void SettingsWidget::on_alwaysShowAccountTabsCheckBox_toggled(bool checked) {
+  MainWindow::setAlwaysShowAccountTabs(checked);
+  // Unlike the frame settings this one needs no restart: the strip is just
+  // shown or hidden.
+  if (auto *w = qobject_cast<MainWindow *>(parent()))
+    w->refreshAccountStrip();
 }
 
 void SettingsWidget::on_checkUpdatesCheckBox_toggled(bool checked) {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -134,6 +134,8 @@ private slots:
   void on_cacheMaxSpinBox_valueChanged(int arg1);
   void on_autostartCheckBox_toggled(bool checked);
   void on_customWindowFrameCheckBox_toggled(bool checked);
+  void on_tabsInTitleBarCheckBox_toggled(bool checked);
+  void on_alwaysShowAccountTabsCheckBox_toggled(bool checked);
   void on_checkUpdatesCheckBox_toggled(bool checked);
   void on_clearCacheButton_clicked();
   void on_exportProfileButton_clicked();
@@ -182,6 +184,10 @@ private slots:
   void on_deletePersistentData_clicked();
 
 private:
+  // Keep the two window-frame checkboxes telling the truth about each other:
+  // hiding the title bar switches the custom frame on, and dropping the custom
+  // frame means the title bar is back whatever the other box remembers.
+  void updateTitleBarOptionState();
   void loadPerformanceSettings();
   void loadNetworkSettings();
   void loadCloudApiSettings();

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -1677,10 +1677,30 @@ background:transparent;
           <item>
            <widget class="QCheckBox" name="customWindowFrameCheckBox">
             <property name="toolTip">
-             <string>Replace the system window border with Whatly's own slim title bar. Applies after a restart.</string>
+             <string>Let Whatly draw the window's border and title bar instead of the system, so they follow Whatly's own theme. On its own this only changes their appearance; tick &quot;Hide the title bar&quot; as well to get rid of the title row altogether. Applies after a restart.</string>
             </property>
             <property name="text">
              <string>Use a custom window frame (requires restart)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="alwaysShowAccountTabsCheckBox">
+            <property name="toolTip">
+             <string>Keep the account tab strip up even when there is only one account, so its &quot;+&quot; is always at hand. With it off, the strip appears once a second account exists; you can still add one with Ctrl+K.</string>
+            </property>
+            <property name="text">
+             <string>Show the account tabs even with a single account</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="tabsInTitleBarCheckBox">
+            <property name="toolTip">
+             <string>Drop the title bar and put its buttons at the end of the account tab strip, the way a browser does, instead of giving them a row of their own. Switches on the custom window frame, which it needs. Applies after a restart.</string>
+            </property>
+            <property name="text">
+             <string>Hide the title bar (requires restart)</string>
             </property>
            </widget>
           </item>

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -20,6 +20,7 @@
 #include <QTimer>
 #include <QToolButton>
 
+#include "customtitlebar.h"
 #include "settingswidget.h"
 
 class TstSettings : public QObject {
@@ -117,6 +118,60 @@ private slots:
     QVERIFY(!startMin->isChecked());
     minClick->setChecked(true);
     QVERIFY(!hide->isChecked());
+  }
+
+  // Gert's request #6: the account tabs can move into the title bar, but only
+  // where there is a custom title bar for them to move into. A stored "yes"
+  // left over from before the custom frame was switched off must not produce a
+  // window with neither a native title bar nor buttons of its own.
+  void tabsInTitleBarNeedsCustomFrame() {
+    const bool frame = CustomTitleBar::isEnabled();
+
+    CustomTitleBar::setTabsInTitleBar(true);
+    CustomTitleBar::setEnabled(false);
+    QVERIFY(!CustomTitleBar::tabsInTitleBar());
+
+    // Turning the frame back on restores the choice rather than losing it.
+    CustomTitleBar::setEnabled(true);
+    QVERIFY(CustomTitleBar::tabsInTitleBar());
+
+    CustomTitleBar::setTabsInTitleBar(false);
+    QVERIFY(!CustomTitleBar::tabsInTitleBar());
+
+    CustomTitleBar::setEnabled(frame);
+  }
+
+  // ...so ticking "Hide the title bar" has to bring the custom frame with it.
+  // Greying the box out until the user finds the other one reads as the app
+  // refusing a setting for no stated reason, so it is granted instead.
+  void hidingTitleBarSwitchesTheFrameOn() {
+    const bool frame = CustomTitleBar::isEnabled();
+    CustomTitleBar::setEnabled(false);
+    CustomTitleBar::setTabsInTitleBar(false);
+
+    QTemporaryDir cache, storage;
+    SettingsWidget sw(nullptr, 0, cache.path(), storage.path());
+    auto *frameBox = sw.findChild<QCheckBox *>("customWindowFrameCheckBox");
+    auto *tabsBox = sw.findChild<QCheckBox *>("tabsInTitleBarCheckBox");
+    QVERIFY(frameBox && tabsBox);
+    QVERIFY(tabsBox->isEnabled()); // never denied
+    QVERIFY(!frameBox->isChecked());
+
+    tabsBox->setChecked(true);
+    QVERIFY(CustomTitleBar::isEnabled());
+    QVERIFY(CustomTitleBar::tabsInTitleBar());
+    QVERIFY(frameBox->isChecked()); // and the other box says so
+
+    // Dropping the frame takes the title bar back, and the box stops claiming
+    // otherwise — but the stored choice survives for when it is switched on.
+    frameBox->setChecked(false);
+    QVERIFY(!CustomTitleBar::tabsInTitleBar());
+    QVERIFY(!tabsBox->isChecked());
+    frameBox->setChecked(true);
+    QVERIFY(CustomTitleBar::tabsInTitleBar());
+
+    CustomTitleBar::setEnabled(frame);
+    CustomTitleBar::setTabsInTitleBar(false);
   }
 
   // #9: the settings page is a set of collapsible accordion sections — an arrow


### PR DESCRIPTION
Two related changes to how the window presents its chrome.

### The account strip is now optional with a single account

It has been up unconditionally since the multi-window work, so that its trailing
"+" was discoverable. With one account that is a whole row of chrome carrying
one tab, and the "+" is on Ctrl+K, the command palette and the Add-account
action anyway.

New setting, **off by default**: "Show the account tabs even with a single
account". It takes effect immediately, no restart. With two or more accounts
nothing changes at all — the strip is the only way to reach the others, so it is
always there.

This reverses a deliberate choice, so it is the one thing here worth arguing
about. Happy to flip the default if you would rather keep the old behaviour.

### "Hide the title bar"

The existing custom-frame mode drops the native title bar and draws its own, on
a row of its own above the account tabs — two full-width bands of chrome before
the first message, where a browser gets away with one.

This merges them. `CustomTitleBar` gains `Mode::Merged`: no icon, no title, no
fixed 34px height, just the minimise/maximise/close buttons, expanding so its
empty left side is the drag handle. `buildAccountArea()` then puts it in one
`QHBoxLayout` beside the strip. 34px of vertical room back, and it looks like
every other tabbed application.

The strip and the buttons stay separate widgets on purpose: Grid view hides the
strip, and a window still has to be closable when it does.

Safety: off by default, applied at launch like the custom frame itself — no
window flag is ever toggled live — and `tabsInTitleBar()` returns false whenever
the custom frame is off, so a stored "yes" from an earlier session can never
produce a window with no title bar and no buttons. Covered by a test.

Ticking it switches the custom frame on rather than greying itself out until the
user has found and understood the other setting, which reads as the app refusing
a setting for no stated reason.

### Where the settings live

All three move from "Network & Startup" — where the frame checkbox had ended up
beside the autostart one, in a section that starts collapsed, and could not be
found — to "Window & zoom".

### Tested

Windows 10, Qt 6.11.1 / MSVC: both settings, the 1↔2-account boundary, dragging
and double-clicking the merged row, the size grip, Grid view, and every
combination of the two checkboxes including a stale stored value. Two new
tst_settings cases.

Linux Mint 22, Qt 6.12 / X11: the same checklist walked again and passed, on top
of a clean merge of all three branches, a clean build and `ctest` 3/3.

Two items neither platform could exercise: the always-on strip with two or more
accounts (no second linked-device slot was available — it is enforced in
`mainwindow_accounts.cpp`, which shows the strip when more than one account is
docked OR the setting is on), and Wayland, there being no Wayland session on the
test box. Everything else was verified live under X11.

### Known gap, deliberately out of scope

`DetachedAccountWindow` never honoured `customWindowFrame` at all — detached
windows keep their native frame in both frameless modes. Pre-existing, not
introduced here; fixing it changes today's behaviour, so it wants its own
decision.

Also: a frameless window has no native resize border, so the bottom-right size
grip is the only resize affordance. Edge and corner resizing needs a custom hit
test that works above the WebEngine view; worth doing, but on its own.
