### PR TITLE
feat(settings): a Restart now button, and three things around it

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,11 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
+#ifdef Q_OS_WIN
+#include <windows.h> // OpenProcess, for the restart handshake below
+#endif
 #include <QDebug>
+#include <QThread>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -371,8 +375,40 @@ static void setChromiumFlags() {
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS", flags.toUtf8());
 }
 
+// "Restart now" starts this process while the old one is still shutting down.
+// SingleApplication would see that one and hand these arguments over instead of
+// starting up, leaving nothing running at all, so wait for it to go first. It
+// is a wait, not a kill: the old instance is quitting through its own quit
+// path, which is what writes the window layout and the settings out.
+static void waitForPreviousInstance(int argc, char *argv[]) {
+  qint64 pid = 0;
+  const QLatin1String flag("--restart-wait=");
+  for (int i = 1; i < argc; ++i) {
+    const QString arg = QString::fromLocal8Bit(argv[i]);
+    if (arg.startsWith(flag)) {
+      pid = arg.mid(flag.size()).toLongLong();
+      break;
+    }
+  }
+  if (pid <= 0)
+    return;
+#ifdef Q_OS_WIN
+  if (HANDLE h = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid))) {
+    WaitForSingleObject(h, 20000); // never hang for ever on a wedged instance
+    CloseHandle(h);
+  }
+#else
+  for (int i = 0; i < 400 && ::kill(static_cast<pid_t>(pid), 0) == 0; ++i)
+    QThread::msleep(50);
+#endif
+  // The lock file/socket can outlive the process by a moment.
+  QThread::msleep(300);
+}
+
 int main(int argc, char *argv[]) {
   DebugLog::install();   // before anything can log
+
+  waitForPreviousInstance(argc, argv);
 
   // Which account this is has to be settled before anything else: it feeds the
   // single-instance key below, the settings file, and the WebEngine storage,
@@ -557,6 +593,16 @@ int main(int argc, char *argv[]) {
                   "in its own window"),
       QStringLiteral("name"));
 
+  // Likewise consumed by waitForPreviousInstance() before QApplication existed.
+  // It MUST be registered even though nothing reads it here: the parser rejects
+  // an unknown option outright, so a restart would spawn a process that put up
+  // "Unknown option 'restart-wait'" and died, leaving nothing running at all.
+  QCommandLineOption restartWaitOption(
+      QStringList() << "restart-wait",
+      QObject::tr("Internal: wait for the process with this id to exit before "
+                  "starting, used by \"Restart now\""),
+      QStringLiteral("pid"));
+
   QCommandLineOption showAppWindowOption(
       QStringList() << "w"
                     << "show-window",
@@ -588,6 +634,7 @@ int main(int argc, char *argv[]) {
   parser.addOption(reloadAppOption);
   parser.addOption(newChatOption);
   parser.addOption(profileOption);
+  parser.addOption(restartWaitOption);
   QCommandLineOption unreadOption(
       QStringList() << "u"
                     << "unread",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,8 @@
 
 #include <QTimer>
 #include <QDesktopServices>
+#include <QMessageBox>
+#include <QProcess>
 #include "privacyblur.h"
 #include "localapi.h"
 #include "cloudapi.h"
@@ -673,6 +675,23 @@ void MainWindow::initSettingWidget() {
             setNotificationPresenter(m_webEngine->page()->profile());
           });
 
+  connect(m_settingsWidget, &SettingsWidget::restartRequested, this,
+          &MainWindow::restartApp);
+
+  // Coming back from a restart: put the settings page back the way it was left,
+  // then forget it, so an ordinary launch does not open it.
+  {
+    QSettings &s = SettingsManager::instance().settings();
+    if (s.value(QStringLiteral("ui/settingsWasOpen"), false).toBool()) {
+      s.setValue(QStringLiteral("ui/settingsWasOpen"), false);
+      QTimer::singleShot(0, this, [this]() {
+        showSettings();
+        if (m_settingsWidget)
+          m_settingsWidget->restoreUiState();
+      });
+    }
+  }
+
   connect(m_settingsWidget, &SettingsWidget::webTweaksChanged, m_settingsWidget,
           [=]() {
             // Update the profile scripts for future page loads, and apply the
@@ -1204,6 +1223,50 @@ void MainWindow::sendAttachmentViaWeb(const QString &number,
                      "+'%2';}catch(e){console.error('whatly attach: '+e);}})();")
           .arg(jobJson, number);
   m_webEngine->page()->runJavaScript(js);
+}
+
+void MainWindow::raiseWindow() {
+  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+  show();
+  raise();
+  activateWindow();
+}
+
+// Come back as the SAME program, launched the SAME way. applicationFilePath()
+// rather than argv[0] (which can be a bare name found on PATH), and the real
+// argument list rather than a reconstruction of it, so --profile=work or a
+// --send still means what it meant.
+//
+// The new process cannot simply be started and left to it: SingleApplication
+// keys on the profile, so a second instance of the same account would hand its
+// arguments to the one still running and exit — and then nothing would be left.
+// It is handed the current process id instead and waits for it to go before
+// claiming the key. Nothing is killed: this window closes through the ordinary
+// quit path, which is also what writes the window layout out.
+void MainWindow::restartApp() {
+  QStringList args = QCoreApplication::arguments();
+  if (!args.isEmpty())
+    args.removeFirst(); // argv[0]
+  args.removeIf([](const QString &a) {
+    return a.startsWith(QLatin1String("--restart-wait="));
+  });
+  args << QStringLiteral("--restart-wait=%1")
+              .arg(QCoreApplication::applicationPid());
+
+  if (m_settingsWidget)
+    m_settingsWidget->saveUiState();
+  saveWindowLayout();
+  SettingsManager::instance().settings().sync(); // the new process reads these
+
+  if (!QProcess::startDetached(QCoreApplication::applicationFilePath(), args)) {
+    // Nothing has been closed yet, so a failure here costs the user nothing
+    // beyond the message.
+    QMessageBox::warning(this, tr("Restart"),
+                         tr("Whatly could not start a new instance, so it has "
+                            "not closed this one. Please quit and reopen it."));
+    return;
+  }
+  quitApp();
 }
 
 void MainWindow::toggleTheme() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -70,6 +70,14 @@ public slots:
   void lockOnHideIfEnabled();
   void toggleTheme();
   void togglePrivacyBlur();
+  // Relaunch this same executable with this same command line, so the settings
+  // that only apply at startup take effect without the user having to quit and
+  // find Whatly again. Everything about how the desk looks is saved first and
+  // put back by the new process.
+  void restartApp();
+  // Bring the window up and give it focus. The tray menu uses it: an action
+  // picked from there used to run with the window still behind everything.
+  void raiseWindow();
   void newChat();
 
 protected slots:

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -213,6 +213,28 @@ void MainWindow::createTrayIcon() {
   m_trayIconMenu->addSeparator();
   m_trayIconMenu->addAction(m_quitAction);
 
+  // Anything picked from the tray menu is a request to use Whatly, so bring it
+  // to the front — it used to run with the window still buried, which is
+  // baffling for "Settings" or "New chat". The three that are ABOUT the window
+  // not being up are the exceptions: quitting, minimising, and the theme
+  // toggle, which is worth having without stealing focus.
+  connect(m_trayIconMenu, &QMenu::triggered, this, [this](QAction *action) {
+    if (action == m_quitAction || action == m_minimizeAction ||
+        action == m_toggleThemeAction)
+      return;
+    raiseWindow();
+    // Settings opens a window of its own, and raising the main window above it
+    // is worse than not raising anything: the page you asked for ends up behind
+    // and without the keyboard. Put it back on top once this menu has unwound.
+    if (action == m_settingsAction)
+      QTimer::singleShot(0, this, [this]() {
+        if (m_settingsWidget && m_settingsWidget->isVisible()) {
+          m_settingsWidget->raise();
+          m_settingsWidget->activateWindow();
+        }
+      });
+  });
+
   m_systemTrayIcon = new QSystemTrayIcon(m_trayIconNormal, this);
   m_systemTrayIcon->setContextMenu(m_trayIconMenu);
   connect(m_trayIconMenu, &QMenu::aboutToShow, this,

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -349,6 +349,11 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     // An empty titled sub-section, ready to receive controls.
     const auto newSection = [host](const QString &title) {
       auto *g = new QGroupBox(title, host);
+      // Named so makeCollapsible can draw its outline by object name; a bare
+      // "QGroupBox" rule would reach the nested groups inside it too.
+      g->setObjectName(QStringLiteral("whatlySection%1")
+                           .arg(QString(title).remove(QLatin1Char(' '))
+                                    .remove(QLatin1Char('&'))));
       auto *v = new QVBoxLayout(g);
       v->setContentsMargins(12, 6, 6, 6);
       v->setSpacing(6);
@@ -464,6 +469,9 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(window), ui->minimizeOnTrayIconClick, G);
     moveWidget(body(window), ui->rememberWindowLayoutCheckBox, G);
     moveWidget(body(window), ui->hideTrayIconCheckBox, G);
+    // Right beside the settings that need one, rather than wherever the .ui
+    // happened to put it.
+    moveWidget(body(window), ui->restartNowButton, G);
     moveLayout(body(window), ui->gridLayout_9); // zoom block
 
     // ── Advanced ────────────────────────────────────────────
@@ -515,7 +523,14 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                             "text-align: left; padding: 3px 6px; }");
 
       box->setTitle(QString()); // the header shows the title now
-      box->setStyleSheet("QGroupBox { border: none; margin-top: 0px; }");
+      // An outline around an open section's contents, so it reads as one block
+      // belonging to the header above it rather than as loose controls. Scoped
+      // by object name: a plain "QGroupBox" rule would also outline the groups
+      // nested inside, doubling the borders.
+      box->setStyleSheet(
+          QStringLiteral("QGroupBox#%1{border:1px solid palette(mid);"
+                         "border-radius:6px;margin-top:0px;padding:2px}")
+              .arg(box->objectName()));
       box->setVisible(open);
 
       QObject::connect(
@@ -574,6 +589,11 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     makeCollapsible(ui->groupBoxJsAddons, false);    // JS Addons
     makeCollapsible(ui->groupBoxCanned, false);      // Canned responses
     makeCollapsible(ui->groupBoxShortcuts, false);   // Shortcuts
+    // These two arrived after the redesign and were left as bare groups, so
+    // they were the only settings on the page with no header to fold them away.
+    // ANY new group belongs on this list — or in one of the sections above.
+    makeCollapsible(ui->groupBoxCloudApi, false);    // Cloud API
+    makeCollapsible(ui->groupBoxLocalApi, false);    // Local API & webhooks
 
     // Stack the section headers directly beneath one another with about one
     // character of breathing room, instead of letting the column stretch them
@@ -1586,6 +1606,59 @@ void SettingsWidget::on_interfaceScaleSpinBox_valueChanged(double arg1) {
 
 void SettingsWidget::on_customWindowFrameCheckBox_toggled(bool checked) {
   CustomTitleBar::setEnabled(checked);
+}
+
+void SettingsWidget::on_restartNowButton_clicked() { emit restartRequested(); }
+
+// The accordion headers, in the order they appear. They are the QToolButtons
+// carrying an arrow — the same handle the section test uses — so there is no
+// second list to keep in step with the one that builds them.
+static QList<QToolButton *> sectionHeaders(const QWidget *page) {
+  QList<QToolButton *> headers;
+  for (auto *tb : page->findChildren<QToolButton *>())
+    if (tb->arrowType() == Qt::DownArrow || tb->arrowType() == Qt::RightArrow)
+      headers << tb;
+  return headers;
+}
+
+void SettingsWidget::saveUiState() {
+  QSettings &s = SettingsManager::instance().settings();
+  QStringList open;
+  const QList<QToolButton *> headers = sectionHeaders(this);
+  for (int i = 0; i < headers.size(); ++i)
+    if (headers[i]->isChecked())
+      open << QString::number(i);
+  s.setValue(QStringLiteral("ui/settingsSections"), open.join(QLatin1Char(',')));
+  s.setValue(QStringLiteral("ui/settingsScroll"),
+             ui->scrollArea->verticalScrollBar()->value());
+  s.setValue(QStringLiteral("ui/settingsGeometry"), saveGeometry());
+  s.setValue(QStringLiteral("ui/settingsWasOpen"), isVisible());
+}
+
+void SettingsWidget::restoreUiState() {
+  QSettings &s = SettingsManager::instance().settings();
+  const QByteArray geom =
+      s.value(QStringLiteral("ui/settingsGeometry")).toByteArray();
+  if (!geom.isEmpty())
+    restoreGeometry(geom);
+
+  QSet<int> want;
+  const QStringList open = s.value(QStringLiteral("ui/settingsSections"))
+                               .toString()
+                               .split(QLatin1Char(','), Qt::SkipEmptyParts);
+  for (const QString &n : open)
+    want.insert(n.toInt());
+  const QList<QToolButton *> headers = sectionHeaders(this);
+  for (int i = 0; i < headers.size(); ++i)
+    headers[i]->setChecked(want.contains(i));
+
+  // The sections have only just been told to open; the scroll range they
+  // create does not exist until the layout settles, so the offset is applied
+  // one turn of the event loop later.
+  const int offset = s.value(QStringLiteral("ui/settingsScroll"), 0).toInt();
+  QTimer::singleShot(0, this, [this, offset]() {
+    ui->scrollArea->verticalScrollBar()->setValue(offset);
+  });
 }
 
 void SettingsWidget::on_checkUpdatesCheckBox_toggled(bool checked) {

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -621,7 +621,12 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     makeCollapsible(ui->groupBoxShortcuts, false);   // Shortcuts
     // These two arrived after the redesign and were left as bare groups, so
     // they were the only settings on the page with no header to fold them away.
-    // ANY new group belongs on this list — or in one of the sections above.
+    //
+    // PLEASE KEEP IT THAT WAY: every setting on this page lives inside a
+    // section that folds. A new one goes into whichever section above it
+    // belongs to; a new group of them gets a header of its own and joins this
+    // list. Nothing should sit loose on the page — that is how the custom
+    // window frame ended up somewhere nobody looked for it.
     makeCollapsible(ui->groupBoxCloudApi, false);    // Cloud API
     makeCollapsible(ui->groupBoxLocalApi, false);    // Local API & webhooks
 

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -18,6 +18,7 @@
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QCheckBox>
+#include <QPushButton>
 #include <QToolButton>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -370,17 +371,29 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
         p->removeItem(inner);
       dst->addLayout(inner);
     };
-    // Move one control (detached from its source layout) onto its own row.
-    const auto moveWidget = [](QVBoxLayout *dst, QWidget *w, QLayout *src) {
+    // Move one control (detached from its source layout) onto its own row. An
+    // `end` widget rides at the right-hand end of that row instead of costing a
+    // row of its own — the shape the zoom controls already use.
+    const auto moveWidget = [](QVBoxLayout *dst, QWidget *w, QLayout *src,
+                               QWidget *end = nullptr) {
       if (!dst || !w)
         return;
       if (src)
         src->removeWidget(w);
-      dst->addWidget(w);
+      if (!end) {
+        dst->addWidget(w);
+        return;
+      }
+      auto *h = new QHBoxLayout;
+      h->setContentsMargins(0, 0, 0, 0);
+      h->addWidget(w);
+      h->addStretch(1);
+      h->addWidget(end);
+      dst->addLayout(h);
     };
     // Move a label + field pair onto a single row.
     const auto moveRow = [](QVBoxLayout *dst, QWidget *a, QWidget *b,
-                            QLayout *src) {
+                            QLayout *src, QWidget *end = nullptr) {
       if (!dst)
         return;
       auto *h = new QHBoxLayout;
@@ -395,7 +408,20 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           src->removeWidget(b);
         h->addWidget(b, 1);
       }
+      if (end)
+        h->addWidget(end);
       dst->addLayout(h);
+    };
+    // A second "Restart now", for a section that has one setting needing a
+    // restart rather than a run of them. Same words and same tooltip as the
+    // button in the .ui, so there is nothing extra to translate.
+    const auto restartButton = [this]() {
+      auto *b = new QPushButton(ui->restartNowButton->text(), this);
+      b->setToolTip(ui->restartNowButton->toolTip());
+      b->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
+      connect(b, &QPushButton::clicked, this,
+              &SettingsWidget::restartRequested);
+      return b;
     };
     // Move a label + a nested control-layout pair onto a single row.
     const auto moveRowL = [](QVBoxLayout *dst, QWidget *a, QLayout *sub,
@@ -422,7 +448,8 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
 
     // ── Basics ──────────────────────────────────────────────
     auto *basics = newSection(tr("Basics"));
-    moveRow(body(basics), ui->languageLabel, ui->languageComboBox, G);
+    moveRow(body(basics), ui->languageLabel, ui->languageComboBox, G,
+            restartButton());
     moveLayout(body(basics), ui->gridLayout_7); // default download location
     moveWidget(body(basics), ui->useNativeFileDialog, G);
     moveWidget(body(basics), ui->identifyInLinkedDevicesCheckBox, G);
@@ -469,9 +496,12 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(window), ui->minimizeOnTrayIconClick, G);
     moveWidget(body(window), ui->rememberWindowLayoutCheckBox, G);
     moveWidget(body(window), ui->hideTrayIconCheckBox, G);
-    // Right beside the settings that need one, rather than wherever the .ui
-    // happened to put it.
-    moveWidget(body(window), ui->restartNowButton, G);
+    // Right beside the setting that needs one, rather than wherever the .ui
+    // happened to put it — which also brings the frame checkbox over from
+    // "Network & Startup", where it had ended up next to the autostart one and
+    // was not where anyone looked for it.
+    moveWidget(body(window), ui->customWindowFrameCheckBox, G,
+               ui->restartNowButton);
     moveLayout(body(window), ui->gridLayout_9); // zoom block
 
     // ── Advanced ────────────────────────────────────────────

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -47,6 +47,9 @@ signals:
   // Emitted when the local API / webhook settings change, so the window can
   // (re)start or stop the server.
   void localApiSettingsChanged();
+  // "Restart now": the settings that only take effect at launch are worth
+  // nothing until the app comes back, so offer to do it here.
+  void restartRequested();
 
 public:
   explicit SettingsWidget(QWidget *parent = nullptr, int screenNumber = 0,
@@ -56,6 +59,11 @@ public:
 
 public slots:
   void refresh();
+  // Remember/replay everything about how this page is left: which sections are
+  // open, how far it is scrolled, where the window sits, and whether it was
+  // open at all — so a restart can put it back rather than merely reopening it.
+  void saveUiState();
+  void restoreUiState();
   void updateDefaultUAButton(const QString engineUA);
   void appLockSetChecked(bool checked);
   void muteAudioSetChecked(bool checked);
@@ -134,6 +142,7 @@ private slots:
   void on_cacheMaxSpinBox_valueChanged(int arg1);
   void on_autostartCheckBox_toggled(bool checked);
   void on_customWindowFrameCheckBox_toggled(bool checked);
+  void on_restartNowButton_clicked();
   void on_checkUpdatesCheckBox_toggled(bool checked);
   void on_clearCacheButton_clicked();
   void on_exportProfileButton_clicked();

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -1685,6 +1685,16 @@ background:transparent;
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="restartNowButton">
+            <property name="toolTip">
+             <string>Restart Whatly now so the settings above take effect. The windows, and this page with it, come back exactly as they are.</string>
+            </property>
+            <property name="text">
+             <string>Restart now</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="checkUpdatesCheckBox">
             <property name="toolTip">
              <string>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</string>

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -477,7 +477,7 @@ background:transparent;
             <item row="6" column="0">
              <widget class="QLabel" name="languageLabel">
               <property name="text">
-               <string>Interface language</string>
+               <string>Interface language (requires restart)</string>
               </property>
              </widget>
             </item>
@@ -1686,6 +1686,12 @@ background:transparent;
           </item>
           <item>
            <widget class="QPushButton" name="restartNowButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="toolTip">
              <string>Restart Whatly now so the settings above take effect. The windows, and this page with it, come back exactly as they are.</string>
             </property>


### PR DESCRIPTION
Several settings only take effect at launch, and until now the app said so and
left the user to quit and find Whatly again. This adds a **Restart now** button
beside them, plus three smaller things noticed while working there.

### Restart now

It comes back as the SAME program launched the SAME way:
`applicationFilePath()` rather than `argv[0]`, which can be a bare name found on
PATH, and the real `QCoreApplication::arguments()` rather than a reconstruction
of it, so `--profile=work` still means what it meant.

Nothing is killed. The old window closes through the ordinary quit path, which
is also what writes the window layout out.

**The part worth reviewing carefully:** the new process cannot simply be started
and left to it. SingleApplication keys on the profile, so a second instance of
the same account would hand its arguments to the one still shutting down and
exit — leaving nothing running at all. It is passed the outgoing process id and
waits for it to go before claiming the key (`waitForPreviousInstance()`, before
QApplication exists: `OpenProcess`/`WaitForSingleObject` on Windows,
`kill(pid, 0)` polling elsewhere, capped at 20s so a wedged instance cannot hang
the restart for ever).

⚠️ **Please do not merge this partially.** `--restart-wait` is consumed early,
before QApplication, but it MUST also be registered with `parser.addOption` —
`QCommandLineParser` rejects an unknown option outright, so without that
registration the relaunched process puts up "Unknown option 'restart-wait'" and
dies, and the user is left with nothing running. That is a real failure I hit
during development, and the `--profile` comment right above it already warned
about exactly this hazard.

What the user had is put back, not merely reopened: the settings page remembers
which sections were open, how far it was scrolled, where its window sat and
whether it was up at all. The window layout was already saved on quit.

### Three things around it

- **The Cloud API and Local API groups get collapsible headers.** They arrived
  after the settings redesign and were never added to that list, so they were
  the only settings on the page with no header to fold them away. The comment
  there now says any new group belongs on the list — that is how the custom
  window frame ended up unfindable.
- **An open section's contents get an outline**, so they read as one block
  belonging to the header above rather than as loose controls. Scoped by object
  name: a plain `QGroupBox` rule would also outline the groups nested inside and
  double the borders.
- **Picking anything from the tray menu brings the window to the front.** It
  used to run with the window still buried, which is baffling for "Settings" or
  "New chat". Quit, Minimise and the theme toggle are exempt — they are about
  the window NOT coming up. Settings additionally gets the keyboard, since
  raising the main window above the page you just asked for is worse than not
  raising anything.

### One request

Every setting on this page now lives inside a section that folds, and these two
groups were the last that did not. **Please keep it that way for new settings.**
A single new setting goes into whichever section it belongs to; a new group of
them gets a header of its own and joins the list in `settingswidget.cpp`, where
the comment now says so. Nothing loose on the page.

It is the one thing about this layout that quietly comes undone — the custom
window frame is how we found out, sitting next to the autostart checkbox where
nobody went looking for it.

### Tested

Windows 10, Qt 6.11.1 / MSVC. The restart handshake was verified in isolation
first — launching with `--restart-wait=<live pid>` leaves two processes, the new
one waiting rather than handing off, and once the old one goes exactly one
remains — and then end to end through the button, including from
`--profile=dogfood`, checking the settings page comes back with the same
sections open, the same scroll offset and the same geometry.

Linux Mint 22, Qt 6.12 / X11: the same checklist walked again and passed. The
restart was watched at the process level — one PID replaced by another carrying
a fresh `--restart-wait`, never zero processes and never two, and no "Unknown
option" at any point.

Not exercised: the relaunch under Flatpak, where `applicationFilePath()` is the
in-sandbox path. The test box built natively only, so that one is worth a
dedicated check before the next Flatpak release.

