### PR TITLE
feat(window): resize the custom frame from every edge and corner, and give detached windows the same frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ performance, so the section is simply called that. **Interface scale** has also
 moved from "Network & Startup", where it sat beside the autostart checkbox, to
 **Window & zoom** beside the other zoom controls. No setting changed its meaning and
 nothing was renamed; they are only in sensible places now.
+**The custom window frame can be resized from any edge or corner, and detached
+windows get the same frame.** With the custom frame on, the only way to resize was
+a single grip in the bottom-right corner — one of the eight places a normal window
+can be grabbed — because dropping the native decoration drops the native resize
+border with it. All four edges and all four corners now work, with the right cursor
+on each, and the drag is handed to the window manager so it behaves exactly as a
+normal window's does. Detached account windows now wear the custom frame too rather
+than being the one window left with the system's, which is why they needed the
+resize borders first. They also gain the trailing "+" tab the main strip has, and
+an account added from a detached window's "+" now appears in that window instead of
+jumping to the main one.
 
 ## 7.0.0 (2026-08-03)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ set(SOURCES
     src/scheduledmessages.cpp
     src/scheduledmessagesdialog.cpp
     src/webtweaks.cpp
+    src/windowresizer.cpp
     src/webview.cpp
     src/widgets/elidedlabel/elidedlabel.cpp
     src/widgets/scrolltext/scrolltext.cpp
@@ -325,6 +326,7 @@ set(HEADERS
     src/scheduledmessagesdialog.h
     src/pagebridge.h
     src/webtweaks.h
+    src/windowresizer.h
     src/webview.h
     src/webenginenotifproxy.h
     src/widgets/elidedlabel/elidedlabel.h

--- a/src/detachedaccountwindow.cpp
+++ b/src/detachedaccountwindow.cpp
@@ -1,11 +1,14 @@
 #include "detachedaccountwindow.h"
 #include "accounttabbar.h"
+#include "customtitlebar.h"
+#include "windowresizer.h"
 
 #include <QCloseEvent>
 #include <QEvent>
 #include <QIcon>
 #include <QMoveEvent>
 #include <QResizeEvent>
+#include <QHBoxLayout>
 #include <QStackedWidget>
 #include <QVBoxLayout>
 
@@ -17,9 +20,27 @@ DetachedAccountWindow::DetachedAccountWindow(QWidget *parent) : QWidget(parent) 
   setWindowIcon(QIcon(QStringLiteral(":/icons/app/icon-64.png")));
   resize(900, 700);
 
+  // Same client-side decoration as the main window, for the same reason: a
+  // detached account is a peer of it, not a lesser window, so with the custom
+  // frame on it should not be the one thing still wearing the system's.
+  const bool frameless = CustomTitleBar::isEnabled();
+  if (frameless)
+    setWindowFlag(Qt::FramelessWindowHint, true);
+
   auto *layout = new QVBoxLayout(this);
-  layout->setContentsMargins(0, 0, 0, 0);
+  // The margin is the resize border, and it exists only in frameless mode —
+  // dropping the native frame is what takes the native resize edges with it.
+  if (frameless)
+    layout->setContentsMargins(WindowResizer::kBorder, WindowResizer::kBorder,
+                               WindowResizer::kBorder, WindowResizer::kBorder);
+  else
+    layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
+
+  // A standalone bar only when the tabs are not sharing the row; otherwise the
+  // window buttons ride at the end of the strip, below.
+  if (frameless && !CustomTitleBar::tabsInTitleBar())
+    layout->addWidget(new CustomTitleBar(this, this));
 
   // Its own tab strip — a first-class peer of the main window. It accepts
   // dropped tabs, so accounts can be dragged into this window from others.
@@ -30,10 +51,27 @@ DetachedAccountWindow::DetachedAccountWindow(QWidget *parent) : QWidget(parent) 
   m_bar->setFocusPolicy(Qt::NoFocus);
   m_bar->setAcceptDrops(true);
   m_bar->setContextMenuPolicy(Qt::CustomContextMenu); // MainWindow builds the menu
-  layout->addWidget(m_bar);
+  if (frameless && CustomTitleBar::tabsInTitleBar()) {
+    // Chrome-style, mirroring the main window: the strip is the title bar, with
+    // the window buttons at its right-hand end.
+    auto *titleRow = new QHBoxLayout;
+    titleRow->setContentsMargins(0, 0, 0, 0);
+    titleRow->setSpacing(0);
+    titleRow->addWidget(m_bar, 0);
+    titleRow->addWidget(
+        new CustomTitleBar(this, this, CustomTitleBar::Mode::Merged), 1);
+    layout->addLayout(titleRow);
+  } else {
+    layout->addWidget(m_bar);
+  }
 
   m_stack = new QStackedWidget(this);
   layout->addWidget(m_stack, 1);
+
+  // All eight resize regions, since dropping the native frame dropped the
+  // native ones. Installed last, so the border margin is already in place.
+  if (frameless)
+    WindowResizer::install(this, this);
 }
 
 void DetachedAccountWindow::closeEvent(QCloseEvent *event) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -212,7 +212,10 @@ private:
   // anywhere near setActiveAccount().
   void ensureAccountLoaded(int index);
   void setActiveAccount(int index);
-  void promptAddAccount();
+  // `target` is the detached window whose "+" was clicked, so the new account
+  // lands where it was asked for. Null means the main strip, which falls back to
+  // the focused window for the tray and palette paths.
+  void promptAddAccount(DetachedAccountWindow *target = nullptr);
   void renameAccount(int index);
   void removeAccount(int index);
   // Tear an account off into its own top-level window. An account's `window`

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -17,7 +17,6 @@
 #include <QVBoxLayout>
 #include <QGridLayout>
 #include <QHBoxLayout>
-#include <QSizeGrip>
 #include <QLabel>
 #include <QScreen>
 #include <QScrollArea>
@@ -28,6 +27,7 @@
 
 #include "settingsmanager.h"
 #include "customtitlebar.h"
+#include "windowresizer.h"
 #include "commandpalette.h"
 #include "cannedresponses.h"
 
@@ -221,14 +221,15 @@ void MainWindow::buildAccountArea() {
   }
   layout->addWidget(m_displayStack);
 
-  // In frameless mode there is no native resize edge, so give the window a
-  // corner size grip to drag.
+  // In frameless mode there is no native resize edge. This used to be a single
+  // QSizeGrip in the bottom-right corner — one grab region out of the eight a
+  // normal window has. WindowResizer restores all eight; the margin below is the
+  // border strip it watches, and it has to belong to `central` rather than to any
+  // child, or the web view would swallow the mouse events.
   if (CustomTitleBar::isEnabled()) {
-    auto *gripRow = new QHBoxLayout;
-    gripRow->setContentsMargins(0, 0, 0, 0);
-    gripRow->addStretch();
-    gripRow->addWidget(new QSizeGrip(central), 0, Qt::AlignBottom | Qt::AlignRight);
-    layout->addLayout(gripRow);
+    layout->setContentsMargins(WindowResizer::kBorder, WindowResizer::kBorder,
+                               WindowResizer::kBorder, WindowResizer::kBorder);
+    WindowResizer::install(central, this);
   }
 
   setCentralWidget(central);
@@ -1222,10 +1223,14 @@ void MainWindow::updateLauncherBadge(int count) {
 #endif
 }
 
-void MainWindow::promptAddAccount() {
-  // Put the strip back on the active account: the click landed on "+", which is
-  // not a real page.
-  setActiveAccount(m_activeAccount);
+void MainWindow::promptAddAccount(DetachedAccountWindow *target) {
+  // Put the strip that was clicked back onto a real account: the click landed on
+  // "+", which is not a page, and it must not be left selected if the dialog is
+  // cancelled.
+  if (target)
+    refreshDetachedStrips();
+  else
+    setActiveAccount(m_activeAccount);
 
   bool ok = false;
   const QString name =
@@ -1240,10 +1245,12 @@ void MainWindow::promptAddAccount() {
   const QString id = Utils::generateRandomId(8);
   addAccount(id, name.trimmed(), true);
   saveAccounts();
-  // The new account joins the focused ("main") window — which may be a detached
-  // window if that is where the user was last working.
+  // The new account joins the window it was asked for. An explicit target is the
+  // strip whose "+" was clicked; without one, fall back to the focused window,
+  // which is what the tray action and the command palette go through.
   DetachedAccountWindow *focused =
-      m_focusOrder.isEmpty() ? nullptr : m_focusOrder.first();
+      target ? target
+             : (m_focusOrder.isEmpty() ? nullptr : m_focusOrder.first());
   if (focused) {
     moveAccountToWindow(id, focused, 1 << 20); // append into that window
   } else {
@@ -1334,8 +1341,10 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     if (t < 0)
       return;
     const QVariant d = win->bar()->tabData(t);
-    if (!d.isValid())
+    if (!d.isValid()) { // the "+" affordance, same as on the main strip
+      promptAddAccount(win);
       return;
+    }
     const int idx = accountIndexForId(d.toString());
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
@@ -1752,9 +1761,13 @@ void MainWindow::refreshDetachedStrips() {
     for (int i = 0; i < m_accounts.size(); ++i)
       if (m_accounts[i].window == win)
         members.append(i);
-    while (bar->count() > members.size())
+    // Mirror the main strip: one tab per member plus a trailing "+", so adding
+    // an account is reachable from a detached window too rather than only from
+    // the main one.
+    const int wanted = members.size() + 1;
+    while (bar->count() > wanted)
       bar->removeTab(bar->count() - 1);
-    while (bar->count() < members.size())
+    while (bar->count() < wanted)
       bar->addTab(QString());
     QWidget *current = win->stack()->currentWidget();
     int activeTab = 0;
@@ -1769,6 +1782,10 @@ void MainWindow::refreshDetachedStrips() {
       if (m_accounts[i].view == current)
         activeTab = t;
     }
+    const int plus = members.size();
+    bar->setTabText(plus, QStringLiteral("  +  "));
+    bar->setTabData(plus, QVariant()); // no data marks the "+" tab
+    bar->setTabToolTip(plus, tr("Add another account"));
     if (!members.isEmpty()) {
       bar->setCurrentIndex(activeTab);
       const int i = members[qBound(0, activeTab, members.size() - 1)];

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -230,8 +230,12 @@ void MainWindow::createActions() {
   // A visible way to add another account (the "+" tab only shows once the
   // account strip is up); mirrors the command palette's "Add account…".
   m_addAccountAction = new QAction(tr("Add account…"), this);
+  // Through a lambda rather than a direct member pointer: promptAddAccount takes
+  // an optional target window, and triggered(bool) cannot bind past a default
+  // argument. No target here means "the focused window", which is what this
+  // action wants anyway.
   connect(m_addAccountAction, &QAction::triggered, this,
-          &MainWindow::promptAddAccount);
+          [this]() { promptAddAccount(); });
   addAction(m_addAccountAction);
 
   m_commandPaletteAction = new QAction(tr("Command palette"), this);

--- a/src/windowresizer.cpp
+++ b/src/windowresizer.cpp
@@ -1,0 +1,95 @@
+#include "windowresizer.h"
+
+#include <QEvent>
+#include <QMouseEvent>
+#include <QWidget>
+#include <QWindow>
+
+namespace {
+
+// The cursor that says what a drag from here would do.
+Qt::CursorShape cursorFor(Qt::Edges edges) {
+  const bool left = edges.testFlag(Qt::LeftEdge);
+  const bool right = edges.testFlag(Qt::RightEdge);
+  const bool top = edges.testFlag(Qt::TopEdge);
+  const bool bottom = edges.testFlag(Qt::BottomEdge);
+  if ((left && top) || (right && bottom))
+    return Qt::SizeFDiagCursor;
+  if ((right && top) || (left && bottom))
+    return Qt::SizeBDiagCursor;
+  if (left || right)
+    return Qt::SizeHorCursor;
+  if (top || bottom)
+    return Qt::SizeVerCursor;
+  return Qt::ArrowCursor;
+}
+
+} // namespace
+
+WindowResizer::WindowResizer(QWidget *frame, QWidget *window)
+    : QObject(frame), m_frame(frame), m_window(window) {}
+
+void WindowResizer::install(QWidget *frame, QWidget *window) {
+  if (!frame || !window)
+    return;
+  auto *resizer = new WindowResizer(frame, window);
+  // Mouse tracking so the cursor changes on the way in, without a button held.
+  frame->setMouseTracking(true);
+  frame->installEventFilter(resizer);
+}
+
+Qt::Edges WindowResizer::edgesAt(const QPoint &pos) const {
+  Qt::Edges edges;
+  if (!m_frame)
+    return edges;
+  const QRect r = m_frame->rect();
+  if (pos.x() <= r.left() + kBorder)
+    edges |= Qt::LeftEdge;
+  else if (pos.x() >= r.right() - kBorder)
+    edges |= Qt::RightEdge;
+  if (pos.y() <= r.top() + kBorder)
+    edges |= Qt::TopEdge;
+  else if (pos.y() >= r.bottom() - kBorder)
+    edges |= Qt::BottomEdge;
+  return edges;
+}
+
+bool WindowResizer::eventFilter(QObject *watched, QEvent *event) {
+  if (watched != m_frame || !m_window)
+    return QObject::eventFilter(watched, event);
+
+  switch (event->type()) {
+  case QEvent::MouseMove: {
+    auto *me = static_cast<QMouseEvent *>(event);
+    // Only while no button is down: during a drag the compositor owns the
+    // pointer, and re-reading the position here would fight it.
+    if (me->buttons() == Qt::NoButton)
+      m_frame->setCursor(cursorFor(edgesAt(me->position().toPoint())));
+    break;
+  }
+  case QEvent::Leave:
+    m_frame->unsetCursor();
+    break;
+  case QEvent::MouseButtonPress: {
+    auto *me = static_cast<QMouseEvent *>(event);
+    if (me->button() != Qt::LeftButton)
+      break;
+    const Qt::Edges edges = edgesAt(me->position().toPoint());
+    if (!edges)
+      break;
+    QWindow *handle = m_window->windowHandle();
+    if (!handle)
+      break;
+    // Maximized windows are not resizable by dragging an edge, and asking the
+    // compositor to try leaves the pointer grabbed with nothing happening.
+    if (m_window->isMaximized() || m_window->isFullScreen())
+      break;
+    if (handle->startSystemResize(edges))
+      return true; // the window manager has the drag; do not also deliver it
+    break;
+  }
+  default:
+    break;
+  }
+  return QObject::eventFilter(watched, event);
+}

--- a/src/windowresizer.h
+++ b/src/windowresizer.h
@@ -1,0 +1,51 @@
+#ifndef WINDOWRESIZER_H
+#define WINDOWRESIZER_H
+
+#include <QObject>
+#include <Qt>
+
+class QWidget;
+
+// Gives a frameless top-level window the eight resize grab regions a normal
+// window has: four edges and four corners.
+//
+// A frameless window has no native resize border, and Qt's answer in the
+// codebase so far was a single QSizeGrip in the bottom-right corner — one corner
+// out of eight. This restores the rest.
+//
+// The mechanism is QWindow::startSystemResize(), which hands the drag straight to
+// the window manager. That matters: the resize then feels exactly like a normal
+// window's on X11, Wayland and Windows alike, with the compositor doing the
+// tracking, rather than us following the mouse and fighting it.
+//
+// The catch it has to work around is that the grab region needs mouse events, and
+// a window whose child widgets cover every pixel never sees one — the web view
+// swallows them. So the border is a real margin on the frame widget's layout,
+// belonging to the frame itself rather than to any child, and that is the strip
+// watched here.
+class WindowResizer : public QObject {
+  Q_OBJECT
+public:
+  // Width of the grab border, in device-independent pixels. Wide enough to hit
+  // without aiming, narrow enough not to look like a frame.
+  static constexpr int kBorder = 5;
+
+  // Watch `frame` and resize its top-level `window`. `frame` must carry a
+  // contents margin of at least kBorder on the sides that should be grabbable,
+  // or there will be no strip to hit. Takes ownership via the QObject tree.
+  static void install(QWidget *frame, QWidget *window);
+
+protected:
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+  WindowResizer(QWidget *frame, QWidget *window);
+  // Which edges the point is on, as a set: two bits for a corner, one for an
+  // edge, none for anywhere else.
+  Qt::Edges edgesAt(const QPoint &pos) const;
+
+  QWidget *m_frame = nullptr;
+  QWidget *m_window = nullptr;
+};
+
+#endif // WINDOWRESIZER_H


### PR DESCRIPTION
**Out of draft — good to merge.** It was opened early as a draft so the Windows side knew what to build; it has since been through hand testing on Linux and on Windows, and the results are at the bottom.

Three changes to the window chrome, deliberately in one PR because they are coupled through frameless mode: giving detached windows a custom title bar is exactly what removes their native resize edges, so shipping that without all-sides resize would make them *harder* to resize than they are today.

## Resize from every edge and corner

With the custom frame on, `buildAccountArea()` added a single `QSizeGrip` in the bottom-right corner, with the comment that a frameless window has no native resize edge. That is one grab region out of the eight a normal window has.

`WindowResizer` restores the rest. It hit-tests a border strip and calls `QWindow::startSystemResize()`, which hands the drag to the window manager — so the resize is tracked by the compositor and behaves natively on X11, Wayland and Windows, rather than us following the mouse and fighting it. Each of the eight regions gets its proper cursor.

Two details worth knowing, because both are easy to get wrong:

- **The border has to be a contents margin on the frame widget, not a hit test on the window.** A window whose children cover every pixel never sees the mouse events — the web view takes them. So the margin exists only in frameless mode, and it belongs to the frame rather than to any child.
- **Maximized and fullscreen are skipped.** The compositor cannot resize those by dragging an edge, and asking it to leaves the pointer grabbed with nothing happening.

## Detached windows get the custom frame

A detached account is a peer of the main window, so with the custom frame enabled it should not be the one window still wearing the system's decoration. It picks up the same `CustomTitleBar`, in merged mode when the tabs share the title row, and the same eight resize regions.

## A detached strip gets the trailing "+"

`refreshDetachedStrips()` built exactly one tab per member, so adding an account was only reachable from the main window. It now mirrors the main strip, and the strip's `currentChanged` handler calls the same prompt rather than returning early on a tab with no data.

**An account added from a detached "+" now lands in that window.** `promptAddAccount()` already routed new accounts to the focused window; it now takes an explicit target so the window whose "+" was clicked is used directly, instead of depending on focus having followed the click. The tray connection goes through a lambda, because `triggered(bool)` cannot bind past a default argument.

## Testing

Builds clean; `ui_assets`, `logic` and `settings` all pass. Everything here is behind the existing custom-frame setting, which is off by default, so a default install is untouched.

### Exercised by hand, all three configurations

The three things that were open when this was a draft have all been checked, on Linux and again on Windows. Because the change is behind a setting that not everyone has on, all three frame configurations were tested rather than only the one being used day to day:

- **Custom frame + tabs in the title row.** All four edges and all four corners resize, on the main window and on a detached one, with the correct cursor on each; a maximized window ignores an edge drag, which is what should happen; the detached window carries the custom title bar.
- **Custom frame, tabs below it.** Both windows get a proper title row above the tab strip, nothing overlaps or is cut off, and all eight regions still work.
- **Custom frame off — the default, and the one to protect.** Normal system title bar, system resize, and no trace of the change: no 5px border and no leftover size grip.
- **The detached "+"** opens the Add-account dialog, the new account appears in that window rather than the main one, cancelling leaves the strip on a real account, and the main window's "+" is unaffected.

One visible consequence worth stating plainly: in frameless mode the content is inset by 5px on all four sides, because the border has to belong to the frame rather than to a child. It was looked at and is fine, but it is a change a user can see.

One thing this PR did *not* fix, found while testing it: adding an account from the tray or the command palette still landed in the main window rather than the window in front. That was the wider "one window is the main one" assumption rather than anything in this diff, and it is fixed in #55 ("stop treating one window as the main one"), which is already merged.
