### PR TITLE
feat(accounts): reopen on the account that was active at exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+**Whatly reopens on the account you were last using.** With more than one
+account, the app always started on the first tab, so anyone whose main number was
+not first had to switch accounts by hand on every launch. The active account is
+now remembered and restored. It is stored by account id rather than by position,
+so reordering the tabs does not send the next start to the wrong account, and if
+that account has since been removed the first tab is used as before.
+
 ## 7.0.0 (2026-08-03)
 
 Whatly 7.0.0 is a major feature release. Highlights: a built-in AI assistant

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -707,6 +707,15 @@ void MainWindow::setActiveAccount(int index) {
       break;
     }
   }
+  // Remember the account, so the next start reopens here instead of always
+  // falling back to the first tab. Guarded exactly like saveAccounts(): a layout
+  // restore or the quit-time collapse of detached windows both drive this
+  // function, and neither is the user choosing an account. Stored as a token
+  // when it is the default account, whose real id is the empty string.
+  if (!m_loadingLayout && !m_isQuitting)
+    SettingsManager::instance().settings().setValue(
+        QStringLiteral("accounts/active"),
+        id.isEmpty() ? QStringLiteral("__default__") : id);
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
     setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
@@ -1930,5 +1939,16 @@ void MainWindow::loadAccounts() {
   }
 
   refreshAccountTabs();
-  setActiveAccount(0);
+  // Reopen on whichever account was active when the app last closed. Falls back
+  // to the first tab when nothing is stored yet, or when that account has since
+  // been removed.
+  int active = 0;
+  const QString wantedActive = s.value(QStringLiteral("accounts/active")).toString();
+  if (!wantedActive.isEmpty()) {
+    const int found =
+        accountIndexForId(wantedActive == kDefault ? QString() : wantedActive);
+    if (found >= 0)
+      active = found;
+  }
+  setActiveAccount(active);
 }


### PR DESCRIPTION
**DRAFT — please do not merge yet.** Being dogfooded on Linux now and on Windows next; I will mark it ready once both rounds are in. Opening it early so the Windows side knows what to build.

## The problem

With more than one account, Whatly always started on the first tab. `loadAccounts()` ended in a hardcoded `setActiveAccount(0)`, and the active account was never persisted at all — there is no stored key for it. Anyone whose main number is not the first tab had to switch accounts by hand on every single launch.

## The change

The active account is recorded when it changes and restored at startup.

- **Stored by account id, not by index.** Reordering the tabs is a normal thing to do, and a stored position would send the next start to whichever account happened to land in that slot.
- **A stored id that no longer exists falls back to the first tab**, so removing the account you were last using cannot leave the app with nothing selected.
- **The default account is written as the same `__default__` token `saveAccounts()` already uses**, because its real id is the empty string, which the comment there notes Windows' registry string lists can silently truncate.
- **The write is guarded by `m_loadingLayout` and `m_isQuitting`**, for exactly the reason `saveAccounts()` is: a layout restore and the quit-time collapse of detached windows both drive `setActiveAccount()`, and neither is the user choosing an account. Without that guard, quitting would overwrite the real choice with wherever the teardown happened to land.

## Testing

`ui_assets`, `logic` and `settings` all pass, and the change is behind no new setting.

Not yet exercised by hand, which is why this is a draft: reopening on a later account after a restart, and the same after dragging the tabs into a different order. Both are in the dogfood round now running.
