### PR TITLE
feat(diag): log the version, commit, branch and build time at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+**The build identifies itself at startup.** The first line of output is now the
+version, the commit, the branch and the build time. A bug report, or a tester
+saying a fix did not work, is only worth as much as the certainty about what was
+running: an install that silently did not replace the previous one, and a build
+from the wrong branch, both look exactly like a fix that failed. It goes through
+the normal log, so it is included in the output a bug report carries. Packagers
+can set `-DWHATLY_BUILD_LABEL=" (…)"` to mark a one-off build; a normal build
+prints nothing extra.
+
 ## 7.0.0 (2026-08-03)
 
 Whatly 7.0.0 is a major feature release. Highlights: a built-in AI assistant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,12 @@ if(APPLE)
 endif()
 
 # Define compiler definitions
+# Appended to the startup line, to tell a one-off build apart from a release at a
+# glance — e.g. -DWHATLY_BUILD_LABEL=" (drag-drop test 3)" while asking someone to
+# retest something. Empty for a normal build, which then prints nothing extra.
+set(WHATLY_BUILD_LABEL "" CACHE STRING
+    "Text appended to the startup version line, to identify a test build")
+
 target_compile_definitions(whatly PRIVATE
     QAPPLICATION_CLASS=QApplication
     QT_DEPRECATED_WARNINGS
@@ -482,6 +488,7 @@ target_compile_definitions(whatly PRIVATE
     GIT_BRANCH="${GIT_BRANCH}"
     BUILD_TIMESTAMP="${BUILD_TIMESTAMP}"
     VERSIONSTR="${PROJECT_VERSION}"
+    WHATLY_BUILD_LABEL="${WHATLY_BUILD_LABEL}"
 )
 
 # Check for WebEngine spellchecker support

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -408,6 +408,19 @@ static void waitForPreviousInstance(int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
   DebugLog::install();   // before anything can log
 
+  // Which build this is, as the first thing logged. A bug report, or a tester
+  // saying a fix did not work, is only worth as much as the certainty about what
+  // was actually running: an install that did not replace the previous one, or a
+  // build from the wrong branch, otherwise looks exactly like a fix that failed.
+  // The branch is included for that second case. qWarning, not qInfo, so a
+  // release build prints it too, and it lands in the log the bug reporter sends.
+  // WHATLY_BUILD_LABEL is empty unless a build sets it, to mark a test build.
+  qWarning().noquote()
+      << QStringLiteral("whatly: starting %1 (%2 on %3, built %4)%5")
+             .arg(QLatin1String(VERSIONSTR), QLatin1String(GIT_HASH),
+                  QLatin1String(GIT_BRANCH), QLatin1String(BUILD_TIMESTAMP),
+                  QLatin1String(WHATLY_BUILD_LABEL));
+
   waitForPreviousInstance(argc, argv);
 
   // Which account this is has to be settled before anything else: it feeds the


### PR DESCRIPTION
Nothing at runtime says which build is running, and two situations look exactly like a fix that failed: an install that silently did not replace the previous build, and a build made from the wrong branch.

This is not hypothetical — it cost a full test round while working on #40. A tester reported "still didn't work" on a build that had been installed 33 minutes earlier; they had launched about half a minute before the new one finished installing. Adding this line is what caught it, and it also caught a wrong-branch build later the same day, which is why the **branch** is included and not just the commit.

So the first line of output is now:

```
whatly: starting 7.0.0 (d7a78a1 on main, built 2026-08-04 10:58:08)
```

- `qWarning`, not `qInfo`, so a release build prints it too.
- It goes through the normal message handler, so besides the terminal it lands in the `DebugLog` ring buffer — which means it is already inside the block that About → "Report a bug" fills in, and every future bug report says which build it came from without anyone having to ask.
- `WHATLY_BUILD_LABEL` is appended when a build sets it (`-DWHATLY_BUILD_LABEL=" (drag-drop test 3)"`), to mark a one-off build handed to someone for a retest. Empty by default, so a normal build prints nothing extra and release output is unchanged apart from the one line.

Three files, 31 lines added, no behaviour change. Built and run on Linux; `logic` suite passes.

One platform note, since it affects how useful this is on Windows rather than whether it works: the code is plain Qt with no platform branches, but a **release** Windows build routes `qWarning` to `OutputDebugString` rather than the console (`QT_FORCE_STDERR_LOGGING` is only set under `#ifdef QT_DEBUG` in `main.cpp`), so the line will not show up in a terminal capture there unless that variable is set. It is still captured in the ring buffer, so the bug-report path carries it on Windows regardless. Happy to force stderr logging for this one line, or leave that alone, whichever you prefer.
