### PR TITLE
feat(i18n): add Esperanto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ if (Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
         TS_FILES
             src/i18n/ar_SA.ts
             src/i18n/de_DE.ts
+            src/i18n/eo.ts
             src/i18n/es_ES.ts
             src/i18n/fr_FR.ts
             src/i18n/hi_IN.ts

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -1,0 +1,3129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eo">
+<context>
+    <name>About</name>
+    <message>
+        <location filename="../about.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="117"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Whatly&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;WhatsApp Web Client for Linux Desktop.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Whatly&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Klientprogramo de Vacapo Reto por labortabla Linukso.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="135"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="142"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Designed &amp;amp; Developed by:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Email: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Website:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Desegnita kaj programita de:&lt;/span&gt; Keshav Bhatt &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Retpoŝto: &lt;/span&gt;keshavnrj@gmail.com&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Retejo:&lt;/span&gt; http://ktechpit.com&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="171"/>
+        <source>Donate PayPal</source>
+        <translation>Donaci per PayPal</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="178"/>
+        <source>Ko-fi</source>
+        <translation>Ko-fi</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="185"/>
+        <source>Wise</source>
+        <translation>Wise</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="192"/>
+        <source>Rate in Store</source>
+        <translation>Taksi en la butiko</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="203"/>
+        <source>More Applications</source>
+        <translation>Pliaj aplikaĵoj</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="210"/>
+        <source>Source Code</source>
+        <translation>Fontkodo</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="217"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the debug information below to the clipboard and opens the issue tracker, so it can be pasted straight into the report.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kopias la sencimigan informon sube al la tondujo kaj malfermas la cimlistigilon, por ke vi povu rekte alglui ĝin en la raporton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="220"/>
+        <location filename="../about.cpp" line="144"/>
+        <source>Report a Bug</source>
+        <translation>Raporti cimon</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="229"/>
+        <source>Debug Info</source>
+        <translation>Sencimiga informo</translation>
+    </message>
+    <message>
+        <location filename="../about.cpp" line="88"/>
+        <source>Version: </source>
+        <translation>Versio: </translation>
+    </message>
+    <message>
+        <location filename="../about.cpp" line="145"/>
+        <source>The debug information was too long for the browser to carry, so it has been copied to your clipboard instead. Paste it into the issue.</source>
+        <translation>La sencimiga informo estis tro longa por la retumilo, do ĝi anstataŭe estis kopiita al via tondujo. Algluu ĝin en la raporton.</translation>
+    </message>
+    <message>
+        <location filename="../about.cpp" line="152"/>
+        <source> | About</source>
+        <translation> | Pri</translation>
+    </message>
+</context>
+<context>
+    <name>AutomaticTheme</name>
+    <message>
+        <location filename="../automatictheme.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.ui" line="27"/>
+        <source>Sunrise</source>
+        <translation>Sunleviĝo</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.ui" line="34"/>
+        <source>Sunset</source>
+        <translation>Sunsubiro</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.ui" line="55"/>
+        <source>  Refresh </source>
+        <translation>  Aktualigi </translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.ui" line="70"/>
+        <source>Disable and Close</source>
+        <translation>Malŝalti kaj fermi</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.ui" line="94"/>
+        <source>  Enable and Close</source>
+        <translation>  Ŝalti kaj fermi</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.cpp" line="27"/>
+        <location filename="../automatictheme.cpp" line="62"/>
+        <location filename="../automatictheme.cpp" line="94"/>
+        <location filename="../automatictheme.cpp" line="103"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.cpp" line="95"/>
+        <source>Invalid Geo-Coordinates.
+
+Please try again.</source>
+        <translation>Nevalidaj geografiaj koordinatoj.
+
+Bonvolu reprovi.</translation>
+    </message>
+    <message>
+        <location filename="../automatictheme.cpp" line="104"/>
+        <source>Invalid configuration.
+
+Sunrise and Sunset time cannot have similar values.
+
+Please try again.</source>
+        <translation>Nevalida agordo.
+
+La horoj de sunleviĝo kaj sunsubiro ne povas esti samaj.
+
+Bonvolu reprovi.</translation>
+    </message>
+</context>
+<context>
+    <name>CertificateErrorDialog</name>
+    <message>
+        <location filename="../certificateerrordialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Dialogo</translation>
+    </message>
+    <message>
+        <location filename="../certificateerrordialog.ui" line="26"/>
+        <source>Icon</source>
+        <translation>Piktogramo</translation>
+    </message>
+    <message>
+        <location filename="../certificateerrordialog.ui" line="42"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../certificateerrordialog.ui" line="61"/>
+        <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate mean you may not be connected with the host you tried to connect to.
+
+Do you wish to override the security check and continue ?   </source>
+        <translation>Se vi deziras, vi povas daŭrigi kun nekontrolita atestilo. Akcepti nekontrolitan atestilon signifas, ke eble vi ne konektiĝas al la gastiganto, al kiu vi provis konektiĝi.
+
+Ĉu vi volas preteriri la sekurecan kontrolon kaj daŭrigi ?   </translation>
+    </message>
+</context>
+<context>
+    <name>ChatTheme</name>
+    <message>
+        <location filename="../chattheme.cpp" line="156"/>
+        <source>WhatsApp (default)</source>
+        <translation>Vacapo (defaŭlta)</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="158"/>
+        <source>Barbie pink</source>
+        <translation>Barbie-rozkolora</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="160"/>
+        <source>Dusty rose</source>
+        <translation>Polvorozkolora</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="162"/>
+        <source>Lavender</source>
+        <translation>Lavendkolora</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="164"/>
+        <source>Violet</source>
+        <translation>Viola</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="166"/>
+        <source>Sky blue</source>
+        <translation>Ĉielblua</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="168"/>
+        <source>Deep ocean</source>
+        <translation>Profunda oceano</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="170"/>
+        <source>Teal</source>
+        <translation>Anasblua</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="172"/>
+        <source>Mint</source>
+        <translation>Mento</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="174"/>
+        <source>Coral</source>
+        <translation>Koralo</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="176"/>
+        <source>Peach</source>
+        <translation>Persiko</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="178"/>
+        <source>Gold</source>
+        <translation>Ora</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="180"/>
+        <source>Crimson</source>
+        <translation>Karmezina</translation>
+    </message>
+    <message>
+        <location filename="../chattheme.cpp" line="182"/>
+        <source>Graphite</source>
+        <translation>Grafito</translation>
+    </message>
+</context>
+<context>
+    <name>CommandPalette</name>
+    <message>
+        <location filename="../commandpalette.cpp" line="46"/>
+        <source>Command palette</source>
+        <translation>Komandpaletro</translation>
+    </message>
+    <message>
+        <location filename="../commandpalette.cpp" line="57"/>
+        <source>Type a command…</source>
+        <translation>Tajpu komandon…</translation>
+    </message>
+    <message>
+        <location filename="../commandpalette.cpp" line="59"/>
+        <source>Command search</source>
+        <translation>Serĉo de komandoj</translation>
+    </message>
+    <message>
+        <location filename="../commandpalette.cpp" line="62"/>
+        <source>Matching commands</source>
+        <translation>Kongruaj komandoj</translation>
+    </message>
+</context>
+<context>
+    <name>CustomTitleBar</name>
+    <message>
+        <location filename="../customtitlebar.cpp" line="47"/>
+        <source>Minimise</source>
+        <translation>Minimumigi</translation>
+    </message>
+    <message>
+        <location filename="../customtitlebar.cpp" line="51"/>
+        <source>Maximise</source>
+        <translation>Maksimumigi</translation>
+    </message>
+    <message>
+        <location filename="../customtitlebar.cpp" line="55"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadManagerWidget</name>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="20"/>
+        <source>Downloads</source>
+        <translation>Elŝutoj</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="80"/>
+        <source>No downloads</source>
+        <translation>Neniu elŝuto</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="125"/>
+        <source>Clear download list</source>
+        <translation>Malplenigi la liston de elŝutoj</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="128"/>
+        <source>Clear all</source>
+        <translation>Forigi ĉion</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="139"/>
+        <source>Open download directory in file manager</source>
+        <translation>Malfermi la elŝutan dosierujon en la dosieradministrilo</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.ui" line="142"/>
+        <source>Open Download directory</source>
+        <translation>Malfermi la elŝutan dosierujon</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.cpp" line="36"/>
+        <source>File with same name already exist!</source>
+        <translation>Dosiero kun la sama nomo jam ekzistas!</translation>
+    </message>
+    <message>
+        <location filename="../downloadmanagerwidget.cpp" line="37"/>
+        <source>Save file with a new name?</source>
+        <translation>Ĉu konservi la dosieron sub nova nomo?</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWidget</name>
+    <message>
+        <location filename="../downloadwidget.ui" line="26"/>
+        <location filename="../downloadwidget.ui" line="48"/>
+        <source>TextLabel</source>
+        <translation>TekstEtikedo</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.ui" line="63"/>
+        <source>Open file using system application</source>
+        <translation>Malfermi la dosieron per la sistema aplikaĵo</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="58"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="60"/>
+        <source>%L1 KiB</source>
+        <translation>%L1 KiB</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="62"/>
+        <source>%L1 MiB</source>
+        <translation>%L1 MiB</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="64"/>
+        <source>%L1 GiB</source>
+        <translation>%L1 GiB</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="86"/>
+        <source>%p% - %1 of %2 downloaded - %3/s</source>
+        <translation>%p% - %1 el %2 elŝutitaj - %3/s</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="94"/>
+        <source>unknown size - %1 downloaded - %2/s</source>
+        <translation>nekonata grando - %1 elŝutitaj - %2/s</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="103"/>
+        <source>completed - %1 downloaded - %2/s</source>
+        <translation>finita - %1 elŝutitaj - %2/s</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="111"/>
+        <source>cancelled - %1 downloaded - %2/s</source>
+        <translation>nuligita - %1 elŝutitaj - %2/s</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="119"/>
+        <source>interrupted: %1</source>
+        <translation>interrompita: %1</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="127"/>
+        <source>Stop downloading</source>
+        <translation>Ĉesigi la elŝuton</translation>
+    </message>
+    <message>
+        <location filename="../downloadwidget.cpp" line="131"/>
+        <source>Remove from list</source>
+        <translation>Forigi el la listo</translation>
+    </message>
+</context>
+<context>
+    <name>Lock</name>
+    <message>
+        <location filename="../lock.ui" line="20"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="199"/>
+        <source>Set lock passcode</source>
+        <translation>Agordi la ŝlosan paskodon</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="224"/>
+        <source>enter passcode</source>
+        <translation>enigu la paskodon</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="243"/>
+        <source>enter passcode again</source>
+        <translation>enigu la paskodon denove</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="256"/>
+        <source>Set Pass Code</source>
+        <translation>Agordi paskodon</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="269"/>
+        <source>Cancel</source>
+        <translation>Nuligi</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="276"/>
+        <location filename="../lock.ui" line="629"/>
+        <source>Warning: Caps Lock is On</source>
+        <translation>Averto: Majuskla baskulo estas ŝaltita</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="346"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Passcode must be more then 3 characters and must match in both fields.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Noto: la paskodo devas havi pli ol 3 signojn kaj devas kongrui en ambaŭ kampoj.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="597"/>
+        <source>Enter your passcode to get access</source>
+        <translation>Enigu vian paskodon por aliri</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="622"/>
+        <source>enter your passcode</source>
+        <translation>enigu vian paskodon</translation>
+    </message>
+    <message>
+        <location filename="../lock.ui" line="639"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wrong Passcode, Please try again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Malĝusta paskodo. Bonvolu reprovi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.cpp" line="101"/>
+        <location filename="../mainwindow.cpp" line="1069"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
+        <source>No WhatsApp window is open</source>
+        <translation>Neniu fenestro de Vacapo estas malfermita</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="106"/>
+        <source>Reminder</source>
+        <translation>Memorigilo</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="106"/>
+        <source>Reminder: %1</source>
+        <translation>Memorigilo: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="185"/>
+        <source>Update available</source>
+        <translation>Ĝisdatigo disponebla</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="186"/>
+        <source>Whatly %1 is available. Click to open the download page.</source>
+        <translation>Whatly %1 estas disponebla. Alklaku por malfermi la elŝutan paĝon.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="811"/>
+        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow_webengine.cpp" line="918"/>
+        <location filename="../mainwindow_webengine.cpp" line="921"/>
+        <source>| Error</source>
+        <translation>| Eraro</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="812"/>
+        <source>Unlock to access Settings.</source>
+        <translation>Malŝlosu por atingi la agordojn.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="818"/>
+        <source>Unable to initialize settings module.
+Webengine is not initialized.</source>
+        <translation>Ne eblas pravalorizi la agordan modulon.
+La retmotoro ne estas pravalorizita.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="839"/>
+        <source> | Action required</source>
+        <translation> | Ago necesa</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="840"/>
+        <source>Page needs to be reloaded to continue.</source>
+        <translation>La paĝo devas esti reŝargita por daŭrigi.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1022"/>
+        <source>The Cloud API needs a phone number as the recipient.</source>
+        <translation>La Nuba API bezonas telefonnumeron kiel ricevanton.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1027"/>
+        <source>The Cloud API is not configured.</source>
+        <translation>La Nuba API ne estas agordita.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1036"/>
+        <source>Cloud API send failed: %1</source>
+        <translation>Sendo per la Nuba API malsukcesis: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1061"/>
+        <source>Could not understand the recipient: %1</source>
+        <translation>Ne eblis kompreni la ricevanton: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1090"/>
+        <location filename="../mainwindow.cpp" line="1171"/>
+        <source>Could not read the file to send: %1</source>
+        <translation>Ne eblis legi la sendotan dosieron: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1181"/>
+        <source>The file is too large to send over the web backend.</source>
+        <translation>La dosiero estas tro granda por sendi tra la reta internaĵo.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1124"/>
+        <source>Opening the group and sending…</source>
+        <translation>Malfermado de la grupo kaj sendado…</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1125"/>
+        <source>Opening the chat with &quot;%1&quot; and sending…</source>
+        <translation>Malfermado de la babilo kun &quot;%1&quot; kaj sendado…</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1156"/>
+        <source>The local API could not start: %1</source>
+        <translation>La loka API ne povis startiĝi: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1284"/>
+        <source>Open</source>
+        <translation>Malfermi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1294"/>
+        <location filename="../mainwindow_tray.cpp" line="21"/>
+        <source>New Chat</source>
+        <translation>Nova babilo</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1295"/>
+        <source>Enter a valid WhatsApp number with country code (ex- +91XXXXXXXXXX)</source>
+        <translation>Enigu validan numeron de Vacapo kun landokodo (ekz. +91XXXXXXXXXX)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1325"/>
+        <source>Rate Application</source>
+        <translation>Taksi la aplikaĵon</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="165"/>
+        <location filename="../mainwindow_accounts.cpp" line="1053"/>
+        <source>Rename…</source>
+        <translation>Alinomi…</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="166"/>
+        <location filename="../mainwindow_accounts.cpp" line="1054"/>
+        <source>Open in own window</source>
+        <translation>Malfermi en propra fenestro</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="170"/>
+        <location filename="../mainwindow_accounts.cpp" line="1057"/>
+        <source>Remove account</source>
+        <translation>Forigi la konton</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="247"/>
+        <source>Switch to account: %1</source>
+        <translation>Ŝalti al la konto: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="250"/>
+        <location filename="../mainwindow_tray.cpp" line="133"/>
+        <source>Add account…</source>
+        <translation>Aldoni konton…</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="255"/>
+        <source>Insert: %1</source>
+        <translation>Enmeti: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="533"/>
+        <source>%1 — %2 unread</source>
+        <translation>%1 — %2 nelegitaj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="833"/>
+        <source>Add another account</source>
+        <translation>Aldoni alian konton</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="856"/>
+        <location filename="../mainwindow_accounts.cpp" line="861"/>
+        <source>Restore</source>
+        <translation>Restarigi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="857"/>
+        <source>messages</source>
+        <translation>mesaĝoj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="857"/>
+        <source>message</source>
+        <translation>mesaĝo</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="902"/>
+        <source>Add account</source>
+        <translation>Aldoni konton</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="903"/>
+        <source>Name for the new account:</source>
+        <translation>Nomo por la nova konto:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="904"/>
+        <location filename="../mainwindow_accounts.cpp" line="1750"/>
+        <location filename="../mainwindow_accounts.cpp" line="1755"/>
+        <source>Account %1</source>
+        <translation>Konto %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="931"/>
+        <source>Rename account</source>
+        <translation>Alinomi la konton</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="931"/>
+        <source>Account name:</source>
+        <translation>Nomo de la konto:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="1438"/>
+        <source>Tip: give an account its own window</source>
+        <translation>Konsileto: donu al konto ĝian propran fenestron</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="1439"/>
+        <source>You now have more than one account, shown as tabs along the top.
+
+You can pull any account out into its own window: right-click its tab and choose “Open in own window”. Close that window to dock the account back as a tab.</source>
+        <translation>Vi nun havas pli ol unu konton, montratajn kiel langetojn supre.
+
+Vi povas eltiri iun ajn konton en propran fenestron: dekstre alklaku ĝian langeton kaj elektu “Malfermi en propra fenestro”. Fermu tiun fenestron por redoki la konton kiel langeton.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_accounts.cpp" line="1744"/>
+        <location filename="../mainwindow_accounts.cpp" line="1748"/>
+        <source>Account 1</source>
+        <translation>Konto 1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_lock.cpp" line="136"/>
+        <source>App lock is not configured, 
+Please setup the password in the Settings first.
+
+Open Settings now?</source>
+        <translation>La aplikaĵa ŝloso ne estas agordita.
+Bonvolu unue agordi la pasvorton en la Agordoj.
+
+Ĉu malfermi la Agordojn nun?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="26"/>
+        <location filename="../mainwindow_tray.cpp" line="173"/>
+        <source>Fullscreen</source>
+        <translation>Plenekrane</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="32"/>
+        <source>Mi&amp;nimize to tray</source>
+        <translation>Mi&amp;nimumigi al la sistempleto</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="51"/>
+        <source>&amp;Restore</source>
+        <translation>&amp;Restarigi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="55"/>
+        <source>Re&amp;load</source>
+        <translation>Reŝar&amp;gi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="61"/>
+        <source>Loc&amp;k</source>
+        <translation>Ŝ&amp;losi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="66"/>
+        <source>&amp;Mute audio</source>
+        <translation>&amp;Silentigi la sonon</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="75"/>
+        <source>Zoom in</source>
+        <translation>Enzomi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="81"/>
+        <source>Zoom out</source>
+        <translation>Elzomi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="86"/>
+        <location filename="../mainwindow_tray.cpp" line="175"/>
+        <source>Reset zoom</source>
+        <translation>Restarigi la zomon</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="91"/>
+        <source>&amp;Settings</source>
+        <translation>&amp;Agordoj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="97"/>
+        <source>Scheduled &amp;messages…</source>
+        <translation>Planitaj &amp;mesaĝoj…</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="102"/>
+        <source>&amp;Toggle theme</source>
+        <translation>&amp;Baskuligi la etoson</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="113"/>
+        <source>Tabbed view</source>
+        <translation>Langeta vido</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="120"/>
+        <location filename="../mainwindow_tray.cpp" line="178"/>
+        <source>Grid view</source>
+        <translation>Krada vido</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="138"/>
+        <location filename="../mainwindow_tray.cpp" line="179"/>
+        <source>Command palette</source>
+        <translation>Komandpaletro</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="147"/>
+        <source>&amp;About</source>
+        <translation>&amp;Pri</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="156"/>
+        <source>&amp;Quit</source>
+        <translation>&amp;Eliri</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="169"/>
+        <source>Reload</source>
+        <translation>Reŝargi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="170"/>
+        <source>Minimise to tray</source>
+        <translation>Minimumigi al la sistempleto</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="171"/>
+        <source>Lock</source>
+        <translation>Ŝlosi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="172"/>
+        <source>Mute audio</source>
+        <translation>Silentigi la sonon</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="174"/>
+        <source>New chat / open URL</source>
+        <translation>Nova babilo / malfermi URL</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="176"/>
+        <source>Settings</source>
+        <translation>Agordoj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="177"/>
+        <source>Toggle theme</source>
+        <translation>Baskuligi la etoson</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="180"/>
+        <source>Quit</source>
+        <translation>Eliri</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_webengine.cpp" line="916"/>
+        <source>Unlock to Reload the App.</source>
+        <translation>Malŝlosu por reŝargi la aplikaĵon.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_webengine.cpp" line="959"/>
+        <source>Waiting for network…</source>
+        <translation>Atendado de la reto…</translation>
+    </message>
+</context>
+<context>
+    <name>MoreApps</name>
+    <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../widgets/MoreApps/moreapps.ui" line="33"/>
+        <source>... ... ... ...</source>
+        <translation>... ... ... ...</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationPopup</name>
+    <message>
+        <location filename="../notificationpopup.h" line="53"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordDialog</name>
+    <message>
+        <location filename="../passworddialog.ui" line="14"/>
+        <source>Authentication Required</source>
+        <translation>Aŭtentigo necesa</translation>
+    </message>
+    <message>
+        <location filename="../passworddialog.ui" line="20"/>
+        <source>Icon</source>
+        <translation>Piktogramo</translation>
+    </message>
+    <message>
+        <location filename="../passworddialog.ui" line="36"/>
+        <source>Info</source>
+        <translation>Informo</translation>
+    </message>
+    <message>
+        <location filename="../passworddialog.ui" line="46"/>
+        <source>Username:</source>
+        <translation>Uzantnomo:</translation>
+    </message>
+    <message>
+        <location filename="../passworddialog.ui" line="56"/>
+        <source>Password:</source>
+        <translation>Pasvorto:</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionDialog</name>
+    <message>
+        <location filename="../permissiondialog.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../permissiondialog.ui" line="24"/>
+        <source>Feature</source>
+        <translation>Funkcio</translation>
+    </message>
+    <message>
+        <location filename="../permissiondialog.ui" line="29"/>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyBlur</name>
+    <message>
+        <location filename="../privacyblur.cpp" line="85"/>
+        <source>Off</source>
+        <translation>Malŝaltita</translation>
+    </message>
+    <message>
+        <location filename="../privacyblur.cpp" line="87"/>
+        <source>Chat list</source>
+        <translation>Listo de babiloj</translation>
+    </message>
+    <message>
+        <location filename="../privacyblur.cpp" line="89"/>
+        <source>Open conversation</source>
+        <translation>Malfermita konversacio</translation>
+    </message>
+    <message>
+        <location filename="../privacyblur.cpp" line="91"/>
+        <source>Chat list and conversation</source>
+        <translation>Listo de babiloj kaj konversacio</translation>
+    </message>
+    <message>
+        <location filename="../privacyblur.cpp" line="94"/>
+        <source>Everything, photos included</source>
+        <translation>Ĉio, inkluzive de la fotoj</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../about.cpp" line="94"/>
+        <location filename="../about.cpp" line="172"/>
+        <source>Show Debug Info</source>
+        <translation>Montri la sencimigan informon</translation>
+    </message>
+    <message>
+        <location filename="../about.cpp" line="129"/>
+        <source>&lt;!-- What did you do, what did you expect, and what happened instead? --&gt;
+
+
+</source>
+        <translation>&lt;!-- Kion vi faris, kion vi atendis, kaj kio okazis anstataŭe? --&gt;
+
+
+</translation>
+    </message>
+    <message>
+        <location filename="../about.cpp" line="177"/>
+        <source>Hide Debug Info</source>
+        <translation>Kaŝi la sencimigan informon</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="17"/>
+        <source>Could not run &apos;tar&apos;</source>
+        <translation>Ne eblis ruli &apos;tar&apos;</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="36"/>
+        <source>Nothing to back up</source>
+        <translation>Nenio por sekurkopii</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="48"/>
+        <location filename="../backup.cpp" line="66"/>
+        <location filename="../chatwallpaper.cpp" line="150"/>
+        <location filename="../customcss.cpp" line="88"/>
+        <location filename="../customjs.cpp" line="84"/>
+        <source>Cannot create %1</source>
+        <translation>Ne eblas krei %1</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="74"/>
+        <source>Cannot copy %1</source>
+        <translation>Ne eblas kopii %1</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="86"/>
+        <location filename="../backup.cpp" line="107"/>
+        <source>Cannot create a temporary directory</source>
+        <translation>Ne eblas krei provizoran dosierujon</translation>
+    </message>
+    <message>
+        <location filename="../backup.cpp" line="119"/>
+        <source>Could not restore the settings file</source>
+        <translation>Ne eblis restarigi la agordan dosieron</translation>
+    </message>
+    <message>
+        <location filename="../chatwallpaper.cpp" line="156"/>
+        <source>Cannot write %1</source>
+        <translation>Ne eblas skribi %1</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="189"/>
+        <source>Nothing to migrate from &quot;%1&quot; — already migrated, or no data found there.</source>
+        <translation>Nenio por migrigi el &quot;%1&quot; — jam migrigita, aŭ neniuj datumoj troviĝis tie.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="194"/>
+        <source>Would copy:</source>
+        <translation>Kopius:</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="194"/>
+        <source>Copied:</source>
+        <translation>Kopiitaj:</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="198"/>
+        <source>Run again without --dry-run to perform the copy.</source>
+        <translation>Rulu denove sen --dry-run por efektive kopii.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="495"/>
+        <source>Feature rich WhatsApp web client based on Qt WebEngine</source>
+        <translation>Funkcioriĉa klientprogramo de Vacapo Reto bazita sur Qt WebEngine</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="502"/>
+        <source>Displays help on commandline options</source>
+        <translation>Montras helpon pri la komandliniaj opcioj</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="507"/>
+        <source>Opens Settings dialog in a running instance of </source>
+        <translation>Malfermas la agordan dialogon en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="512"/>
+        <source>Locks a running instance of </source>
+        <translation>Ŝlosas ruliĝantan ekzempleron de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="518"/>
+        <source>Opens About dialog in a running instance of </source>
+        <translation>Malfermas la dialogon Pri en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="523"/>
+        <source>Opens the scheduled messages dialog in a running instance of </source>
+        <translation>Malfermas la dialogon de planitaj mesaĝoj en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="530"/>
+        <source>Toggle between dark &amp; light theme in a running instance of </source>
+        <translation>Baskuligas inter malhela kaj hela etoso en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="537"/>
+        <source>Reload the app in a running instance of </source>
+        <translation>Reŝargas la aplikaĵon en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="543"/>
+        <source>Open new chat prompt in a running instance of </source>
+        <translation>Malfermas la inviton por nova babilo en ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="556"/>
+        <source>Run as a separate account with its own session and settings, in its own window</source>
+        <translation>Ruli kiel apartan konton kun propra seanco kaj propraj agordoj, en propra fenestro</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="563"/>
+        <source>Show main window of running instance of </source>
+        <translation>Montras la ĉefan fenestron de ruliĝanta ekzemplero de </translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="570"/>
+        <source>Copy settings and the logged-in session from a previous install (e.g. the older &quot;whatsie&quot; build) into this one, then exit</source>
+        <translation>Kopias la agordojn kaj la ensalutitan seancon el antaŭa instalo (ekz. la pli malnova muntaĵo &quot;whatsie&quot;) en ĉi tiun, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="577"/>
+        <source>With --migrate-from, only report what would be copied</source>
+        <translation>Kun --migrate-from, nur raportas kio estus kopiita</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="594"/>
+        <source>Print the current unread message count and exit</source>
+        <translation>Presas la nunan nombron de nelegitaj mesaĝoj kaj eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="600"/>
+        <source>Send a message via the running instance, then exit (needs --to and --message)</source>
+        <translation>Sendas mesaĝon per la ruliĝanta ekzemplero, poste eliras (bezonas --to kaj --message)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="604"/>
+        <source>Recipient for --send: a phone number (international), a group id, or a contact name</source>
+        <translation>Ricevanto por --send: telefonnumero (internacia), grupa identigilo, aŭ nomo de kontakto</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="609"/>
+        <source>Message text for --send</source>
+        <translation>Teksto de la mesaĝo por --send</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="612"/>
+        <source>Attach a file for --send (its --message, if any, becomes the caption)</source>
+        <translation>Alkroĉas dosieron por --send (ĝia --message, se ekzistas, iĝas la apudskribo)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="617"/>
+        <source>Caption for the --file attachment (alias of --message)</source>
+        <translation>Apudskribo por la alkroĉaĵo --file (alinomo de --message)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="621"/>
+        <source>How --send delivers: &apos;web&apos; (the running WhatsApp Web session) or &apos;cloud&apos; (Meta WhatsApp Business Cloud API)</source>
+        <translation>Kiel --send liveras: &apos;web&apos; (la ruliĝanta seanco de Vacapo Reto) aŭ &apos;cloud&apos; (Meta WhatsApp Business Cloud API)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="627"/>
+        <source>Use the saved template of this name as the --send message (fill its {{fields}} with --var)</source>
+        <translation>Uzas la konservitan ŝablonon kun ĉi tiu nomo kiel la mesaĝon de --send (plenigu ĝiajn {{kampojn}} per --var)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="632"/>
+        <source>Fill a template field: key=value (repeatable)</source>
+        <translation>Plenigas kampon de ŝablono: ŝlosilo=valoro (ripetebla)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="636"/>
+        <source>List the saved message templates and exit</source>
+        <translation>Listigas la konservitajn mesaĝŝablonojn kaj eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="639"/>
+        <source>Save (or replace) a message template, then exit: name=body</source>
+        <translation>Konservas (aŭ anstataŭigas) mesaĝŝablonon, poste eliras: nomo=korpo</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="643"/>
+        <source>Delete the saved message template of this name, then exit</source>
+        <translation>Forigas la konservitan mesaĝŝablonon kun ĉi tiu nomo, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="648"/>
+        <source>Turn auto-reply to incoming messages on, then exit</source>
+        <translation>Ŝaltas aŭtomatan respondon al alvenantaj mesaĝoj, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="651"/>
+        <source>Turn auto-reply off, then exit</source>
+        <translation>Malŝaltas la aŭtomatan respondon, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="654"/>
+        <source>List the active auto-reply rules (status included) and exit</source>
+        <translation>Listigas la aktivajn regulojn de aŭtomata respondo (kun la stato) kaj eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="657"/>
+        <source>Use this JSON file as a source of auto-reply rules, then exit (empty to clear)</source>
+        <translation>Uzas ĉi tiun JSON-dosieron kiel fonton de reguloj de aŭtomata respondo, poste eliras (malplena por forigi)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="663"/>
+        <source>Set the Cloud API phone-number id, then exit</source>
+        <translation>Agordas la identigilon de la telefonnumero de la Nuba API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="667"/>
+        <source>Set the Cloud API access token, then exit (stored in the account config)</source>
+        <translation>Agordas la alirĵetonon de la Nuba API, poste eliras (konservita en la agordo de la konto)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="672"/>
+        <source>Set the Cloud API graph version (e.g. v21.0), then exit</source>
+        <translation>Agordas la version de la Graph-API (ekz. v21.0), poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="676"/>
+        <source>Show whether the Cloud API is configured, then exit</source>
+        <translation>Montras ĉu la Nuba API estas agordita, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="679"/>
+        <source>For --send --backend cloud: send this Meta-approved template</source>
+        <translation>Por --send --backend cloud: sendas ĉi tiun ŝablonon aprobitan de Meta</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="683"/>
+        <source>Language code for --cloud-template (e.g. es, en_US)</source>
+        <translation>Lingvokodo por --cloud-template (ekz. es, en_US)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="687"/>
+        <source>A positional body parameter for --cloud-template (repeatable)</source>
+        <translation>Pozicia parametro de la korpo por --cloud-template (ripetebla)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="692"/>
+        <source>Enable the local HTTP API, then exit</source>
+        <translation>Ŝaltas la lokan HTTP-API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="695"/>
+        <source>Disable the local HTTP API, then exit</source>
+        <translation>Malŝaltas la lokan HTTP-API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="698"/>
+        <source>Set the local HTTP API port (default 8590), then exit</source>
+        <translation>Agordas la pordon de la loka HTTP-API (defaŭlte 8590), poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="702"/>
+        <source>Set the local HTTP API bearer token, then exit</source>
+        <translation>Agordas la Bearer-ĵetonon de la loka HTTP-API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="706"/>
+        <source>Show the local HTTP API configuration, then exit</source>
+        <translation>Montras la agordon de la loka HTTP-API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="710"/>
+        <source>Enable receiving Cloud API webhooks, then exit</source>
+        <translation>Ŝaltas la ricevadon de webhook-oj de la Nuba API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="713"/>
+        <source>Disable receiving Cloud API webhooks, then exit</source>
+        <translation>Malŝaltas la ricevadon de webhook-oj de la Nuba API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="716"/>
+        <source>Set the Cloud API webhook verify token, then exit</source>
+        <translation>Agordas la kontrolĵetonon de la webhook de la Nuba API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="720"/>
+        <source>Set the Meta app secret for webhook signature checks, then exit</source>
+        <translation>Agordas la sekreton de la Meta-aplikaĵo por kontroli la subskribon de la webhook, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="724"/>
+        <source>Show the Cloud API webhook configuration, then exit</source>
+        <translation>Montras la agordon de la webhook de la Nuba API, poste eliras</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="1114"/>
+        <source>App lock is not configured, 
+Please setup the password in the Settings first.</source>
+        <translation>La aplikaĵa ŝloso ne estas agordita.
+Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="1212"/>
+        <source>Recovered from a start-up crash by switching to safe rendering. You can adjust this in Settings → Performance.</source>
+        <translation>Restariĝis post starta kolapso per ŝalto al sekura bildigo. Vi povas ŝanĝi tion en Agordoj → Rendimento.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_webengine.cpp" line="913"/>
+        <source>Reloading...</source>
+        <translation>Reŝargado...</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="315"/>
+        <location filename="../utils.cpp" line="349"/>
+        <source>Install mode</source>
+        <translation>Instala reĝimo</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="333"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="335"/>
+        <source>Source Branch</source>
+        <translation>Fontbranĉo</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="337"/>
+        <source>Commit Hash</source>
+        <translation>Kommit-haŝo</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="339"/>
+        <source>Build Datetime</source>
+        <translation>Dato kaj horo de la muntado</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="341"/>
+        <source>Qt Runtime Version</source>
+        <translation>Rultempa versio de Qt</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="343"/>
+        <source>Qt Compiled Version</source>
+        <translation>Kompilita versio de Qt</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="345"/>
+        <source>System</source>
+        <translation>Sistemo</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="347"/>
+        <source>Architecture</source>
+        <translation>Arkitekturo</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="490"/>
+        <source>Exception</source>
+        <translation>Escepto</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="493"/>
+        <source> has encountered a problem.</source>
+        <translation> renkontis problemon.</translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="496"/>
+        <source> may need to Restart. Please report the error to developer.</source>
+        <translation> eble bezonas restartiĝi. Bonvolu raporti la eraron al la programisto.</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="386"/>
+        <source>Switch to light theme</source>
+        <comment>WebTweaks</comment>
+        <translation>Ŝalti al la hela etoso</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="387"/>
+        <source>Switch to dark theme</source>
+        <comment>WebTweaks</comment>
+        <translation>Ŝalti al la malhela etoso</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="388"/>
+        <source>Show the chats</source>
+        <comment>WebTweaks</comment>
+        <translation>Montri la babilojn</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="389"/>
+        <source>Blur the chats</source>
+        <comment>WebTweaks</comment>
+        <translation>Nebuligi la babilojn</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="390"/>
+        <source>Zoom in</source>
+        <comment>WebTweaks</comment>
+        <translation>Enzomi</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="391"/>
+        <source>Zoom out</source>
+        <comment>WebTweaks</comment>
+        <translation>Elzomi</translation>
+    </message>
+    <message>
+        <location filename="../webtweaks.cpp" line="392"/>
+        <source>Reset zoom</source>
+        <comment>WebTweaks</comment>
+        <translation>Restarigi la zomon</translation>
+    </message>
+</context>
+<context>
+    <name>RateApp</name>
+    <message>
+        <location filename="../rateapp.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="43"/>
+        <source>Rate this app</source>
+        <translation>Taksi ĉi tiun aplikaĵon</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="56"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you enjoy using this app, would you mind taking a moment to rate it?&lt;/p&gt;&lt;p&gt;It won&apos;t take more than a minute. Thanks you for your support!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se plaĉas al vi uzi ĉi tiun aplikaĵon, ĉu vi bonvolus preni momenton por taksi ĝin?&lt;/p&gt;&lt;p&gt;Tio ne daŭros pli ol unu minuton. Dankon pro via subteno!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="73"/>
+        <source>  Rate in Store</source>
+        <translation>  Taksi en la butiko</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="99"/>
+        <location filename="../rateapp.ui" line="156"/>
+        <source>Or</source>
+        <translation>Aŭ</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="119"/>
+        <source>Star rate Github repo</source>
+        <translation>Steligi la deponejon en GitHub</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="130"/>
+        <source>Donate via PayPal </source>
+        <translation>Donaci per PayPal </translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="176"/>
+        <source>Donate via OpenCollective</source>
+        <translation>Donaci per OpenCollective</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="187"/>
+        <source>Later</source>
+        <translation>Poste</translation>
+    </message>
+    <message>
+        <location filename="../rateapp.ui" line="210"/>
+        <source>  Already Done  </source>
+        <translation>  Jam farite  </translation>
+    </message>
+</context>
+<context>
+    <name>ScheduledMessages</name>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="245"/>
+        <source>Timed out waiting for the message to send</source>
+        <translation>Tempolimo atingita dum atendado de la sendo de la mesaĝo</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="325"/>
+        <source>Daily</source>
+        <translation>Ĉiutage</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="327"/>
+        <source>Weekdays</source>
+        <translation>Labortagoj</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="329"/>
+        <source>Weekly</source>
+        <translation>Ĉiusemajne</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="333"/>
+        <source>Once</source>
+        <translation>Unufoje</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="339"/>
+        <source>Sent</source>
+        <translation>Sendita</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="341"/>
+        <source>Failed</source>
+        <translation>Malsukcesis</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessages.cpp" line="345"/>
+        <source>Pending</source>
+        <translation>Atendanta</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduledMessagesDialog</name>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="22"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="114"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="120"/>
+        <source>Scheduled messages</source>
+        <translation>Planitaj mesaĝoj</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="42"/>
+        <source>To</source>
+        <translation>Al</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="51"/>
+        <source>When</source>
+        <translation>Kiam</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <location filename="../scheduledmessagesdialog.cpp" line="71"/>
+        <source>Message</source>
+        <translation>Mesaĝo</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="30"/>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="41"/>
+        <source>Phone number, international format e.g. 447700900000</source>
+        <translation>Telefonnumero, internacia formo, ekz. 447700900000</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="45"/>
+        <source>Optional label</source>
+        <translation>Nedeviga etikedo</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="46"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="54"/>
+        <source>Once</source>
+        <translation>Unufoje</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="56"/>
+        <source>Daily</source>
+        <translation>Ĉiutage</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="58"/>
+        <source>Weekdays</source>
+        <translation>Labortagoj</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="60"/>
+        <source>Weekly</source>
+        <translation>Ĉiusemajne</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="62"/>
+        <source>Repeat</source>
+        <translation>Ripeto</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="65"/>
+        <source>Remind me instead of sending (notify, don&apos;t message)</source>
+        <translation>Memorigu min anstataŭ sendi (sciigu, ne mesaĝu)</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="69"/>
+        <source>Message to send</source>
+        <translation>Sendota mesaĝo</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="75"/>
+        <source>The app must be running and WhatsApp logged in at the scheduled time. If it is closed, the message is sent the next time you open the app. Sending opens the recipient&apos;s chat.</source>
+        <translation>La aplikaĵo devas ruliĝi kaj Vacapo devas esti ensalutita je la planita horo. Se ĝi estas fermita, la mesaĝo estas sendata kiam vi venontfoje malfermas la aplikaĵon. La sendo malfermas la babilon de la ricevanto.</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="85"/>
+        <source>Schedule</source>
+        <translation>Plani</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="86"/>
+        <source>Remove selected</source>
+        <translation>Forigi la elektitajn</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="87"/>
+        <source>Clear sent/failed</source>
+        <translation>Forigi senditajn/malsukcesajn</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="88"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="115"/>
+        <source>Enter a phone number and a message.</source>
+        <translation>Enigu telefonnumeron kaj mesaĝon.</translation>
+    </message>
+    <message>
+        <location filename="../scheduledmessagesdialog.cpp" line="121"/>
+        <source>The time is in the past — send this message now?</source>
+        <translation>La horo estas en la pasinteco — ĉu sendi ĉi tiun mesaĝon nun?</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWidget</name>
+    <message>
+        <location filename="../settingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formularo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="78"/>
+        <source>Settings</source>
+        <translation>Agordoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="106"/>
+        <source>General settings</source>
+        <translation>Ĝeneralaj agordoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="114"/>
+        <source>Widget Style</source>
+        <translation>Stilo de la fenestraĵoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="153"/>
+        <source>Display theme</source>
+        <translation>Vidiga etoso</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="166"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Based on your system timezone and location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Laŭ la horzono kaj la loko de via sistemo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="169"/>
+        <location filename="../settingswidget.ui" line="1599"/>
+        <location filename="../settingswidget.ui" line="1643"/>
+        <location filename="../settingswidget.ui" line="1712"/>
+        <location filename="../settingswidget.cpp" line="1352"/>
+        <source>Automatic</source>
+        <translation>Aŭtomata</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="177"/>
+        <source>Dark</source>
+        <translation>Malhela</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="186"/>
+        <source>Light</source>
+        <translation>Hela</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="198"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Match the desktop&apos;s own light/dark preference, and change with it. Overrides the manual theme and the automatic sunrise/sunset switch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sekvi la helan/malhelan preferon de la labortablo mem, kaj ŝanĝiĝi kun ĝi. Superregas la permanan etoson kaj la aŭtomatan ŝaltilon laŭ sunleviĝo/sunsubiro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="201"/>
+        <source>Follow system light/dark theme</source>
+        <translation>Sekvi la helan/malhelan etoson de la sistemo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="238"/>
+        <source>Native notification</source>
+        <translation>Indiĝena sciigo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="247"/>
+        <source>Customized notification</source>
+        <translation>Propra sciigo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="265"/>
+        <source>  Try</source>
+        <translation>  Provi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="276"/>
+        <source>Notification type</source>
+        <translation>Tipo de sciigo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="283"/>
+        <source>Disable Notifications Popup</source>
+        <translation>Malŝalti la ŝprucfenestron de sciigoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="290"/>
+        <source>Popup timeout</source>
+        <translation>Daŭro de la ŝprucfenestro</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="297"/>
+        <location filename="../settingswidget.ui" line="1172"/>
+        <source> Secs</source>
+        <translation> sek.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="310"/>
+        <source>Notification delivery</source>
+        <translation>Livero de sciigoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="317"/>
+        <source>How native notifications are sent on Linux. Automatic uses the desktop portal inside a Flatpak sandbox and the system service otherwise.</source>
+        <translation>Kiel indiĝenaj sciigoj estas senditaj en Linukso. Aŭtomata uzas la labortablan portalon ene de Flatpak-sablujo, kaj alie la sisteman servon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="324"/>
+        <source>Suppress notification popups during a daily quiet period. Unread badges still update; only the popup is held back.</source>
+        <translation>Subpremas la ŝprucfenestrojn de sciigoj dum ĉiutaga silenta periodo. La insignoj de nelegitaj mesaĝoj plu ĝisdatiĝas; nur la ŝprucfenestro estas retenata.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="327"/>
+        <source>Do Not Disturb</source>
+        <translation>Ne ĝeni</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="336"/>
+        <source>From</source>
+        <translation>De</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="343"/>
+        <location filename="../settingswidget.ui" line="357"/>
+        <source>HH:mm</source>
+        <translation>HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="350"/>
+        <source>to</source>
+        <translation>ĝis</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="379"/>
+        <source>Highlight keywords</source>
+        <translation>Emfazaj ŝlosilvortoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="386"/>
+        <source>Comma-separated words that always notify, even during Do Not Disturb (case-insensitive).</source>
+        <translation>Vortoj disigitaj per komoj, kiuj ĉiam sciigas, eĉ dum Ne ĝeni (sen distingo inter majuskloj kaj minuskloj).</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="389"/>
+        <source>e.g. urgent, boss, invoice</source>
+        <translation>ekz. urĝa, estro, fakturo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="425"/>
+        <source>Use Native File Dialog</source>
+        <translation>Uzi la indiĝenan dosierdialogon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="432"/>
+        <source>Mute Audio from Page</source>
+        <translation>Silentigi la sonon de la paĝo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="439"/>
+        <source>Disable Auto Playback of Media</source>
+        <translation>Malŝalti la aŭtomatan ludadon de aŭdvidaĵoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="446"/>
+        <source>Minimize in tray on start</source>
+        <translation>Minimumigi al la sistempleto ĉe la starto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="453"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you use more than one account window, remember each window&apos;s position, size and tabs and restore them next time. Off by default: the app comes back as a single window holding every account.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kiam vi uzas pli ol unu kontofenestron, memori la pozicion, la grandon kaj la langetojn de ĉiu fenestro kaj restarigi ilin venontfoje. Defaŭlte malŝaltita: la aplikaĵo revenas kiel unu sola fenestro entenanta ĉiujn kontojn.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="456"/>
+        <source>Remember multiple window positions on restart</source>
+        <translation>Memori la poziciojn de pluraj fenestroj ĉe restarto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="463"/>
+        <source>Show/Hide on clicking tray Icon (if supported)</source>
+        <translation>Montri/kaŝi per alklako de la pletopiktogramo (se subtenata)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="470"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fermi la panelon de emoĝioj, GIF-oj kaj glumarkoj kiam vi alklakas aliloke. Alikaze Vacapo Reto tenas ĝin malfermita ĝis la butono estas repremita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="473"/>
+        <source>Close emoji/sticker panel when clicking outside</source>
+        <translation>Fermi la panelon de emoĝioj/glumarkoj ĉe alklako ekstere</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="480"/>
+        <source>Interface language</source>
+        <translation>Lingvo de la interfaco</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="487"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language of Whatly&apos;s own interface. Takes effect after restarting the app. The language of the chats themselves comes from WhatsApp Web and cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lingvo de la propra interfaco de Whatly. Efektiviĝas post restartigo de la aplikaĵo. La lingvo de la babiloj mem venas de Vacapo Reto kaj ne ŝanĝeblas ĉi tie.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="494"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a light/dark button to WhatsApp&apos;s own sidebar, just above your profile picture.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aldonas helan/malhelan butonon al la propra flanka breto de Vacapo, ĝuste super via profilbildo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="497"/>
+        <source>Theme button in WhatsApp&apos;s sidebar</source>
+        <translation>Etosa butono en la flanka breto de Vacapo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="504"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that blurs and unblurs your chats in one click, without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aldonas butonon al la propra flanka breto de Vacapo, kiu nebuligas kaj malnebuligas viajn babilojn per unu alklako, sen malfermi la Agordojn.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="507"/>
+        <source>Blur button in WhatsApp&apos;s sidebar</source>
+        <translation>Nebuliga butono en la flanka breto de Vacapo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="514"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds zoom out / reset / zoom in buttons to WhatsApp&apos;s own sidebar, to scale the page live without opening Settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aldonas butonojn elzomi / restarigi / enzomi al la propra flanka breto de Vacapo, por skali la paĝon tuj sen malfermi la Agordojn.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="517"/>
+        <source>Zoom buttons in WhatsApp&apos;s sidebar</source>
+        <translation>Zomaj butonoj en la flanka breto de Vacapo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="524"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a single-colour tray icon that matches the rest of your panel, instead of the green WhatsApp one. The icon also dims when WhatsApp is not connected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uzi unukoloran pletopiktogramon, kiu kongruas kun la cetero de via panelo, anstataŭ la verdan de Vacapo. La piktogramo ankaŭ paliĝas kiam Vacapo ne estas konektita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="527"/>
+        <source>Monochrome tray icon</source>
+        <translation>Unukolora pletopiktogramo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="534"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animate scrolling instead of jumping line by line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Animacii la rulumadon anstataŭ salti linion post linio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="537"/>
+        <source>Smooth scrolling</source>
+        <translation>Glata rulumado</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="544"/>
+        <location filename="../settingswidget.cpp" line="1143"/>
+        <source>Custom CSS</source>
+        <translation>Propra CSS</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="553"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load a .css file to restyle WhatsApp Web — the community stylesheets (catppuccin and the like) work here. Applied on top of the chat theme.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ŝargi .css-dosieron por restilizi Vacapon Reton — la komunumaj stilfolioj (catppuccin kaj similaj) funkcias ĉi tie. Aplikata super la babila etoso.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="556"/>
+        <source>Choose file…</source>
+        <translation>Elekti dosieron…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="563"/>
+        <location filename="../settingswidget.ui" line="703"/>
+        <source>Clear</source>
+        <translation>Forigi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="572"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the system-tray icon entirely. With no tray to restore from, closing the window then quits the app instead of hiding it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Forigi la pletopiktogramon tute. Sen pleto el kiu restarigi, fermi la fenestron tiam ĉesigas la aplikaĵon anstataŭ kaŝi ĝin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="575"/>
+        <source>Hide tray icon</source>
+        <translation>Kaŝi la pletopiktogramon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="582"/>
+        <source>Font family</source>
+        <translation>Tiparo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="589"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render WhatsApp Web&apos;s text in a font installed on your system. Emoji, icons and monospaced message formatting are left untouched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bildigi la tekston de Vacapo Reto per tiparo instalita en via sistemo. Emoĝioj, piktogramoj kaj egallarĝa formatado de mesaĝoj restas netuŝitaj.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="596"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide the &quot;Muted updates&quot; section in the Status/Updates panel, so statuses from contacts you have muted do not show up at all.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kaŝi la sekcion &quot;Silentigitaj ĝisdatigoj&quot; en la panelo Stato/Ĝisdatigoj, por ke statoj de kontaktoj, kiujn vi silentigis, tute ne aperu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="599"/>
+        <source>Hide muted status updates</source>
+        <translation>Kaŝi la silentigitajn statajn ĝisdatigojn</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="606"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Underlines misspelt words as you type, and offers corrections in the right-click menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substrekas misliterumitajn vortojn dum vi tajpas, kaj proponas korektojn en la dekstroklaka menuo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="609"/>
+        <location filename="../settingswidget.cpp" line="1662"/>
+        <source>Check spelling as I type</source>
+        <translation>Kontroli la literumadon dum mi tajpas</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="616"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language to check against.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;La lingvo laŭ kiu kontroli.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="623"/>
+        <source>Interface font size</source>
+        <translation>Tipargrando de la interfaco</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="630"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Point size of the app&apos;s own interface — menus, settings and dialogs. This does not affect WhatsApp Web&apos;s text; use the zoom for that.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Punktogrando de la propra interfaco de la aplikaĵo — menuoj, agordoj kaj dialogoj. Tio ne influas la tekston de Vacapo Reto; uzu la zomon por tio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="633"/>
+        <source> pt</source>
+        <translation> pt</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="646"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If WhatsApp Web&apos;s page process crashes, reload it automatically instead of asking first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se la paĝa procezo de Vacapo Reto kolapsas, reŝargi ĝin aŭtomate anstataŭ unue demandi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="649"/>
+        <source>Reload automatically after a crash</source>
+        <translation>Reŝargi aŭtomate post kolapso</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="656"/>
+        <source>Privacy blur</source>
+        <translation>Privateca nebulo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="663"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blurs your chats until you hover over them, so someone glancing at the screen cannot read them. Hovering a row reveals just that row.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nebuligas viajn babilojn ĝis vi ŝvebas super ili, por ke iu ekrigardanta la ekranon ne povu legi ilin. Ŝvebi super vico malkaŝas nur tiun vicon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="670"/>
+        <source>Chat colour Tint</source>
+        <translation>Kolornuanco de la babilo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="677"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recolours WhatsApp Web itself. Photos, avatars and stickers keep their own colours. Works on top of the light or dark theme, whichever is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rekoloras Vacapon Reton mem. Fotoj, avataroj kaj glumarkoj konservas siajn proprajn kolorojn. Funkcias super la hela aŭ malhela etoso, kiu ajn estas aktiva.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="684"/>
+        <location filename="../settingswidget.cpp" line="1119"/>
+        <source>Chat wallpaper</source>
+        <translation>Tapeto de la babilo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="693"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use one of your own images as the background of the chat pane, as WhatsApp does on Android. The image is stored inside Whatly, not uploaded anywhere, and is only visible to you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uzi unu el viaj propraj bildoj kiel fonon de la babila panelo, kiel Vacapo faras en Androido. La bildo estas konservita ene de Whatly, ne alŝutita ien ajn, kaj videbla nur al vi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="696"/>
+        <source>Choose image…</source>
+        <translation>Elekti bildon…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="712"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;Whatly for Linux&amp;quot; (or the matching platform) in your phone&apos;s linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Novaj ensalutoj aperas kiel &amp;quot;Whatly for Linux&amp;quot; (aŭ la kongrua platformo) en la listo de ligitaj aparatoj de via telefono anstataŭ &amp;quot;Google Chrome (Linux)&amp;quot;. La nomo estas konservita en la telefono kiam aparato estas ligata, do ŝanĝi tion influas nur estontajn ligojn — elsalutu kaj religu por alinomi ekzistantan seancon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="715"/>
+        <source>Identify as Whatly in linked devices</source>
+        <translation>Identiĝi kiel Whatly en la ligitaj aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="729"/>
+        <source>User Agent</source>
+        <translation>Uzantagento</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="732"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced — leave this alone unless you know exactly what you are doing. A non-standard user agent can make WhatsApp refuse to load, and unusual values risk your WhatsApp account being flagged or blacklisted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Progresinta — ne tuŝu tion krom se vi scias precize kion vi faras. Nenorma uzantagento povas igi Vacapon rifuzi ŝargiĝi, kaj nekutimaj valoroj riskas, ke via konto ĉe Vacapo estu markita aŭ nigralistigita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="742"/>
+        <source>  Set</source>
+        <translation>  Agordi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="753"/>
+        <source>Reset to default</source>
+        <translation>Restarigi al la defaŭlto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="776"/>
+        <source>Zoom factor when normal</source>
+        <translation>Zomfaktoro en normala stato</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="804"/>
+        <location filename="../settingswidget.ui" line="939"/>
+        <source>Zoom Out</source>
+        <translation>Elzomi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="843"/>
+        <location filename="../settingswidget.ui" line="978"/>
+        <source>Zoom In</source>
+        <translation>Enzomi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="888"/>
+        <location filename="../settingswidget.ui" line="1023"/>
+        <source>reset</source>
+        <translation>restarigi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="911"/>
+        <source>Zoom factor when maximized/fullscreen</source>
+        <translation>Zomfaktoro en maksimumigita/plenekrana stato</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1046"/>
+        <source>Minimize to tray</source>
+        <translation>Minimumigi al la sistempleto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1055"/>
+        <source>Quit</source>
+        <translation>Eliri</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1067"/>
+        <source>Global shortcuts</source>
+        <translation>Ĉieaj fulmoklavoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1074"/>
+        <source>Close button action</source>
+        <translation>Ago de la ferma butono</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1081"/>
+        <source>  Show shortcuts</source>
+        <translation>  Montri la fulmoklavojn</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1092"/>
+        <source>Permissions</source>
+        <translation>Permesoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1099"/>
+        <source>  Show permissions</source>
+        <translation>  Montri la permesojn</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1114"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable lock screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ŝalti la ŝlosekranon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1117"/>
+        <source>Enable App lock on start</source>
+        <translation>Ŝalti la aplikaĵan ŝloson ĉe la starto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1124"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the window hides to the system tray, lock it behind the passcode. Requires a password to be set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kiam la fenestro kaŝiĝas al la sistempleto, ŝlosi ĝin malantaŭ la paskodo. Postulas, ke pasvorto estu agordita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1127"/>
+        <source>Lock when hidden to tray</source>
+        <translation>Ŝlosi kiam kaŝita al la pleto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1134"/>
+        <source>Also lock Whatly when the desktop session locks. Requires a password to be set. (Linux)</source>
+        <translation>Ankaŭ ŝlosi Whatly kiam la labortabla seanco ŝlosiĝas. Postulas, ke pasvorto estu agordita. (Linukso)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1137"/>
+        <source>Lock when the screen locks</source>
+        <translation>Ŝlosi kiam la ekrano ŝlosiĝas</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1144"/>
+        <source>Current Password</source>
+        <translation>Nuna pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1151"/>
+        <location filename="../settingswidget.ui" line="1185"/>
+        <source>Change password</source>
+        <translation>Ŝanĝi la pasvorton</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1154"/>
+        <location filename="../settingswidget.ui" line="1263"/>
+        <source>Change</source>
+        <translation>Ŝanĝi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1165"/>
+        <source>Enable auto locking after</source>
+        <translation>Ŝalti aŭtomatan ŝlosadon post</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1188"/>
+        <source>Reset</source>
+        <translation>Restarigi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1220"/>
+        <source>View password</source>
+        <translation>Montri la pasvorton</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1247"/>
+        <source>Default Download location</source>
+        <translation>Defaŭlta elŝuta loko</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1260"/>
+        <source>Change Download Location</source>
+        <translation>Ŝanĝi la elŝutan lokon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1279"/>
+        <source>Storage </source>
+        <translation>Konservejo </translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1299"/>
+        <source>Property</source>
+        <translation>Atributo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1306"/>
+        <source>  Clear (requires restart)</source>
+        <translation>  Forigi (postulas restartigon)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1317"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Persistent data includes persistent cookies, HTML5 local storage, and visited links.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Daŭraj datumoj inkluzivas daŭrajn kuketojn, lokan konservejon de HTML5, kaj vizititajn ligilojn.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1320"/>
+        <source>Persistent data</source>
+        <translation>Daŭraj datumoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1327"/>
+        <location filename="../settingswidget.ui" line="1347"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1337"/>
+        <source>The HTTP/media cache. Clearing it is safe — it is re-downloaded as needed.</source>
+        <translation>La kaŝmemoro de HTTP kaj aŭdvidaĵoj. Forigi ĝin estas sendanĝere — ĝi estas reelŝutata laŭbezone.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1340"/>
+        <source>Cache</source>
+        <translation>Kaŝmemoro</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1357"/>
+        <source>  Clear cache</source>
+        <translation>  Malplenigi la kaŝmemoron</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1380"/>
+        <source>Size</source>
+        <translation>Grando</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1402"/>
+        <source>Action</source>
+        <translation>Ago</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1416"/>
+        <source>Backup</source>
+        <translation>Sekurkopio</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1423"/>
+        <source>Save this account (settings, session and addons) to a .tar.gz archive. The archive contains your logged-in session — keep it private.</source>
+        <translation>Konservi ĉi tiun konton (agordojn, seancon kaj aldonaĵojn) en .tar.gz-arkivon. La arkivo enhavas vian ensalutitan seancon — tenu ĝin privata.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1426"/>
+        <source>Export profile…</source>
+        <translation>Eksporti la profilon…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1433"/>
+        <source>Restore an account from a .tar.gz archive. This overwrites the current data and needs a restart.</source>
+        <translation>Restarigi konton el .tar.gz-arkivo. Tio anstataŭigas la nunajn datumojn kaj postulas restartigon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1436"/>
+        <source>Import profile…</source>
+        <translation>Importi profilon…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1461"/>
+        <source>Performance &amp; Privacy</source>
+        <translation>Rendimento kaj privateco</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1467"/>
+        <source>Fine-tune the rendering engine. The defaults are safe on most systems; if the window is blank or the app crashes on start, or if it stutters, try changing these. Changes apply after a restart.</source>
+        <translation>Fajnagordi la bildigan motoron. La defaŭltoj estas sendanĝeraj en la plimulto de la sistemoj; se la fenestro estas malplena aŭ la aplikaĵo kolapsas ĉe la starto, aŭ se ĝi saltetas, provu ŝanĝi ĉi tiujn. La ŝanĝoj efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1477"/>
+        <source>Render entirely on the CPU (--disable-gpu). Fixes blank windows and start-up crashes on some GPU/driver setups. Default on Linux.</source>
+        <translation>Bildigi tute per la ĉefprocesoro (--disable-gpu). Riparas malplenajn fenestrojn kaj startajn kolapsojn ĉe iuj GPU-aj/pelilaj agordoj. Defaŭlta en Linukso.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1480"/>
+        <source>Disable GPU acceleration</source>
+        <translation>Malŝalti la GPU-akceladon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1487"/>
+        <source>Composite the page on the CPU (--disable-gpu-compositing). Avoids stale-frame flicker on some drivers.</source>
+        <translation>Kunmeti la paĝon per la ĉefprocesoro (--disable-gpu-compositing). Evitas flagradon pro malfreŝaj kadroj ĉe iuj peliloj.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1490"/>
+        <source>Disable GPU compositing</source>
+        <translation>Malŝalti la GPU-kunmetadon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1497"/>
+        <source>Disable GPU VSync (--disable-gpu-vsync). May reduce input lag at the cost of tearing.</source>
+        <translation>Malŝalti GPU-VSync (--disable-gpu-vsync). Povas redukti la enigan malfruon je la kosto de bildoŝiriĝo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1500"/>
+        <source>Disable GPU VSync</source>
+        <translation>Malŝalti GPU-VSync</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1507"/>
+        <source>Run the GPU process inside the main process (--in-process-gpu). A workaround for some sandboxed setups.</source>
+        <translation>Ruli la GPU-procezon ene de la ĉefa procezo (--in-process-gpu). Provizora solvo por iuj sablujaj agordoj.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1510"/>
+        <source>Run GPU in-process</source>
+        <translation>Ruli la GPU-on ene de la procezo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1517"/>
+        <source>Force acceleration even when the driver is blocklisted (--ignore-gpu-blocklist). Try this to turn the GPU back on.</source>
+        <translation>Devigi la akceladon eĉ kiam la pelilo estas nigralistigita (--ignore-gpu-blocklist). Provu tion por reŝalti la GPU-on.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1520"/>
+        <source>Ignore GPU blocklist</source>
+        <translation>Ignori la nigran liston de GPU-oj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1527"/>
+        <source>Run everything in a single process (--single-process). Uses less memory but is less stable.</source>
+        <translation>Ruli ĉion en unu sola procezo (--single-process). Uzas malpli da memoro sed estas malpli stabila.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1530"/>
+        <source>Single-process mode (lower memory)</source>
+        <translation>Unuproceza reĝimo (malpli da memoro)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1537"/>
+        <source>Share one renderer process per site (--process-per-site). Reduces memory use.</source>
+        <translation>Kunhavigi unu bildigan procezon por ĉiu retejo (--process-per-site). Reduktas la memoruzon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1540"/>
+        <source>One process per site (lower memory)</source>
+        <translation>Unu procezo por ĉiu retejo (malpli da memoro)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1547"/>
+        <source>Ask the JavaScript engine to use less memory at a small cost in speed (V8 --optimize-for-size). Recommended for an app that stays in the tray. Ignored when a JavaScript memory limit is set below.</source>
+        <translation>Peti al la JavaScript-motoro uzi malpli da memoro je malgranda kosto en rapideco (V8 --optimize-for-size). Rekomendata por aplikaĵo, kiu restas en la pleto. Ignorata kiam JavaScript-memorlimo estas agordita sube.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1550"/>
+        <source>Optimize memory over speed (lower memory)</source>
+        <translation>Optimumigi memoron anstataŭ rapidecon (malpli da memoro)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1557"/>
+        <source>Hide contact names and message previews in the chat list (hover to reveal one). Useful when sharing your screen. The open conversation is untouched.</source>
+        <translation>Kaŝi la nomojn de kontaktoj kaj la antaŭrigardojn de mesaĝoj en la listo de babiloj (ŝvebu por malkaŝi unu). Utila kiam vi kunhavigas vian ekranon. La malfermita konversacio restas netuŝita.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1560"/>
+        <source>Focus mode (hide chat-list previews)</source>
+        <translation>Fokusa reĝimo (kaŝi la antaŭrigardojn en la listo de babiloj)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1567"/>
+        <source>Default photos and videos to HD quality in the media editor. Depends on WhatsApp Web&apos;s layout; if a WhatsApp update breaks it, turn it off.</source>
+        <translation>Defaŭlte uzi HD-kvaliton por fotoj kaj filmetoj en la aŭdvidaĵa redaktilo. Dependas de la aranĝo de Vacapo Reto; se ĝisdatigo de Vacapo rompas ĝin, malŝaltu ĝin.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1570"/>
+        <source>Send photos and videos in HD by default</source>
+        <translation>Sendi fotojn kaj filmetojn en HD defaŭlte</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1577"/>
+        <source>Stop WebRTC from revealing your local IP address over non-proxied connections.</source>
+        <translation>Malebligi al WebRTC malkaŝi vian lokan IP-adreson tra konektoj sen prokurilo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1580"/>
+        <source>Prevent WebRTC IP leak</source>
+        <translation>Malhelpi la IP-liKon de WebRTC</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1589"/>
+        <source>JavaScript memory limit</source>
+        <translation>Memorlimo de JavaScript</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1596"/>
+        <source>Cap the JavaScript heap (V8 --max-old-space-size). 0 = automatic. Lower it if the app uses too much RAM.</source>
+        <translation>Limigi la JavaScript-amason (V8 --max-old-space-size). 0 = aŭtomate. Malaltigu ĝin se la aplikaĵo uzas tro da RAM.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1602"/>
+        <location filename="../settingswidget.ui" line="1646"/>
+        <source> MB</source>
+        <translation> MB</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1619"/>
+        <source>HTTP cache</source>
+        <translation>HTTP-kaŝmemoro</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1626"/>
+        <source>Where to keep the HTTP cache. Memory clears on exit; None disables caching.</source>
+        <translation>Kie teni la HTTP-kaŝmemoron. Memoro malpleniĝas ĉe la eliro; Neniu malŝaltas la kaŝmemoradon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1633"/>
+        <source>Max size</source>
+        <translation>Maksimuma grando</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1640"/>
+        <source>Maximum on-disk cache size. 0 = automatic.</source>
+        <translation>Maksimuma grando de la kaŝmemoro sur la disko. 0 = aŭtomate.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1664"/>
+        <source>Network &amp; Startup</source>
+        <translation>Reto kaj starto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1670"/>
+        <source>Launch Whatly automatically when you log in to your desktop session.</source>
+        <translation>Lanĉi Whatly aŭtomate kiam vi ensalutas en vian labortablan seancon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1673"/>
+        <source>Start Whatly when I log in</source>
+        <translation>Startigi Whatly kiam mi ensalutas</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1680"/>
+        <source>Replace the system window border with Whatly&apos;s own slim title bar. Applies after a restart.</source>
+        <translation>Anstataŭigi la sisteman fenestran randon per la propra maldika titolbreto de Whatly. Efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1683"/>
+        <source>Use a custom window frame (requires restart)</source>
+        <translation>Uzi propran fenestran kadron (postulas restartigon)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1690"/>
+        <source>Check GitHub once a day for a newer release and let you know. Whatly never downloads or installs anything on its own.</source>
+        <translation>Kontroli GitHub unufoje tage pri pli nova eldono kaj sciigi vin. Whatly neniam elŝutas aŭ instalas ion ajn per si mem.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1693"/>
+        <source>Check for updates automatically</source>
+        <translation>Kontroli ĝisdatigojn aŭtomate</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1702"/>
+        <source>Interface scale</source>
+        <translation>Skalo de la interfaco</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1709"/>
+        <source>Scale the whole window and the page (QT_SCALE_FACTOR). Automatic follows the desktop. A QT_SCALE_FACTOR environment variable, if set, overrides this. Applies after a restart.</source>
+        <translation>Skali la tutan fenestron kaj la paĝon (QT_SCALE_FACTOR). Aŭtomata sekvas la labortablon. Media variablo QT_SCALE_FACTOR, se agordita, superregas tion. Efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1745"/>
+        <source>Proxy</source>
+        <translation>Prokurilo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1752"/>
+        <source>How Whatly connects to the network. System follows the operating system; None connects directly.</source>
+        <translation>Kiel Whatly konektiĝas al la reto. Sistemo sekvas la mastruman sistemon; Neniu konektiĝas rekte.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1777"/>
+        <source>Host</source>
+        <translation>Gastiganto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1784"/>
+        <source>127.0.0.1</source>
+        <translation>127.0.0.1</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1791"/>
+        <location filename="../settingswidget.ui" line="2071"/>
+        <source>Port</source>
+        <translation>Pordo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1805"/>
+        <source>Username</source>
+        <translation>Uzantnomo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1812"/>
+        <location filename="../settingswidget.ui" line="1829"/>
+        <source>Optional</source>
+        <translation>Nedeviga</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1819"/>
+        <source>Password</source>
+        <translation>Pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1842"/>
+        <source>Custom JavaScript addons</source>
+        <translation>Propraj JavaScript-aldonaĵoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1848"/>
+        <source>Load .js files to run on WhatsApp Web. Each addon runs in its own sandbox, so a broken one cannot take down the others or the page. Untick an addon to disable it without removing it. Changes apply after a restart.</source>
+        <translation>Ŝargi .js-dosierojn por ruli en Vacapo Reto. Ĉiu aldonaĵo ruliĝas en propra sablujo, do difektita ne povas faligi la aliajn nek la paĝon. Malmarku aldonaĵon por malŝalti ĝin sen forigi ĝin. La ŝanĝoj efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1870"/>
+        <source>Add addon…</source>
+        <translation>Aldoni aldonaĵon…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1877"/>
+        <location filename="../settingswidget.ui" line="1937"/>
+        <source>Remove</source>
+        <translation>Forigi</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1902"/>
+        <source>Saved replies</source>
+        <translation>Konservitaj respondoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1908"/>
+        <source>Short texts you send often. Insert one from the command palette (Ctrl+K) — type &quot;Insert&quot; and pick it; the text is typed into the message box.</source>
+        <translation>Mallongaj tekstoj, kiujn vi ofte sendas. Enmetu unu el la komandpaletro (Stir+K) — tajpu &quot;Enmeti&quot; kaj elektu ĝin; la teksto estas tajpata en la mesaĝkampon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1930"/>
+        <source>Add reply…</source>
+        <translation>Aldoni respondon…</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1962"/>
+        <source>Keyboard shortcuts</source>
+        <translation>Fulmoklavoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1968"/>
+        <source>Click a field and press the key combination. Clear a field to remove the shortcut. Changes apply after a restart.</source>
+        <translation>Alklaku kampon kaj premu la klavkombinon. Malplenigu kampon por forigi la fulmoklavon. La ŝanĝoj efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1984"/>
+        <source>Cloud API (send without a browser session)</source>
+        <translation>Nuba API (sendi sen retumila seanco)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="1990"/>
+        <source>Send with `--send --backend cloud` through the Meta WhatsApp Business Cloud API — no running WhatsApp Web session needed. The access token is one you supply from Meta; it is stored in this account&apos;s config and Whatly never obtains it itself.</source>
+        <translation>Sendi per `--send --backend cloud` tra la Meta WhatsApp Business Cloud API — neniu ruliĝanta seanco de Vacapo Reto necesas. La alirĵetonon vi mem provizas de Meta; ĝi estas konservita en la agordo de ĉi tiu konto kaj Whatly neniam akiras ĝin mem.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2000"/>
+        <source>Phone-number ID</source>
+        <translation>Identigilo de la telefonnumero</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2014"/>
+        <source>Access token</source>
+        <translation>Alirĵetono</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2024"/>
+        <source>your Meta access token</source>
+        <translation>via alirĵetono de Meta</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2031"/>
+        <source>Graph API version</source>
+        <translation>Versio de la Graph-API</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2048"/>
+        <source>Local API &amp; Cloud webhooks</source>
+        <translation>Loka API kaj nubaj webhook-oj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2054"/>
+        <source>A small HTTP endpoint on the loopback interface (127.0.0.1) lets other programs on this machine send through Whatly, and lets Meta deliver Cloud API webhooks (incoming messages) so auto-reply works without a browser. It is never exposed to the network; to receive webhooks from Meta, forward the port with a tunnel or reverse proxy (e.g. cloudflared or ngrok).</source>
+        <translation>Malgranda HTTP-finpunkto en la retrocirkla interfaco (127.0.0.1) permesas al aliaj programoj en ĉi tiu komputilo sendi tra Whatly, kaj permesas al Meta liveri webhook-ojn de la Nuba API (alvenantajn mesaĝojn), por ke la aŭtomata respondo funkciu sen retumilo. Ĝi neniam estas elmetita al la reto; por ricevi webhook-ojn de Meta, plusendu la pordon per tunelo aŭ inversa prokurilo (ekz. cloudflared aŭ ngrok).</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2064"/>
+        <source>Enable the local HTTP API (send over HTTP)</source>
+        <translation>Ŝalti la lokan HTTP-API (sendi tra HTTP)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2088"/>
+        <source>Bearer token</source>
+        <translation>Bearer-ĵetono</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2098"/>
+        <source>required to authorise requests</source>
+        <translation>necesa por rajtigi la petojn</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2105"/>
+        <source>Receive Cloud API webhooks (incoming messages)</source>
+        <translation>Ricevi webhook-ojn de la Nuba API (alvenantajn mesaĝojn)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2112"/>
+        <source>Webhook verify token</source>
+        <translation>Kontrolĵetono de la webhook</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2122"/>
+        <source>echoed to Meta during setup</source>
+        <translation>resendata al Meta dum la agordado</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2129"/>
+        <source>Meta app secret</source>
+        <translation>Sekreto de la Meta-aplikaĵo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="2139"/>
+        <source>verifies the webhook signature</source>
+        <translation>kontrolas la subskribon de la webhook</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="419"/>
+        <source>Basics</source>
+        <translation>Bazaĵoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="426"/>
+        <source>Appearance</source>
+        <translation>Aspekto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="442"/>
+        <source>Notifications</source>
+        <translation>Sciigoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="446"/>
+        <source>Chatting</source>
+        <translation>Babilado</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="455"/>
+        <source>Privacy &amp; Lock</source>
+        <translation>Privateco kaj ŝloso</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="461"/>
+        <source>Window &amp;&amp; zoom</source>
+        <translation>Fenestro &amp;&amp; zomo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="470"/>
+        <source>Advanced</source>
+        <translation>Progresinta</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="704"/>
+        <source>Shortcut in use</source>
+        <translation>Fulmoklavo jam uzata</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="705"/>
+        <source>That shortcut is already used by another action.</source>
+        <translation>Tiu fulmoklavo jam estas uzata de alia ago.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="717"/>
+        <source>Clear cache</source>
+        <translation>Malplenigi la kaŝmemoron</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="718"/>
+        <source>Clear the cache now? It will be re-downloaded as needed.</source>
+        <translation>Ĉu malplenigi la kaŝmemoron nun? Ĝi estos reelŝutita laŭbezone.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="728"/>
+        <location filename="../settingswidget.cpp" line="734"/>
+        <location filename="../settingswidget.cpp" line="743"/>
+        <location filename="../settingswidget.cpp" line="746"/>
+        <source>Export profile</source>
+        <translation>Eksporti la profilon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="729"/>
+        <source>The archive will contain your logged-in WhatsApp session. Keep it private. Continue?</source>
+        <translation>La arkivo enhavos vian ensalutitan seancon de Vacapo. Tenu ĝin privata. Ĉu daŭrigi?</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="736"/>
+        <location filename="../settingswidget.cpp" line="751"/>
+        <source>Archives (*.tar.gz)</source>
+        <translation>Arkivoj (*.tar.gz)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="744"/>
+        <source>Profile exported.</source>
+        <translation>La profilo estas eksportita.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="751"/>
+        <location filename="../settingswidget.cpp" line="755"/>
+        <location filename="../settingswidget.cpp" line="763"/>
+        <location filename="../settingswidget.cpp" line="766"/>
+        <source>Import profile</source>
+        <translation>Importi profilon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="756"/>
+        <source>This overwrites the current account&apos;s data with the archive, then Whatly must be restarted. Continue?</source>
+        <translation>Tio anstataŭigas la datumojn de la nuna konto per la arkivo, poste Whatly devas esti restartigita. Ĉu daŭrigi?</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="764"/>
+        <source>Profile imported. Please restart Whatly.</source>
+        <translation>La profilo estas importita. Bonvolu restartigi Whatly.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="787"/>
+        <source>This will delete Persistent Data ! Persistent data includes persistent cookies and Cache, and Quit the application.</source>
+        <translation>Tio forigos la daŭrajn datumojn ! Daŭraj datumoj inkluzivas daŭrajn kuketojn kaj la kaŝmemoron, kaj ĉesigos la aplikaĵon.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="792"/>
+        <source>Delete Cookies and Quit Application?</source>
+        <translation>Ĉu forigi la kuketojn kaj ĉesigi la aplikaĵon?</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="894"/>
+        <source>| Error</source>
+        <translation>| Eraro</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="895"/>
+        <source>Cannot set an empty UserAgent String.</source>
+        <translation>Ne eblas agordi malplenan ĉenon de uzantagento.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="946"/>
+        <source>Automatic theme switching was disabled due to manual theme toggle.</source>
+        <translation>La aŭtomata ŝanĝo de etoso estis malŝaltita pro permana baskuligo de la etoso.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="985"/>
+        <source>App lock is not configured.</source>
+        <translation>La aplikaĵa ŝloso ne estas agordita.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="989"/>
+        <source>Do you want to setup App lock now?</source>
+        <translation>Ĉu vi volas agordi la aplikaĵan ŝloson nun?</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1031"/>
+        <source>Feature permissions</source>
+        <translation>Permesoj de la funkcioj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1110"/>
+        <source>Choose a chat wallpaper</source>
+        <translation>Elekti tapeton por la babilo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1112"/>
+        <source>Images (%1)</source>
+        <translation>Bildoj (%1)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1120"/>
+        <source>Could not use that image: %1</source>
+        <translation>Ne eblis uzi tiun bildon: %1</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1135"/>
+        <source>Choose a CSS file</source>
+        <translation>Elekti CSS-dosieron</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1137"/>
+        <source>Stylesheets (*.css);;All files (*)</source>
+        <translation>Stilfolioj (*.css);;Ĉiuj dosieroj (*)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1144"/>
+        <source>Could not read that file: %1</source>
+        <translation>Ne eblis legi tiun dosieron: %1</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1217"/>
+        <source>Disk</source>
+        <translation>Disko</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1218"/>
+        <source>Memory</source>
+        <translation>Memoro</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1219"/>
+        <location filename="../settingswidget.cpp" line="1712"/>
+        <source>None</source>
+        <translation>Neniu</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1325"/>
+        <source>System</source>
+        <translation>Sistemo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1326"/>
+        <source>None (direct)</source>
+        <translation>Neniu (rekta)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1327"/>
+        <source>SOCKS5</source>
+        <translation>SOCKS5</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1328"/>
+        <source>HTTP</source>
+        <translation>HTTP</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1354"/>
+        <source>Desktop portal (Flatpak)</source>
+        <translation>Labortabla portalo (Flatpak)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1356"/>
+        <source>System service (libnotify)</source>
+        <translation>Sistema servo (libnotify)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1517"/>
+        <location filename="../settingswidget.cpp" line="1521"/>
+        <source>Add reply</source>
+        <translation>Aldoni respondon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1517"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1521"/>
+        <source>Text to insert</source>
+        <translation>Enmetota teksto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1538"/>
+        <source>Choose a JavaScript file</source>
+        <translation>Elekti JavaScript-dosieron</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1539"/>
+        <source>JavaScript (*.js);;All files (*)</source>
+        <translation>JavaScript (*.js);;Ĉiuj dosieroj (*)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1544"/>
+        <source>Could not add addon</source>
+        <translation>Ne eblis aldoni la aldonaĵon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1557"/>
+        <source>Remove addon</source>
+        <translation>Forigi la aldonaĵon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1558"/>
+        <source>Remove the addon &quot;%1&quot;? This deletes its file.</source>
+        <translation>Ĉu forigi la aldonaĵon &quot;%1&quot;? Tio forigas ĝian dosieron.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1661"/>
+        <source>Spell checker (no dictionaries installed)</source>
+        <translation>Literumkontrolilo (neniu vortaro instalita)</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1716"/>
+        <source>%1 languages</source>
+        <translation>%1 lingvoj</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1788"/>
+        <source>WhatsApp default</source>
+        <translation>Defaŭlto de Vacapo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1827"/>
+        <source>System default</source>
+        <translation>Defaŭlto de la sistemo</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1862"/>
+        <source>The interface language will change when you restart %1.</source>
+        <translation>La lingvo de la interfaco ŝanĝiĝos kiam vi restartigos %1.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1876"/>
+        <source>App Lock Setup</source>
+        <translation>Agordo de la aplikaĵa ŝloso</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1877"/>
+        <source>Please setup the App lock password first.</source>
+        <translation>Bonvolu unue agordi la pasvorton de la aplikaĵa ŝloso.</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="1988"/>
+        <location filename="../settingswidget.cpp" line="1999"/>
+        <source>Select download directory</source>
+        <translation>Elekti la elŝutan dosierujon</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="2039"/>
+        <source>You are about to change your current app lock password!
+
+This will LogOut your current session.
+You may also require a complete restart of Application!</source>
+        <translation>Vi estas ŝanĝonta vian nunan pasvorton de la aplikaĵa ŝloso!
+
+Tio elsalutigos vian nunan seancon.
+Eble vi ankaŭ bezonos kompletan restartigon de la aplikaĵo!</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.cpp" line="2045"/>
+        <source>Do you want to proceed?</source>
+        <translation>Ĉu vi volas daŭrigi?</translation>
+    </message>
+</context>
+<context>
+    <name>SetupWizard</name>
+    <message>
+        <location filename="../setupwizard.cpp" line="24"/>
+        <location filename="../setupwizard.cpp" line="30"/>
+        <source>Welcome to Whatly</source>
+        <translation>Bonvenon al Whatly</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="31"/>
+        <source>A fast, native WhatsApp Web client for the desktop. Let&apos;s set a few things up — you can change all of this later in Settings.</source>
+        <translation>Rapida, indiĝena klientprogramo de Vacapo Reto por la labortablo. Ni agordu kelkajn aferojn — vi povas ŝanĝi ĉion ĉi poste en la Agordoj.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="36"/>
+        <source>Whatly keeps your chats in a proper desktop window, with a tray icon, notifications, themes, and multiple accounts.</source>
+        <translation>Whatly tenas viajn babilojn en vera labortabla fenestro, kun pletopiktogramo, sciigoj, etosoj kaj pluraj kontoj.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="46"/>
+        <source>A few preferences</source>
+        <translation>Kelkaj preferoj</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="47"/>
+        <source>Sensible defaults; tweak to taste.</source>
+        <translation>Prudentaj defaŭltoj; alĝustigu laŭ via gusto.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="50"/>
+        <source>Match the system light/dark theme</source>
+        <translation>Sekvi la helan/malhelan etoson de la sistemo</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="55"/>
+        <source>Start Whatly when I log in</source>
+        <translation>Startigi Whatly kiam mi ensalutas</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="61"/>
+        <source>Notification delivery:</source>
+        <translation>Livero de sciigoj:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="64"/>
+        <source>Automatic</source>
+        <translation>Aŭtomata</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="65"/>
+        <source>Desktop portal (Flatpak)</source>
+        <translation>Labortabla portalo (Flatpak)</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="67"/>
+        <source>System service (libnotify)</source>
+        <translation>Sistema servo (libnotify)</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="77"/>
+        <source>All set</source>
+        <translation>Ĉio preta</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="78"/>
+        <source>You&apos;re ready to go. Scan the QR code with your phone to sign in.</source>
+        <translation>Vi estas preta. Skanu la QR-kodon per via telefono por ensaluti.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizard.cpp" line="82"/>
+        <source>Everything here lives in Settings if you change your mind.</source>
+        <translation>Ĉio ĉi troviĝas en la Agordoj se vi ŝanĝos vian opinion.</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateChecker</name>
+    <message>
+        <location filename="../updatechecker.cpp" line="111"/>
+        <source>Could not read the latest release</source>
+        <translation>Ne eblis legi la plej novan eldonon</translation>
+    </message>
+</context>
+<context>
+    <name>WebEnginePage</name>
+    <message>
+        <location filename="../webenginepage.cpp" line="51"/>
+        <source>Share your screen</source>
+        <translation>Kunhavigi vian ekranon</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="53"/>
+        <source>Choose what to share:</source>
+        <translation>Elektu kion kunhavigi:</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="65"/>
+        <source>Untitled</source>
+        <translation>Sentitola</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="69"/>
+        <source>Screen: </source>
+        <translation>Ekrano: </translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="70"/>
+        <source>Window: </source>
+        <translation>Fenestro: </translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="149"/>
+        <source>Allow %1 to access your location information?</source>
+        <translation>Ĉu permesi al %1 aliri vian lokan informon?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="151"/>
+        <source>Allow %1 to access your microphone?</source>
+        <translation>Ĉu permesi al %1 aliri vian mikrofonon?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="153"/>
+        <source>Allow %1 to access your webcam?</source>
+        <translation>Ĉu permesi al %1 aliri vian retkameraon?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="155"/>
+        <source>Allow %1 to access your microphone and webcam?</source>
+        <translation>Ĉu permesi al %1 aliri vian mikrofonon kaj retkameraon?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="157"/>
+        <source>Allow %1 to lock your mouse cursor?</source>
+        <translation>Ĉu permesi al %1 ŝlosi vian musmontrilon?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="159"/>
+        <source>Allow %1 to capture video of your desktop?</source>
+        <translation>Ĉu permesi al %1 kapti videon de via labortablo?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="161"/>
+        <source>Allow %1 to capture audio and video of your desktop?</source>
+        <translation>Ĉu permesi al %1 kapti sonon kaj videon de via labortablo?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="164"/>
+        <source>Allow %1 to show notification on your desktop?</source>
+        <translation>Ĉu permesi al %1 montri sciigojn en via labortablo?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="166"/>
+        <source>Allow %1 to read your clipboard? This is needed to paste images into a chat.</source>
+        <translation>Ĉu permesi al %1 legi vian tondujon? Tio necesas por alglui bildojn en babilon.</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="169"/>
+        <source>Allow %1 to see the fonts installed on your system?</source>
+        <translation>Ĉu permesi al %1 vidi la tiparojn instalitajn en via sistemo?</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="189"/>
+        <location filename="../webenginepage.cpp" line="403"/>
+        <source>Permission Request</source>
+        <translation>Peto de permeso</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="326"/>
+        <location filename="../webenginepage.cpp" line="335"/>
+        <source>Certificate Error</source>
+        <translation>Eraro de atestilo</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="355"/>
+        <source>Enter username and password for &quot;%1&quot; at %2</source>
+        <translation>Enigu uzantnomon kaj pasvorton por &quot;%1&quot; ĉe %2</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="385"/>
+        <source>Connect to proxy &quot;%1&quot; using:</source>
+        <translation>Konektiĝi al la prokurilo &quot;%1&quot; per:</translation>
+    </message>
+    <message>
+        <location filename="../webenginepage.cpp" line="404"/>
+        <source>Allow %1 to open all %2 links?</source>
+        <translation>Ĉu permesi al %1 malfermi ĉiujn ligilojn %2?</translation>
+    </message>
+</context>
+<context>
+    <name>WebView</name>
+    <message>
+        <location filename="../webview.cpp" line="37"/>
+        <source>Render process normal exit</source>
+        <translation>Normala eliro de la bildiga procezo</translation>
+    </message>
+    <message>
+        <location filename="../webview.cpp" line="40"/>
+        <source>Render process abnormal exit</source>
+        <translation>Nenormala eliro de la bildiga procezo</translation>
+    </message>
+    <message>
+        <location filename="../webview.cpp" line="43"/>
+        <source>Render process crashed</source>
+        <translation>La bildiga procezo kolapsis</translation>
+    </message>
+    <message>
+        <location filename="../webview.cpp" line="46"/>
+        <source>Render process killed</source>
+        <translation>La bildiga procezo estis mortigita</translation>
+    </message>
+    <message>
+        <location filename="../webview.cpp" line="69"/>
+        <source>Render process exited with code: %1
+Do you want to reload the page ?</source>
+        <translation>La bildiga procezo eliris kun la kodo: %1
+Ĉu vi volas reŝargi la paĝon ?</translation>
+    </message>
+</context>
+</TS>

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -1840,8 +1840,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="480"/>
-        <source>Interface language</source>
-        <translation>Lingvo de la interfaco</translation>
+        <source>Interface language (requires restart)</source>
+        <translation>Lingvo de la interfaco (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="487"/>

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -186,6 +186,21 @@ Do you wish to override the security check and continue ?   </source>
     </message>
 </context>
 <context>
+    <name>ChatListStrip</name>
+    <message>
+        <source>Small</source>
+        <translation>Malgranda</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>Meza</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>Granda</translation>
+    </message>
+</context>
+<context>
     <name>ChatTheme</name>
     <message>
         <location filename="../chattheme.cpp" line="156"/>
@@ -854,6 +869,22 @@ Bonvolu unue agordi la pasvorton en la Agordoj.
         <source>Waiting for network…</source>
         <translation>Atendado de la reto…</translation>
     </message>
+    <message>
+        <source>Restart</source>
+        <translation>Restartigo</translation>
+    </message>
+    <message>
+        <source>Whatly could not start a new instance, so it has not closed this one. Please quit and reopen it.</source>
+        <translation>Whatly ne povis lanĉi novan instancon, do ĝi ne fermis ĉi tiun. Bonvolu eliri kaj remalfermi ĝin.</translation>
+    </message>
+    <message>
+        <source>Expand the chat list</source>
+        <translation>Malfaldi la liston de babiloj</translation>
+    </message>
+    <message>
+        <source>Collapse the chat list</source>
+        <translation>Faldi la liston de babiloj</translation>
+    </message>
 </context>
 <context>
     <name>MoreApps</name>
@@ -1383,6 +1414,20 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
         <source>Reset zoom</source>
         <comment>WebTweaks</comment>
         <translation>Restarigi la zomon</translation>
+    </message>
+    <message>
+        <source>Internal: wait for the process with this id to exit before starting, used by &quot;Restart now&quot;</source>
+        <translation>Interna: atendi la finiĝon de la procezo kun ĉi tiu identigilo antaŭ ol lanĉiĝi; uzata de “Restartigi nun”</translation>
+    </message>
+    <message>
+        <source>Collapse the chat list</source>
+        <comment>WebTweaks</comment>
+        <translation>Faldi la liston de babiloj</translation>
+    </message>
+    <message>
+        <source>Show the chat list</source>
+        <comment>WebTweaks</comment>
+        <translation>Montri la liston de babiloj</translation>
     </message>
 </context>
 <context>
@@ -2907,6 +2952,50 @@ Eble vi ankaŭ bezonos kompletan restartigon de la aplikaĵo!</translation>
         <location filename="../settingswidget.cpp" line="2045"/>
         <source>Do you want to proceed?</source>
         <translation>Ĉu vi volas daŭrigi?</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a button to WhatsApp&apos;s own sidebar that collapses the chat list to a strip of profile pictures, giving the conversation the width it was using.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aldonas butonon al la propra flanka breto de Vacapo, kiu faldas la liston de babiloj en strion de profilbildoj, donante al la konversacio la larĝon kiun ĝi uzis.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Chat-list collapse button in WhatsApp&apos;s sidebar</source>
+        <translation>Falda butono de la listo de babiloj en la flanka breto de Vacapo</translation>
+    </message>
+    <message>
+        <source>Collapsed chat preview</source>
+        <translation>Antaŭrigardo en la faldita listo</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How large to draw the preview that appears when you hover a picture in the collapsed chat list. The default suits this platform&apos;s font rendering; pick another if it reads small or large on your screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kiom grande desegni la antaŭrigardon kiu aperas kiam vi ŝvebas super bildo en la faldita listo de babiloj. La defaŭlta valoro konvenas al la tiparbildigo de ĉi tiu platformo; elektu alian se ĝi legiĝas tro malgranda aŭ tro granda sur via ekrano.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Let Whatly draw the window&apos;s border and title bar instead of the system, so they follow Whatly&apos;s own theme. On its own this only changes their appearance; tick &quot;Hide the title bar&quot; as well to get rid of the title row altogether. Applies after a restart.</source>
+        <translation>Lasi Whatly desegni la randon kaj la titolbreton de la fenestro anstataŭ la sistemon, por ke ili sekvu la propran etoson de Whatly. Per si mem tio ŝanĝas nur ilian aspekton; marku ankaŭ “Kaŝi la titolbreton” por tute forigi la titolan vicon. Efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <source>Keep the account tab strip up even when there is only one account, so its &quot;+&quot; is always at hand. With it off, the strip appears once a second account exists; you can still add one with Ctrl+K.</source>
+        <translation>Teni la strion de kontolangetoj videbla eĉ kiam ekzistas nur unu konto, por ke ĝia “+” ĉiam estu ĉemane. Kiam ĝi estas malŝaltita, la strio aperas post kiam ekzistas dua konto; vi tamen povas aldoni konton per Ctrl+K.</translation>
+    </message>
+    <message>
+        <source>Show the account tabs even with a single account</source>
+        <translation>Montri la kontolangetojn eĉ kun unu sola konto</translation>
+    </message>
+    <message>
+        <source>Restart Whatly now so the settings above take effect. The windows, and this page with it, come back exactly as they are.</source>
+        <translation>Restartigi Whatly nun por ke la supraj agordoj efektiviĝu. La fenestroj, kaj ĉi tiu paĝo kun ili, revenos ĝuste tiaj, kiaj ili estas.</translation>
+    </message>
+    <message>
+        <source>Restart now</source>
+        <translation>Restartigi nun</translation>
+    </message>
+    <message>
+        <source>Drop the title bar and put its buttons at the end of the account tab strip, the way a browser does, instead of giving them a row of their own. Switches on the custom window frame, which it needs. Applies after a restart.</source>
+        <translation>Forigi la titolbreton kaj meti ĝiajn butonojn ĉe la fino de la strio de kontolangetoj, kiel faras retumilo, anstataŭ doni al ili propran vicon. Ŝaltas la propran fenestran kadron, kiun ĝi bezonas. Efektiviĝas post restartigo.</translation>
+    </message>
+    <message>
+        <source>Hide the title bar (requires restart)</source>
+        <translation>Kaŝi la titolbreton (postulas restartigon)</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
A complete Esperanto translation — all **584 strings**, none left `unfinished`, none `obsolete`. Sixteenth language.

It is also the first language added since the `.ts` files started being compiled and loaded, and the first with **no territory**: the file is `eo.ts`, not `eo_XX.ts`. That works because `main.cpp` already falls back from the full locale name to the bare language code when looking for `:/i18n/<name>.qm` — so this quietly exercises that path for the first time.

### Wiring

One line in `CMakeLists.txt`. Nothing else was needed: `populateLanguages()` builds the picker by listing `:/i18n/*.qm` and takes each label from Qt's own `QLocale`, exactly as the comment there promises.

### Vocabulary

WhatsApp is **Vacapo** — what Esperanto speakers actually call it online, not a coinage invented for this file. The same principle throughout: `retumilo` (browser), `sistempleto` (system tray), `kuketoj` (cookies), `emoĝioj`, `glumarkoj` (stickers), `fulmoklavoj` (keyboard shortcuts), `kaŝmemoro` (cache), `nebuligi` (blur), `sekurkopio` (backup).

Left untranslated on purpose: proper nouns and API identifiers — Meta, Graph API, webhook, Flatpak, SOCKS5, and every command-line flag — because translating those makes the documentation impossible to follow. **Whatly** is not translated either; it is the application's name.

### Two things a reviewer cannot see in a 584-string diff

- **Every tray-menu mnemonic is still unique after translation.** The obvious renderings collided on S (`Ŝlosi` against `Silentigi`), so Lock takes **L**.
- **No mnemonic binds a non-ASCII letter.** Reload reads `Reŝargi`, whose natural mnemonic would be **Ŝ** — which most keyboards cannot type — so it takes **G**.

### Checked

`lrelease`: **584 finished, 0 unfinished**. Clean build with the `.qm` embedded, and `ctest` 3/3 on Windows 10 / Qt 6.11.1 / MSVC.

Placeholders (`%1`, `%L1`, `%p%`), the HTML skeleton of the rich-text labels, and the `&&`-escaped literal ampersands were verified **mechanically against the source of every message**, not by eye — that check is what caught the two accelerator problems above.

### What is not verified

**The language itself has not been read in a running interface.** Gert is a fluent Esperanto speaker and will be dogfooding it over the coming days on both Linux and Windows; corrections will come as follow-ups. A translation is the one kind of change where use over time is the only real test, and holding it back until then helps nobody — an untranslated string and a slightly awkward one both fall back to being readable, and neither can break the app.

One consequence worth stating plainly: if `QLocale` on some Qt build returns an empty native name for `eo`, the picker falls back to showing the bare code `eo` instead of `Esperanto`. That fallback is already in `populateLanguages()`; I have not confirmed which of the two Qt 6.11 actually produces.
