### PR TITLE
packaging(flatpak): drop webenginedriver, 17 MB nobody can use

### DIFF
--- a/packaging/flathub/net.shakaran.whatly.yml
+++ b/packaging/flathub/net.shakaran.whatly.yml
@@ -40,6 +40,11 @@ finish-args:
 
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
+  # webenginedriver is the WebDriver server, for automating a browser from a test
+  # harness. Nothing in the app launches it and no user can reach it, but it is a
+  # 16 MB binary in every install. QtWebEngineProcess, beside it, is the renderer
+  # helper and must stay.
+  - rm -f /app/lib/libexec/webenginedriver
 
 modules:
   - name: whatly

--- a/packaging/flatpak/net.shakaran.whatly.yml
+++ b/packaging/flatpak/net.shakaran.whatly.yml
@@ -45,6 +45,11 @@ finish-args:
 
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
+  # webenginedriver is the WebDriver server, for automating a browser from a test
+  # harness. Nothing in the app launches it and no user can reach it, but it is a
+  # 16 MB binary in every install. QtWebEngineProcess, beside it, is the renderer
+  # helper and must stay.
+  - rm -f /app/lib/libexec/webenginedriver
 
 modules:
   - name: whatly


### PR DESCRIPTION
The QtWebEngine base app ships `webenginedriver` — the WebDriver server used to drive a browser from a test harness. Nothing in Whatly launches it, no user can reach it, and it is 16 MB (17,108,928 bytes) sitting in every install.

Measured on a local Flatpak build of v7.0.0, before and after:

| | Installed |
|---|---|
| before | 336.8 MB |
| after | **319.6 MB** |

`QtWebEngineProcess` lives in the same directory and is the renderer helper the app cannot run without, so it stays — the change names the one file rather than clearing the directory.

Done in `cleanup-commands` rather than the `cleanup` list because the file comes from the base app rather than from the module's own install; happy to switch if you prefer the other form. Applied to both the plain and the Flathub manifest, since they carry the same cleanup step.

### While measuring, for whatever it is worth

The rest of the image is mostly not reducible, but two items are worth knowing about, since neither is small:

- **spell-check dictionaries — 45 MB**, 31 languages under `share/whatly/qtwebengine_dictionaries` (`de_DE_neu` alone is 6.5 MB, `el_GR` 6.2 MB).
- **Chromium locale `.pak` files — 39 MB** under `translations/qtwebengine_locales`, one per language regardless of which the app ships.

For context, `libQt6WebEngineCore.so` is 192 MB of the total and the `whatly` binary itself is 3.6 MB, so those two are the only large tractable items left. I have not touched either here: the dictionaries interact with the spell-check language multi-select, and trimming Chromium's locales needs testing I have not done. Glad to look into either if you think they are worth pursuing — the dictionaries in particular could plausibly become downloads fetched on demand into the existing writable dictionary directory, rather than being bundled.
