### PR TITLE
feat(settings): flag restart-only settings and add a per-group Restart now button

### DIFF
--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -2372,8 +2372,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1485"/>
-        <source>Performance &amp; Privacy</source>
-        <translation>Rendimento kaj privateco</translation>
+        <source>Performance &amp; Privacy (requires restart)</source>
+        <translation>Rendimento kaj privateco (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1491"/>
@@ -2562,8 +2562,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1762"/>
-        <source>Interface scale</source>
-        <translation>Skalo de la interfaco</translation>
+        <source>Interface scale (requires restart)</source>
+        <translation>Skalo de la interfaco (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1769"/>
@@ -2614,8 +2614,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1902"/>
-        <source>Custom JavaScript addons</source>
-        <translation>Propraj JavaScript-aldonaĵoj</translation>
+        <source>Custom JavaScript addons (requires restart)</source>
+        <translation>Propraj JavaScript-aldonaĵoj (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1908"/>
@@ -2650,8 +2650,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2022"/>
-        <source>Keyboard shortcuts</source>
-        <translation>Fulmoklavoj</translation>
+        <source>Keyboard shortcuts (requires restart)</source>
+        <translation>Fulmoklavoj (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2028"/>

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -629,6 +629,22 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     makeCollapsible(privacy, false);
     makeCollapsible(window, false);
     makeCollapsible(advanced, false);
+    // Give each group made up entirely of restart-only settings its own
+    // "Restart now" button (bottom-right) — the same one offered beside
+    // Interface language and the window-frame controls (#27). One per group.
+    const auto addGroupRestart = [restartButton](QVBoxLayout *v) {
+      if (!v)
+        return;
+      auto *h = new QHBoxLayout;
+      h->setContentsMargins(0, 0, 0, 0);
+      h->addStretch(1);
+      h->addWidget(restartButton());
+      v->addLayout(h);
+    };
+    addGroupRestart(ui->verticalLayoutPerformance);
+    addGroupRestart(ui->verticalLayoutJsAddons);
+    addGroupRestart(ui->verticalLayoutShortcuts);
+
     makeCollapsible(ui->groupBox_7, false);          // Storage
     makeCollapsible(ui->groupBoxPerformance, false); // Performance & Privacy
     makeCollapsible(ui->groupBoxNetwork, false);     // Network & Startup

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -1526,7 +1526,7 @@ background:transparent;
        <item>
         <widget class="QGroupBox" name="groupBoxPerformance">
          <property name="title">
-          <string>Performance &amp; Privacy</string>
+          <string>Performance &amp; Privacy (requires restart)</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutPerformance">
           <item>
@@ -1855,7 +1855,7 @@ background:transparent;
             <item>
              <widget class="QLabel" name="interfaceScaleLabel">
               <property name="text">
-               <string>Interface scale</string>
+               <string>Interface scale (requires restart)</string>
               </property>
              </widget>
             </item>
@@ -1995,7 +1995,7 @@ background:transparent;
        <item>
         <widget class="QGroupBox" name="groupBoxJsAddons">
          <property name="title">
-          <string>Custom JavaScript addons</string>
+          <string>Custom JavaScript addons (requires restart)</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutJsAddons">
           <item>
@@ -2115,7 +2115,7 @@ background:transparent;
        <item>
         <widget class="QGroupBox" name="groupBoxShortcuts">
          <property name="title">
-          <string>Keyboard shortcuts</string>
+          <string>Keyboard shortcuts (requires restart)</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutShortcuts">
           <item>


### PR DESCRIPTION
Several settings only take effect after a restart but did not advertise it, which makes them easy to miss.

- Adds "(requires restart)" to the Interface scale label and to the Performance & Privacy, Custom JavaScript addons and Keyboard shortcuts group headers, consistent with the existing Interface language and window-frame labels.
- Gives each of those three groups a "Restart now" button (bottom-right), reusing the existing button's text and tooltip, so there is nothing new to translate for the button itself. One button per group rather than per row.
- Interface scale gets the label only; it sits in Window & zoom, which already offers a Restart now button.

Esperanto is translated for the four new strings; the other locales still need an lupdate pass to pick them up.

Tested on Linux (Flatpak): the labels appear, each group's button restarts cleanly (one window, still logged in), and the rest of the settings page is unchanged.
