### PR TITLE
feat(attach): read dropped files off the UI thread, behind a progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+**A progress bar for dropped attachments.** Dropping a file read it, base64-encoded
+it and built the injected script all in the drop handler, so the window froze for
+several seconds — on a video, long enough to look like a hang — with nothing on
+screen to explain it. The reading now happens on a worker thread with a small
+progress bar over the bottom of the chat, so the window stays responsive and the
+wait is visible. The bar waits a moment before appearing, so a quick drop does
+not flash one up and away. Files that do not fit the 64 MB drop buffer were
+skipped with only a terminal warning; they are now named on screen as well. A
+file dropped while another is still being read is queued and attached after it,
+rather than being ignored.
+
 **VIP and muted contacts for notifications.** Settings → Notifications now takes
 a list of VIP contacts, which always notify even during Do Not Disturb, and a
 list of muted contacts, whose popups are never shown (their unread badge still

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ set(SOURCES
     src/dropattach.cpp
     src/chatnav.cpp
     src/dropresolve.cpp
+    src/dropreader.cpp
+    src/dropprogress.cpp
     src/notificationrules.cpp
     src/networkproxy.cpp
     src/autostart.cpp
@@ -285,6 +287,8 @@ set(HEADERS
     src/performance.h
     src/trayicon.h
     src/dropattach.h
+    src/dropreader.h
+    src/dropprogress.h
     src/notificationrules.h
     src/networkproxy.h
     src/autostart.h

--- a/src/dropattach.cpp
+++ b/src/dropattach.cpp
@@ -38,10 +38,33 @@ QString scriptSource(const QList<File> &files) {
       for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
       dt.items.add(new File([bytes], f.name, { type: f.type }));
     });
-    var box = document.querySelector("#main footer [contenteditable='true']") ||
-              document.querySelector("[contenteditable='true']");
-    if (box) box.focus();
-    var target = box || document.activeElement || document.body;
+    // The paste only lands on a box that has the focus, exactly as when you click
+    // into a caption before pressing Ctrl+V, so whichever box is chosen has to be
+    // focused here.
+    //
+    // Which box: with no attachment open there is just the chat composer, in the
+    // footer. Opening the media preview adds its caption box OUTSIDE the footer
+    // and does NOT hide the composer, which stays visible and even keeps the
+    // focus — so preferring the composer sent every extra file to the chat that
+    // was not accepting it, and the file vanished. A visible editable box outside
+    // the footer therefore means the preview is open and is the one to paste into.
+    var visible = function (el) { return el && el.offsetParent !== null; };
+    var inFooter = function (el) {
+      return !!(el && el.closest && el.closest("#main footer"));
+    };
+    var boxes = document.querySelectorAll("[contenteditable='true']");
+    var caption = null, composer = null;
+    for (var b = 0; b < boxes.length; b++) {
+      if (!visible(boxes[b]))
+        continue;
+      if (inFooter(boxes[b])) {
+        if (!composer) composer = boxes[b];
+      } else if (!caption) {
+        caption = boxes[b];
+      }
+    }
+    var target = caption || composer || document.activeElement || document.body;
+    if (target.focus) target.focus();
     target.dispatchEvent(new ClipboardEvent("paste", {
       clipboardData: dt, bubbles: true, cancelable: true
     }));

--- a/src/dropprogress.cpp
+++ b/src/dropprogress.cpp
@@ -1,0 +1,128 @@
+#include "dropprogress.h"
+
+#include <QEvent>
+#include <QFont>
+#include <QLabel>
+#include <QLayout>
+#include <QProgressBar>
+#include <QTimer>
+#include <QVBoxLayout>
+
+namespace {
+// Wide enough for a few long file names; it grows taller for more than that.
+constexpr int kMaxWidth = 520;
+constexpr int kMargin = 18;
+// How long a closing message stays up before the bar disappears.
+constexpr int kMessageMs = 6000;
+// Grace period before the bar appears, so a quick drop never flashes one up.
+constexpr int kShowDelayMs = 400;
+} // namespace
+
+DropProgress::DropProgress(QWidget *host)
+    : QWidget(host ? host->window() : nullptr), m_host(host) {
+  // Purely informational, so it must never swallow a click meant for the chat.
+  setAttribute(Qt::WA_TransparentForMouseEvents);
+
+  m_label = new QLabel(this);
+  m_label->setWordWrap(true);
+  // Weighted like the page's own notices (the over-16MB and unsupported-video
+  // ones), which are bolder than a default label and were what this sat next to.
+  QFont labelFont = m_label->font();
+  labelFont.setBold(true);
+  labelFont.setPointSizeF(labelFont.pointSizeF() * 1.1);
+  m_label->setFont(labelFont);
+  m_bar = new QProgressBar(this);
+  m_bar->setTextVisible(false);
+  m_bar->setFixedHeight(6);
+
+  auto *v = new QVBoxLayout(this);
+  v->setContentsMargins(12, 10, 12, 10);
+  v->setSpacing(8);
+  v->addWidget(m_label);
+  v->addWidget(m_bar);
+
+  // Follows the palette so it reads on both the light and the dark theme.
+  setStyleSheet(QStringLiteral(
+      "DropProgress{background:palette(window);border:1px solid palette(mid);"
+      "border-radius:8px}"));
+
+  m_showTimer = new QTimer(this);
+  m_showTimer->setSingleShot(true);
+  connect(m_showTimer, &QTimer::timeout, this, [this]() {
+    reposition();
+    show();
+    raise();
+  });
+
+  if (m_host) {
+    m_host->installEventFilter(this);
+    if (m_host->window() != m_host)
+      m_host->window()->installEventFilter(this);
+  }
+  hide();
+}
+
+void DropProgress::begin() {
+  m_label->setText(tr("Attaching…"));
+  m_bar->setRange(0, 100);
+  m_bar->setValue(0);
+  m_bar->show();
+  reposition();
+  // Most drops finish in well under a second, and a panel that appears only to
+  // vanish again reads as a glitch. Wait a moment: if the read is already done
+  // by then, nothing is ever shown.
+  m_showTimer->start(kShowDelayMs);
+}
+
+void DropProgress::setProgress(qint64 bytesRead, qint64 bytesTotal) {
+  if (bytesTotal <= 0)
+    return;
+  m_bar->setValue(static_cast<int>((bytesRead * 100) / bytesTotal));
+}
+
+void DropProgress::finish(const QString &message) {
+  m_showTimer->stop(); // the read is over; no point appearing now
+  if (message.isEmpty()) {
+    hide();
+    return;
+  }
+  // A file left out of the drop must not go unnoticed the way a terminal-only
+  // warning did, so this shows even when nothing was read at all and the bar
+  // itself was therefore never on screen.
+  m_label->setText(message);
+  m_bar->hide();
+  reposition();
+  show();
+  raise();
+  QTimer::singleShot(kMessageMs, this, [this]() { hide(); });
+}
+
+bool DropProgress::eventFilter(QObject *watched, QEvent *event) {
+  if (isVisible() && (event->type() == QEvent::Resize ||
+                      event->type() == QEvent::Move))
+    reposition();
+  return QWidget::eventFilter(watched, event);
+}
+
+void DropProgress::reposition() {
+  if (!m_host || !parentWidget())
+    return;
+  const int w = qMin(kMaxWidth, qMax(160, m_host->width() - 2 * kMargin));
+  // Width first, then measure: the label wraps, so its height only means
+  // anything once it knows how wide it will be. Ask the layout for the height
+  // that width needs, so several long file names make the panel taller instead
+  // of being clipped by it.
+  resize(w, height());
+  int h = sizeHint().height();
+  if (QLayout *l = layout()) {
+    l->activate();
+    if (l->hasHeightForWidth())
+      h = l->heightForWidth(w);
+  }
+  resize(w, h);
+  // Bottom-centre of the view, expressed in the window's coordinates.
+  const QPoint hostTopLeft = m_host->mapTo(parentWidget(), QPoint(0, 0));
+  const int x = hostTopLeft.x() + (m_host->width() - width()) / 2;
+  const int y = hostTopLeft.y() + m_host->height() - height() - kMargin;
+  move(x, y);
+}

--- a/src/dropprogress.h
+++ b/src/dropprogress.h
@@ -1,0 +1,44 @@
+#ifndef DROPPROGRESS_H
+#define DROPPROGRESS_H
+
+#include <QWidget>
+
+class QLabel;
+class QProgressBar;
+class QTimer;
+
+// The little bar shown while a dropped file is being read, sitting over the
+// bottom of the chat. Reading a video takes a few seconds, and without this the
+// window simply sat there looking stuck.
+//
+// It parents itself to the top-level window rather than to the view it covers:
+// a child of QWebEngineView has to fight the render widget for stacking order,
+// while a sibling of it does not.
+class DropProgress : public QWidget {
+  Q_OBJECT
+
+public:
+  // host is the view the bar is placed over; it stays owned by host's window.
+  explicit DropProgress(QWidget *host);
+
+  // Show the bar at zero, ready for setProgress().
+  void begin();
+  void setProgress(qint64 bytesRead, qint64 bytesTotal);
+
+  // Take the bar down. With a message, that is shown on its own for a few
+  // seconds first (used to say which files were too large).
+  void finish(const QString &message = QString());
+
+protected:
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+  void reposition();
+
+  QWidget *m_host;
+  QLabel *m_label;
+  QProgressBar *m_bar;
+  QTimer *m_showTimer; // delays the panel so a fast drop never flashes it
+};
+
+#endif // DROPPROGRESS_H

--- a/src/dropreader.cpp
+++ b/src/dropreader.cpp
@@ -1,0 +1,67 @@
+#include "dropreader.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QMimeDatabase>
+
+namespace {
+// Read in slices rather than in one go, so a single large file still moves the
+// progress bar instead of jumping from nothing to done.
+constexpr qint64 kChunkBytes = 1LL * 1024 * 1024;
+} // namespace
+
+DropReader::Plan DropReader::plan(const QStringList &paths) {
+  Plan p;
+  for (const QString &path : paths) {
+    const QFileInfo info(path);
+    // Directories, and empty or vanished files, have nothing to attach.
+    if (!info.isFile() || info.size() <= 0)
+      continue;
+    if (p.totalBytes + info.size() > kMaxTotalBytes) {
+      p.tooLarge.append(info.fileName());
+      continue;
+    }
+    p.totalBytes += info.size();
+    p.accepted.append(info.absoluteFilePath());
+  }
+  return p;
+}
+
+DropReader::DropReader(const QStringList &paths, qint64 totalBytes,
+                       QObject *parent)
+    : QObject(parent), m_paths(paths), m_totalBytes(totalBytes) {}
+
+void DropReader::run() {
+  QList<DropAttach::File> files;
+  QMimeDatabase mimeDb;
+  qint64 done = 0;
+
+  for (const QString &path : m_paths) {
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+      continue;
+
+    QByteArray data;
+    data.reserve(static_cast<int>(file.size()));
+    while (!file.atEnd()) {
+      const QByteArray chunk = file.read(kChunkBytes);
+      if (chunk.isEmpty())
+        break; // read error part-way through; keep what we have
+      data.append(chunk);
+      done += chunk.size();
+      emit progress(done, m_totalBytes);
+    }
+    if (data.isEmpty())
+      continue;
+
+    const QFileInfo info(path);
+    const QString type =
+        mimeDb.mimeTypeForFileNameAndData(info.fileName(), data).name();
+    files.append({info.fileName(), type, QString::fromLatin1(data.toBase64())});
+  }
+
+  // Built here too: the script embeds every file's base64, so assembling it is
+  // as expensive as the reading and belongs off the UI thread as well.
+  m_script = DropAttach::scriptSource(files);
+  emit finished();
+}

--- a/src/dropreader.h
+++ b/src/dropreader.h
@@ -1,0 +1,56 @@
+#ifndef DROPREADER_H
+#define DROPREADER_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+#include "dropattach.h"
+
+// Reads the files from a drop and builds the script that hands them to the page.
+// The contents are base64-encoded into that script, so a dropped video means
+// tens of megabytes of reading, encoding and string building; doing it straight
+// in the drop handler froze the window for several seconds with nothing on
+// screen to say why. This does the work on its own thread and reports how far it
+// has got, so the drop can show a progress bar and the window stays responsive.
+class DropReader : public QObject {
+  Q_OBJECT
+
+public:
+  // Total bytes read into memory for one drop. The files become a base64 string
+  // handed to the renderer, so a huge drop would balloon it; over this the
+  // remaining files are left out rather than risking the page.
+  static constexpr qint64 kMaxTotalBytes = 64LL * 1024 * 1024;
+
+  // What a drop will actually read, worked out from the file sizes before any
+  // reading starts, so the caller can size the progress bar and say up front
+  // which files did not fit.
+  struct Plan {
+    QStringList accepted;  // absolute paths, in drop order
+    QStringList tooLarge;  // file names left out by kMaxTotalBytes
+    qint64 totalBytes = 0; // bytes the accepted files will read
+  };
+  static Plan plan(const QStringList &paths);
+
+  DropReader(const QStringList &paths, qint64 totalBytes,
+             QObject *parent = nullptr);
+
+  // The script for the page, valid once finished() has been emitted. Empty when
+  // nothing could be read.
+  QString script() const { return m_script; }
+
+signals:
+  void progress(qint64 bytesRead, qint64 bytesTotal);
+  void finished();
+
+public slots:
+  // Runs the read. Meant to be invoked on a worker thread.
+  void run();
+
+private:
+  QStringList m_paths;
+  qint64 m_totalBytes;
+  QString m_script;
+};
+
+#endif // DROPREADER_H

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -3293,7 +3293,20 @@ Eble vi ankaŭ bezonos kompletan restartigon de la aplikaĵo!</translation>
     </message>
 </context>
 <context>
+    <name>DropProgress</name>
+    <message>
+        <location filename="../dropprogress.cpp" line="47"/>
+        <source>Attaching…</source>
+        <translation>Kunsendante…</translation>
+    </message>
+</context>
+<context>
     <name>WebView</name>
+    <message>
+        <location filename="../webview.cpp" line="261"/>
+        <source>Too large to attach (limit %1 MB): %2</source>
+        <translation>Tro granda por kunsendi (limo %1 MB): %2</translation>
+    </message>
     <message>
         <location filename="../webview.cpp" line="54"/>
         <source>Render process normal exit</source>

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -1,4 +1,6 @@
 #include "webview.h"
+#include "dropprogress.h"
+#include "dropreader.h"
 #include "dropresolve.h"
 
 #include <QBuffer>
@@ -16,6 +18,7 @@
 #include <QMenu>
 #include <QMimeData>
 #include <QMimeDatabase>
+#include <QThread>
 #include <QUrl>
 #ifdef Q_OS_LINUX
 #include <QDBusConnection>
@@ -241,46 +244,95 @@ bool WebView::dropFiles(const QMimeData *mime) {
 
   const QStringList paths = DropResolve::droppedFilePaths(mime);
 
-  // Cap the total read into memory: the files are base64-encoded and handed to
-  // the page as a JS string, so a huge drop would balloon the renderer.
-  constexpr qint64 kMaxTotalBytes = 64LL * 1024 * 1024;
-
-  QList<DropAttach::File> files;
-  QMimeDatabase mimeDb;
-  qint64 total = 0;
-  for (const QString &path : paths) {
-    const QFileInfo info(path);
-    if (!info.isFile())
-      continue;
-    if (info.size() <= 0 || total + info.size() > kMaxTotalBytes) {
-      qWarning() << "whatly: skipping dropped file (too large for the drop"
-                    " buffer):"
-                 << info.fileName();
-      continue;
-    }
-    QFile file(info.absoluteFilePath());
-    if (!file.open(QIODevice::ReadOnly))
-      continue;
-    const QByteArray data = file.readAll();
-    total += data.size();
-    const QString type =
-        mimeDb.mimeTypeForFileNameAndData(info.fileName(), data).name();
-    files.append({info.fileName(), type, QString::fromLatin1(data.toBase64())});
+  // A drop while one is still being read is queued rather than refused: the
+  // page's composer takes a second paste as another attachment, so the files
+  // join the ones already there instead of replacing them.
+  if (m_dropReading && !paths.isEmpty()) {
+    m_queuedDropPaths += paths;
+    return true;
   }
 
-  if (files.isEmpty()) {
+  return startDropRead(paths, mime);
+}
+
+QString WebView::takeTooLargeMessage() {
+  if (m_dropTooLarge.isEmpty())
+    return QString();
+  const QString names = m_dropTooLarge.join(QStringLiteral(", "));
+  m_dropTooLarge.clear();
+  return tr("Too large to attach (limit %1 MB): %2")
+      .arg(DropReader::kMaxTotalBytes / (1024 * 1024))
+      .arg(names);
+}
+
+bool WebView::startDropRead(const QStringList &paths, const QMimeData *mime) {
+  const DropReader::Plan plan = DropReader::plan(paths);
+
+  for (const QString &name : plan.tooLarge)
+    qWarning() << "whatly: skipping dropped file (too large for the drop"
+                  " buffer):"
+               << name;
+  // Collected across the whole run of drops, not just this batch: with a queued
+  // batch still to read, reporting now would be overwritten by its progress.
+  m_dropTooLarge += plan.tooLarge;
+
+  if (plan.accepted.isEmpty()) {
+    // Everything was over the cap: say so on screen rather than only in a
+    // terminal nobody sees.
+    if (!m_dropTooLarge.isEmpty()) {
+      if (!m_dropProgress)
+        m_dropProgress = new DropProgress(this);
+      m_dropProgress->finish(takeTooLargeMessage());
+      return false;
+    }
     // Fail loudly: the drag was accepted but nothing could be read. In a Flatpak
     // this is the sandbox hiding the host path when the portal route did not
-    // apply (issue #32); elsewhere it is an unreadable or empty file.
-    if (mime->hasUrls() ||
-        mime->hasFormat(QStringLiteral("application/vnd.portal.filetransfer")))
+    // apply (issue #32); elsewhere it is an unreadable or empty file. Only for a
+    // real drop; a queued batch has no mime data to inspect.
+    if (mime && (mime->hasUrls() ||
+                 mime->hasFormat(
+                     QStringLiteral("application/vnd.portal.filetransfer"))))
       qWarning() << "whatly: a file was dropped but none could be read; in a "
                     "Flatpak, files outside the granted folders are not visible "
                     "unless delivered through the FileTransfer portal (issue #32)";
     return false;
   }
 
-  page()->runJavaScript(DropAttach::scriptSource(files));
+  if (!m_dropProgress)
+    m_dropProgress = new DropProgress(this);
+  m_dropProgress->begin();
+  m_dropReading = true;
+
+  // Read and encode on a worker thread: for a video this is seconds of work,
+  // and on the UI thread it froze the window with nothing to show for it.
+  auto *thread = new QThread(this);
+  auto *reader = new DropReader(plan.accepted, plan.totalBytes);
+  reader->moveToThread(thread);
+  connect(thread, &QThread::started, reader, &DropReader::run);
+  connect(reader, &DropReader::progress, this,
+          [this](qint64 read, qint64 total) {
+            m_dropProgress->setProgress(read, total);
+          });
+  connect(reader, &DropReader::finished, this,
+          [this, reader, thread]() {
+            const QString script = reader->script();
+            if (!script.isEmpty())
+              page()->runJavaScript(script);
+            m_dropReading = false;
+            thread->quit();
+            // Anything dropped while this was reading goes next, so the bar
+            // carries straight on instead of leaving files unattached.
+            if (!m_queuedDropPaths.isEmpty()) {
+              const QStringList next = m_queuedDropPaths;
+              m_queuedDropPaths.clear();
+              startDropRead(next, nullptr);
+              return;
+            }
+            m_dropProgress->finish(takeTooLargeMessage());
+          });
+  connect(thread, &QThread::finished, reader, &QObject::deleteLater);
+  connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+  thread->start();
   return true;
 }
 

--- a/src/webview.h
+++ b/src/webview.h
@@ -31,6 +31,22 @@ private:
   // attachment (issue #285). Returns true when at least one file was sent.
   bool dropFiles(const class QMimeData *mime);
 
+  // Reads one batch of dropped files, shows the progress bar, and hands the
+  // result to the page. mime is only there for the "nothing could be read"
+  // diagnosis and is null for a batch that was queued behind another.
+  bool startDropRead(const QStringList &paths, const class QMimeData *mime);
+
+  // The names left out by the size cap, worded for the user and then forgotten.
+  QString takeTooLargeMessage();
+
+  // The progress bar shown while a drop is being read, created on the first
+  // drop; whether a read is in flight; and files dropped during that read,
+  // which are attached after it rather than refused.
+  class DropProgress *m_dropProgress = nullptr;
+  bool m_dropReading = false;
+  QStringList m_queuedDropPaths;
+  QStringList m_dropTooLarge;
+
   // Break a runaway render-process crash loop (issue #28): when the renderer
   // keeps terminating (e.g. repeatedly SIGTERM'd in a Flatpak), stop reloading
   // and re-prompting so the user is not trapped in an endless dialog. Tracks how

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(tst_logic
     ${S}/scheduledmessages.cpp ${S}/messaging.cpp ${S}/messagetemplates.cpp ${S}/autoreply.cpp ${S}/cloudapi.cpp ${S}/localapi.cpp ${S}/cloudwebhook.cpp
     ${S}/webfont.cpp ${S}/chattheme.cpp ${S}/mutedstatus.cpp ${S}/privacyblur.cpp ${S}/chatliststrip.cpp
     ${S}/chatwallpaper.cpp ${S}/customcss.cpp ${S}/customjs.cpp ${S}/commandpalette.cpp ${S}/updatechecker.cpp ${S}/storageinfo.cpp ${S}/shortcuts.cpp ${S}/backup.cpp ${S}/screenlock.cpp ${S}/quickreply.cpp ${S}/focusmode.cpp ${S}/hdmedia.cpp ${S}/cannedresponses.cpp ${S}/webtweaks.cpp
-    ${S}/linkeddevicename.cpp ${S}/performance.cpp ${S}/trayicon.cpp ${S}/dropattach.cpp ${S}/chatnav.cpp ${S}/dropresolve.cpp ${S}/notificationrules.cpp
+    ${S}/linkeddevicename.cpp ${S}/performance.cpp ${S}/trayicon.cpp ${S}/dropattach.cpp ${S}/chatnav.cpp ${S}/dropresolve.cpp ${S}/dropreader.cpp ${S}/notificationrules.cpp
     ${S}/networkproxy.cpp ${S}/autostart.cpp ${S}/portalnotification.cpp
     ${S}/setupwizard.cpp
     ${S}/icons.qrc

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -62,6 +62,7 @@
 #include "trayicon.h"
 #include "chatnav.h"
 #include "dropattach.h"
+#include "dropreader.h"
 #include "dropresolve.h"
 #include "networkproxy.h"
 #include "notificationrules.h"
@@ -2040,6 +2041,80 @@ private slots:
   }
 };
 
+// DropReader::plan: what a drop will read, worked out from the sizes before any
+// reading starts. It sizes the progress bar and names the files left out, which
+// used to be a terminal-only warning.
+class TstDropReader : public QObject {
+  Q_OBJECT
+
+  // A file of exactly the requested size.
+  static QString makeFile(const QTemporaryDir &dir, const QString &name,
+                          qint64 bytes) {
+    const QString path = dir.filePath(name);
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly))
+      return QString();
+    if (bytes > 0)
+      f.write(QByteArray(static_cast<int>(bytes), 'x'));
+    f.close();
+    return path;
+  }
+
+private slots:
+  void emptyPathsPlanNothing() {
+    const DropReader::Plan p = DropReader::plan({});
+    QVERIFY(p.accepted.isEmpty());
+    QVERIFY(p.tooLarge.isEmpty());
+    QCOMPARE(p.totalBytes, 0);
+  }
+
+  // Normal files are accepted and their bytes summed, so the bar has a total.
+  void acceptsAndSumsSizes() {
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString a = makeFile(dir, QStringLiteral("a.bin"), 100);
+    const QString b = makeFile(dir, QStringLiteral("b.bin"), 250);
+
+    const DropReader::Plan p = DropReader::plan({a, b});
+    QCOMPARE(p.accepted.size(), 2);
+    QCOMPARE(p.totalBytes, 350);
+    QVERIFY(p.tooLarge.isEmpty());
+  }
+
+  // Empty files and directories have nothing to attach, and are not reported as
+  // too large either.
+  void skipsEmptyAndDirectories() {
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString empty = makeFile(dir, QStringLiteral("empty.bin"), 0);
+
+    const DropReader::Plan p = DropReader::plan({empty, dir.path()});
+    QVERIFY(p.accepted.isEmpty());
+    QVERIFY(p.tooLarge.isEmpty());
+    QCOMPARE(p.totalBytes, 0);
+  }
+
+  // Over the cap the file is named rather than silently dropped, and a file that
+  // still fits is kept.
+  void oversizeIsReportedNotSilent() {
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString small = makeFile(dir, QStringLiteral("small.bin"), 10);
+    // Sparse, so the test does not write 64 MB to disk.
+    const QString huge = dir.filePath(QStringLiteral("huge.bin"));
+    QFile f(huge);
+    QVERIFY(f.open(QIODevice::WriteOnly));
+    QVERIFY(f.resize(DropReader::kMaxTotalBytes + 1));
+    f.close();
+
+    const DropReader::Plan p = DropReader::plan({small, huge});
+    QCOMPARE(p.accepted.size(), 1);
+    QVERIFY(p.accepted.first().endsWith(QStringLiteral("small.bin")));
+    QCOMPARE(p.tooLarge, QStringList{QStringLiteral("huge.bin")});
+    QCOMPARE(p.totalBytes, 10);
+  }
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // The Flatpak manifests must grant read access to the standard media folders so
 // files dragged from a host file manager can be attached (#32), while staying
@@ -2889,6 +2964,7 @@ int main(int argc, char *argv[]) {
   { TstTrayIcon t;            run(&t); }
   { TstDropAttach t;          run(&t); }
   { TstDropResolve t;         run(&t); }
+  { TstDropReader t;          run(&t); }
   { TstFlatpakManifest t;     run(&t); }
   { TstChatNav t;             run(&t); }
   { TstShortcuts t;           run(&t); }


### PR DESCRIPTION
Dropping a file did all its work in the drop handler — read the file, base64-encode it, build the injected script — so the window froze for as long as that took. On a video that is several seconds looking like a hang, with nothing on screen to explain it.

- The read moves to a worker thread (`DropReader`) that reads in 1 MB slices and reports progress, so the window stays responsive. Building the script moves there too, since embedding the base64 costs as much as the read.
- A small progress bar (`DropProgress`) sits over the bottom of the chat while it runs. It waits 400 ms before appearing, so the common quick drop does not flash one up and away.
- The size accounting moves into `DropReader::plan()`, worked out from the file sizes before any reading starts, so the bar has a total and any file that will not fit is known up front.
- Files over the 64 MB drop buffer were skipped with only a `qWarning`, invisible unless the app was started from a terminal. They are now named on screen too. The cap itself is unchanged.
- A file dropped while another is still being read was refused; it is now queued and attached after it.

That last one also fixes where the paste was aimed. Opening the media preview adds its caption box **outside** the chat footer and does **not** hide the composer, which stays visible and even keeps the focus — so aiming at the composer sent every extra file to the chat, which ignored it, and the file was silently lost. It now prefers a visible editable box outside the footer and focuses it, which is what clicking into the caption before pasting does by hand.

`DropProgress` parents itself to the top-level window rather than to the view: a child of `QWebEngineView` has to fight the render widget for stacking order, a sibling does not.

New unit tests cover `DropReader::plan()` (empty input, summing sizes, skipping empty files and directories, and naming an oversize file instead of dropping it silently); the oversize case uses a sparse file so the test does not write 64 MB. The full `logic` suite passes.

Esperanto is translated for the two new strings; the other locales need an `lupdate` pass to pick them up.

Tested on Linux (Flatpak): a large video shows a moving bar and stays responsive, a second file dropped onto an open preview is added rather than lost, over-64 MB files are named on screen, and a small photo attaches as before with no bar at all.
