### PR TITLE
perf(accounts): give an unused account no page at all, instead of a frozen one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ processes before you had looked at any of them. Measured on a four-account setup
 where three of the accounts were sitting on a QR screen doing nothing, those three
 held about 720 MB — roughly a third of the entire application. With "suspend
 inactive accounts" enabled, an account you have not opened has no page: not a
-frozen one, not an empty one, none. It is built the first time you click its tab,
-and thrown away again once you have left it alone for the configured time, so it
+frozen one, not an empty one, none. It is built the moment something needs to draw
+it — clicking its tab, switching to grid view, tearing it out into its own window
+— and thrown away again once you have left it alone for the configured time, so it
 goes back to costing nothing. Startup is also markedly quicker, because only the
 account you land on is loaded. Previously this option only froze background
 accounts, which stops their timers and scripts but keeps every byte of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Unreleased
+
+**An account you are not using now costs nothing at all.** Every account built a
+full WhatsApp Web page at startup and kept it for the whole session, so a
+four-account setup downloaded the web app four times and paid for four renderer
+processes before you had looked at any of them. Measured on a four-account setup
+where three of the accounts were sitting on a QR screen doing nothing, those three
+held about 720 MB — roughly a third of the entire application. With "suspend
+inactive accounts" enabled, an account you have not opened has no page: not a
+frozen one, not an empty one, none. It is built the first time you click its tab,
+and thrown away again once you have left it alone for the configured time, so it
+goes back to costing nothing. Startup is also markedly quicker, because only the
+account you land on is loaded. Previously this option only froze background
+accounts, which stops their timers and scripts but keeps every byte of the
+renderer, so the memory it was meant to save stayed allocated. The trade is
+unchanged and still opt-in: an account with no page cannot notify you, so with
+this off — the default — every account loads at startup exactly as before.
+
 ## 7.0.0 (2026-08-03)
 
 Whatly 7.0.0 is a major feature release. Highlights: a built-in AI assistant

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -597,8 +597,8 @@ void MainWindow::updateWindowTheme() {
     if (!account.view || account.view == m_webEngine)
       continue;
     account.view->setStyleSheet(viewStyle);
-    if (account.view->page())
-      account.view->page()->setBackgroundColor(pageBg);
+    if (pageOf(account))
+      pageOf(account)->setBackgroundColor(pageBg);
   }
 
   for (QWidget *w : findChildren<QWidget *>())
@@ -718,8 +718,8 @@ void MainWindow::initSettingWidget() {
             // and in grid view they are all on screen at once.
             WebEngineProfileManager::instance().applyUserSettings();
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(WebTweaks::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(WebTweaks::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::followSystemThemeChanged,
@@ -739,24 +739,24 @@ void MainWindow::initSettingWidget() {
           [=]() {
             CustomCss::install(WebEngineProfileManager::instance().profile());
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(CustomCss::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(CustomCss::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::focusModeChanged, m_settingsWidget,
           [=]() {
             FocusMode::install(WebEngineProfileManager::instance().profile());
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(FocusMode::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(FocusMode::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::hdMediaChanged, m_settingsWidget,
           [=]() {
             HdMedia::install(WebEngineProfileManager::instance().profile());
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(HdMedia::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(HdMedia::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::undoSendChanged, m_settingsWidget,
@@ -766,8 +766,8 @@ void MainWindow::initSettingWidget() {
             // enabling/disabling or changing the delay takes effect without a
             // reload.
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(UndoSend::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(UndoSend::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::customJsChanged, m_settingsWidget,
@@ -804,8 +804,8 @@ void MainWindow::initSettingWidget() {
           m_settingsWidget, [=]() {
             WebEngineProfileManager::instance().applyUserSettings();
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(
                     PrivacyBlur::scriptSource());
           });
 
@@ -813,8 +813,8 @@ void MainWindow::initSettingWidget() {
           m_settingsWidget, [=]() {
             WebEngineProfileManager::instance().applyUserSettings();
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(
                     ChatListStrip::scriptSource());
           });
 
@@ -822,16 +822,16 @@ void MainWindow::initSettingWidget() {
           [=]() {
             WebFont::install(WebEngineProfileManager::instance().profile());
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(WebFont::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(WebFont::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::mutedStatusChanged,
           m_settingsWidget, [=]() {
             MutedStatus::install(WebEngineProfileManager::instance().profile());
             for (const Account &account : m_accounts)
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(MutedStatus::scriptSource());
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(MutedStatus::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::spellCheckChanged, m_settingsWidget,
@@ -847,8 +847,8 @@ void MainWindow::initSettingWidget() {
             // existing page). Each account keeps its own label.
             WebEngineProfileManager::instance().applyUserSettings();
             for (const Account &account : m_accounts) {
-              if (account.view && account.view->page())
-                account.view->page()->runJavaScript(
+              if (pageOf(account))
+                pageOf(account)->runJavaScript(
                     LinkedDeviceName::scriptSource(account.name.isEmpty() ||
                                                            account.id.isEmpty()
                                                        ? QString()
@@ -1348,8 +1348,8 @@ void MainWindow::togglePrivacyBlur() {
   // grid view they are all on screen at once. See toggleChatListStrip().
   WebEngineProfileManager::instance().applyUserSettings();
   for (const Account &account : m_accounts)
-    if (account.view && account.view->page())
-      account.view->page()->runJavaScript(PrivacyBlur::scriptSource());
+    if (pageOf(account))
+      pageOf(account)->runJavaScript(PrivacyBlur::scriptSource());
   if (m_settingsWidget)
     m_settingsWidget->refresh();   // keep the combo box telling the truth
 }
@@ -1376,8 +1376,8 @@ void MainWindow::toggleChatListStrip() {
   // a profile's script changes to them.
   WebEngineProfileManager::instance().applyUserSettings();
   for (const Account &account : m_accounts)
-    if (account.view && account.view->page())
-      account.view->page()->runJavaScript(ChatListStrip::scriptSource());
+    if (pageOf(account))
+      pageOf(account)->runJavaScript(ChatListStrip::scriptSource());
   refreshChatListStripAction();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -151,6 +151,10 @@ private:
     QString waVersion;
     // When this account was last the active/visible one; drives idle suspension.
     QDateTime lastActive;
+    // Whether this account currently has a page. A dormant account has none at
+    // all: not a frozen one, not an empty one. It gets a page the first time it
+    // is opened, and loses it again once it has been idle long enough.
+    bool loaded = false;
     // Non-null while the account has been torn off into its own window; its
     // view then lives in that window rather than in the tab stack/grid.
     QPointer<DetachedAccountWindow> window = nullptr;
@@ -167,6 +171,14 @@ private:
   void clearGridCells();
   void updateGridCaptions();
   WebView *addAccount(const QString &id, const QString &name, bool load);
+  // The account's live page, or nullptr while it is dormant. Everything that
+  // walks the account list must go through this rather than view->page():
+  // QWebEngineView hands out a page on demand, so asking a dormant account for
+  // one would build it — on the default profile, and defeating the point.
+  static QWebEnginePage *pageOf(const Account &a);
+  // Throw an idle account's page away, back to the dormant state it started in.
+  // Reopening the account builds it again from scratch.
+  void unloadAccount(int index);
   void setActiveAccount(int index);
   void promptAddAccount();
   void renameAccount(int index);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -179,6 +179,11 @@ private:
   // Throw an idle account's page away, back to the dormant state it started in.
   // Reopening the account builds it again from scratch.
   void unloadAccount(int index);
+  // Build a dormant account's page because it is about to be shown. Every path
+  // that puts an account on screen has to call this, not just the tab switch in
+  // the main window — a detached window shows its own account without going
+  // anywhere near setActiveAccount().
+  void ensureAccountLoaded(int index);
   void setActiveAccount(int index);
   void promptAddAccount();
   void renameAccount(int index);

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -692,10 +692,12 @@ void MainWindow::setActiveAccount(int index) {
   m_activeAccount = index;
   m_webEngine = m_accounts[index].view;   // everything current-account flows through this
   m_accounts[index].lastActive = QDateTime::currentDateTime();
-  // Wake the account we are switching to (no-op if it was never suspended).
-  if (m_accounts[index].view && m_accounts[index].view->page())
-    m_accounts[index].view->page()->setLifecycleState(
-        QWebEnginePage::LifecycleState::Active);
+  // Opening a dormant account is when it comes into existence: build its page
+  // now, exactly as if the app had just started on it. This is the whole point of
+  // the dormant state — a tab the user has not asked for costs nothing until they
+  // click it, and one they stopped using goes back to costing nothing.
+  if (!m_accounts[index].loaded && m_accounts[index].view)
+    createPageFor(m_accounts[index].view, m_accounts[index].id);
   m_accountStack->setCurrentWidget(m_accounts[index].view);
   // Point the strip at the tab carrying this account's id.
   QSignalBlocker block(m_accountBar);
@@ -853,10 +855,12 @@ void MainWindow::reorderWindowFromStrip(DetachedAccountWindow *win) {
 }
 
 void MainWindow::captureAccountVersion(WebView *view) {
-  if (!view || !view->page())
+  const int idx = view ? accountIndexForView(view) : -1;
+  QWebEnginePage *page = idx >= 0 ? pageOf(m_accounts[idx]) : nullptr;
+  if (!page)
     return;
   QPointer<WebView> guarded(view);
-  view->page()->runJavaScript(
+  page->runJavaScript(
       QStringLiteral("(window.Debug && window.Debug.VERSION) || ''"),
       [this, guarded](const QVariant &result) {
         if (!guarded)
@@ -872,29 +876,48 @@ void MainWindow::captureAccountVersion(WebView *view) {
       });
 }
 
+QWebEnginePage *MainWindow::pageOf(const Account &a) {
+  // Deliberately does not fall back to a.view->page(): QWebEngineView builds a
+  // page on demand when asked for one it does not have, so a single stray call
+  // on a dormant account would silently create a renderer bound to the default
+  // profile — the opposite of what dormancy is for, and a session mix-up.
+  return a.loaded && a.view ? a.view->page() : nullptr;
+}
+
+void MainWindow::unloadAccount(int index) {
+  if (index < 0 || index >= m_accounts.size())
+    return;
+  Account &a = m_accounts[index];
+  if (!a.loaded || !a.view)
+    return;
+  QWebEnginePage *page = a.view->page();
+  // Cleared before the page goes, so anything reached during teardown sees a
+  // dormant account and cannot ask for the page being destroyed.
+  a.loaded = false;
+  // Detach first, then delete: the view holds a plain pointer to its page, and
+  // deleting it without detaching would leave that pointer dangling for the next
+  // caller. Detaching also drops the renderer, which is the memory we are after —
+  // freezing the page would have kept every byte of it.
+  a.view->setPage(nullptr);
+  delete page;
+}
+
 void MainWindow::suspendIdleAccounts() {
   const bool enabled = Performance::suspendInactiveAccounts();
   const int threshold = Performance::suspendAfterMinutes() * 60;
   const QDateTime now = QDateTime::currentDateTime();
   for (int i = 0; i < m_accounts.size(); ++i) {
     Account &a = m_accounts[i];
-    if (!a.view || !a.view->page())
-      continue;
+    if (!a.view || !a.loaded)
+      continue; // already dormant, nothing left to give back
     const bool isActive = (i == m_activeAccount);
     const bool isVisible = a.view->isVisible(); // grid tiles / detached windows
     const int idle = a.lastActive.isValid()
                          ? int(a.lastActive.secsTo(now))
                          : 0;
-    auto *page = a.view->page();
     if (Performance::shouldSuspendAccount(enabled, isActive, isVisible, idle,
-                                          threshold)) {
-      if (page->lifecycleState() == QWebEnginePage::LifecycleState::Active)
-        page->setLifecycleState(QWebEnginePage::LifecycleState::Frozen);
-    } else if (!enabled &&
-               page->lifecycleState() != QWebEnginePage::LifecycleState::Active) {
-      // Feature turned off: wake anything we had frozen.
-      page->setLifecycleState(QWebEnginePage::LifecycleState::Active);
-    }
+                                          threshold))
+      unloadAccount(i);
   }
 }
 
@@ -945,8 +968,8 @@ void MainWindow::openChatByName(const QString &accountId, const QString &name) {
 
 QString MainWindow::accountTabTooltip(const Account &acc) const {
   QString token;
-  if (acc.view && acc.view->page())
-    token = QUrlQuery(acc.view->page()->url()).queryItemValue(QStringLiteral("v"));
+  if (pageOf(acc))
+    token = QUrlQuery(pageOf(acc)->url()).queryItemValue(QStringLiteral("v"));
   return accountTabTooltipText(acc.waVersion, token);
 }
 
@@ -1912,20 +1935,27 @@ void MainWindow::loadAccounts() {
       s.value(QStringLiteral("accounts/names")).toStringList();
   const QString kDefault = QStringLiteral("__default__");
 
+  // With winding down enabled, accounts start dormant — no page, no renderer, no
+  // download — and the one that ends up active is built by setActiveAccount()
+  // below. The rest come into existence when the user first clicks them, which is
+  // the same bargain the setting already makes for accounts that go idle later.
+  // Off (the default), every account is built at startup exactly as before.
+  const bool load = !Performance::suspendInactiveAccounts();
+
   if (ids.isEmpty()) {
     // Fresh install: just the default account.
-    addAccount(QString(), tr("Account 1"), true);
+    addAccount(QString(), tr("Account 1"), load);
   } else if (!ids.contains(kDefault)) {
     // Legacy save (before order-with-default): default implicit and first, then
     // the saved non-default accounts in order.
-    addAccount(QString(), tr("Account 1"), true);
+    addAccount(QString(), tr("Account 1"), load);
     for (int i = 0; i < ids.size(); ++i)
-      addAccount(ids[i], names.value(i, tr("Account %1").arg(i + 2)), true);
+      addAccount(ids[i], names.value(i, tr("Account %1").arg(i + 2)), load);
   } else {
     // Recreate the saved order exactly, including where the default sits.
     for (int i = 0; i < ids.size(); ++i) {
       const QString id = (ids[i] == kDefault) ? QString() : ids[i];
-      addAccount(id, names.value(i, tr("Account %1").arg(i + 1)), true);
+      addAccount(id, names.value(i, tr("Account %1").arg(i + 1)), load);
     }
   }
 

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -454,6 +454,17 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event) {
   if (m_gridScroll && watched == m_gridScroll->viewport() &&
       event->type() == QEvent::Resize)
     syncGridContainerSize();
+  // About to be drawn is the real trigger for building a dormant account, and it
+  // is the only one that catches every case. Switching tabs is not enough: a
+  // detached window shows its own account without touching setActiveAccount(),
+  // and grid mode draws every account at once, so both would otherwise paint a
+  // blank view. Hooking the view's own visibility covers all of them, including
+  // any future path that puts an account on screen.
+  if (event->type() == QEvent::Show) {
+    const int idx = accountIndexForView(watched);
+    if (idx >= 0)
+      ensureAccountLoaded(idx);
+  }
   return QMainWindow::eventFilter(watched, event);
 }
 
@@ -662,6 +673,9 @@ WebView *MainWindow::addAccount(const QString &id, const QString &name,
       {m_translateSelectionAction},
       {m_aiSummarizeAction, m_exportChatAction});
 
+  // Watched so that whatever eventually puts this view on screen — a tab switch,
+  // grid mode, a detached window — builds the account first. See eventFilter().
+  view->installEventFilter(this);
   m_accountStack->addWidget(view);
   m_accounts.append({id, name, view, 0});
   m_accounts.last().lastActive = QDateTime::currentDateTime();
@@ -692,12 +706,8 @@ void MainWindow::setActiveAccount(int index) {
   m_activeAccount = index;
   m_webEngine = m_accounts[index].view;   // everything current-account flows through this
   m_accounts[index].lastActive = QDateTime::currentDateTime();
-  // Opening a dormant account is when it comes into existence: build its page
-  // now, exactly as if the app had just started on it. This is the whole point of
-  // the dormant state — a tab the user has not asked for costs nothing until they
-  // click it, and one they stopped using goes back to costing nothing.
-  if (!m_accounts[index].loaded && m_accounts[index].view)
-    createPageFor(m_accounts[index].view, m_accounts[index].id);
+  // Opening a dormant account is when it comes into existence.
+  ensureAccountLoaded(index);
   m_accountStack->setCurrentWidget(m_accounts[index].view);
   // Point the strip at the tab carrying this account's id.
   QSignalBlocker block(m_accountBar);
@@ -882,6 +892,19 @@ QWebEnginePage *MainWindow::pageOf(const Account &a) {
   // on a dormant account would silently create a renderer bound to the default
   // profile — the opposite of what dormancy is for, and a session mix-up.
   return a.loaded && a.view ? a.view->page() : nullptr;
+}
+
+void MainWindow::ensureAccountLoaded(int index) {
+  if (index < 0 || index >= m_accounts.size())
+    return;
+  Account &a = m_accounts[index];
+  if (a.loaded || !a.view)
+    return;
+  // Marked before building, not after. createPageFor() attaches a page to the
+  // view, and that can emit a show event, which comes straight back here through
+  // eventFilter() — with the flag set afterwards, that would recurse forever.
+  a.loaded = true;
+  createPageFor(a.view, a.id);
 }
 
 void MainWindow::unloadAccount(int index) {

--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -149,7 +149,14 @@ void MainWindow::createPageFor(WebView *view, const QString &accountId) {
                              .settings()
                              .value("zoomFactor", 1.0)
                              .toDouble();
-  view->page()->setZoomFactor(currentFactor);
+  page->setZoomFactor(currentFactor);
+
+  // The account now has a page, so everything that walks the account list may
+  // reach it. Recorded here rather than at each call site, because this is the
+  // only place a page is ever built.
+  const int idx = accountIndexForView(view);
+  if (idx >= 0)
+    m_accounts[idx].loaded = true;
 }
 
 // Buttons Whatly injects into WhatsApp's own UI need a way back into the app.
@@ -1319,8 +1326,8 @@ void MainWindow::toggleMute(const bool &checked) {
   // Mute every account, not just the visible one — a background account's call
   // tone or notification sound should go quiet too.
   for (const Account &account : m_accounts)
-    if (account.view && account.view->page())
-      account.view->page()->setAudioMuted(checked);
+    if (pageOf(account))
+      pageOf(account)->setAudioMuted(checked);
 
   SettingsManager::instance().settings().setValue("muteAudio", checked);
   // Keep the tray action and the Settings checkbox showing the same state,


### PR DESCRIPTION
**DRAFT — please do not merge yet.** This is being dogfooded on Linux now and on Windows next; I will mark it ready once both rounds are in. Opening it early so the Windows side knows what to build.

## The measurement

On a four-account setup, three of the accounts sitting on a QR screen doing nothing:

```
whatly process tree                    2,283.7 MB
  active account renderer                763.5 MB
  browser process                        454.5 MB
  QR-screen account renderer             235.5 MB
  QR-screen account renderer             237.6 MB
  QR-screen account renderer             245.5 MB
```

Those three idle renderers are about **720 MB, roughly a third of the whole application**, for tabs displaying a QR code. Instrumentation on the same session measured them at ~165 calls into WhatsApp's A/B property lookup against ~400,000 for the active account, so they really are inert — they are not doing work, they are just resident.

## Why the existing option did not fix this

`suspendInactiveAccounts` freezes background accounts with `LifecycleState::Frozen`. Freezing stops the page's timers and script execution, which does save CPU — but the renderer process stays alive and its memory stays allocated. Only `Discarded` releases it. The declaration's own comment says the feature exists "to cut memory with multiple accounts", so it did not do the one thing it promised.

## What this changes

An account is now either **loaded** or **dormant**, and dormant means it has no page: not a frozen one, not an empty one, none at all.

- **At startup**, only the account you land on is built. `addAccount()` already took a `load` flag, but all five call sites passed `true`, so that path had never run.
- **On first click**, `setActiveAccount()` builds the page, exactly as if the app had started on that account.
- **On going idle**, `suspendIdleAccounts()` destroys the page again, returning the account to the same state it starts in.

Startup also gets noticeably quicker, since a cold cache no longer means downloading WhatsApp Web once per account simultaneously.

## The part that needed more than a flag

`QWebEngineView` builds a page on demand when asked for one it does not have. That means the existing `if (account.view && account.view->page())` checks in the settings-apply loops were not the guards they appear to be — the first one to run against a dormant account would have created a page **bound to the default profile**, which both defeats the point and mixes sessions.

Every walk over the account list now goes through `pageOf(const Account &)`, which returns `nullptr` for a dormant account and never asks the view for a page. Teardown detaches with `setPage(nullptr)` before deleting, because the view holds a plain pointer to its page and deleting without detaching would leave it dangling.

## The trade-off, deliberately unchanged

An account with no page cannot notify you. That is the same bargain this option already stated, which is why the new behaviour follows the existing setting rather than adding one, and why **with the option off — the default — every account loads at startup exactly as before**. No new settings, and the existing threshold is untouched.

## Testing

`ui_assets`, `logic` and `settings` all pass. The existing `shouldSuspendAccount` unit tests are unchanged and still cover the decision, since the gate itself did not change — only what happens when it fires.

Still to be confirmed by dogfooding, and the reason this is a draft: that teardown and rebuild are clean in practice across grid view, detached windows and the tray's recent-unread list.
