### PR TITLE
feat(chatlist): show unread counts on the collapsed strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ performance, so the section is simply called that. **Interface scale** has also
 moved from "Network & Startup", where it sat beside the autostart checkbox, to
 **Window & zoom** beside the other zoom controls. No setting changed its meaning and
 nothing was renamed; they are only in sensible places now.
+**The collapsed chat list shows unread counts again.** Collapsing the list to a
+strip of avatars cut WhatsApp's own unread badge off the right-hand edge, so the one
+thing the narrow list most needs to tell you — which conversations are waiting — was
+only visible by hovering each row in turn. Each collapsed row now carries a small
+green count in its top-right corner, and no badge at all when there is nothing
+unread. The number is WhatsApp's own, read from the row rather than tracked
+separately, so it cannot drift out of step, and it is drawn without adding anything
+to the page.
 
 ## 7.0.0 (2026-08-03)
 

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -68,16 +68,28 @@ static const char kCollapseCss[] =
     // the one thing the collapsed list most needs to tell you. Redrawn as a pill
     // in the row's top-right corner from the count that markUnread() reads into
     // the attribute, so there is no extra element to create, keep in step or leak
-    // when WhatsApp recycles the row. `position:relative` on the row is what the
-    // corner is measured against; rows carrying no attribute draw nothing, which
-    // is how "absent if zero" falls out for free.
-    "#pane-side [role=\"row\"]{position:relative!important}"
+    // when WhatsApp recycles the row. Rows carrying no attribute draw nothing,
+    // which is how "absent if zero" falls out for free.
+    //
+    // NOTE what this must NOT do: give the row `position:relative`. A row here is
+    // a virtual-list item, absolutely positioned and translated into place (see
+    // the preview note below). Making it relative returns it to normal flow while
+    // it keeps its transform, so the rows drift apart down the list and the
+    // filtered views appear to lose entries. It is also unnecessary — an
+    // absolutely positioned element is already the containing block its own
+    // absolutely positioned children are measured against.
+    //
+    // The colour comes from WhatsApp's own badge, published by markUnread() as a
+    // custom property, so it matches whatever the current theme paints rather than
+    // being a hard-coded green that only suits one of them.
     "#pane-side [role=\"row\"][data-whatly-unread]::after{"
     "content:attr(data-whatly-unread);position:absolute!important;"
     "top:2px;right:2px;z-index:5;"
-    "min-width:16px;height:16px;padding:0 4px;box-sizing:border-box;"
-    "border-radius:8px;background:#25d366;color:#fff;"
-    "font-size:11px;font-weight:600;line-height:16px;text-align:center;"
+    "min-width:24px;height:24px;padding:0 6px;box-sizing:border-box;"
+    "border-radius:12px;"
+    "background:var(--whatly-unread-bg,#25d366);"
+    "color:var(--whatly-unread-fg,#fff);"
+    "font-size:15px;font-weight:600;line-height:24px;text-align:center;"
     "pointer-events:none}"
     // The filter pills (All / Unread / Favourites / more) are a horizontal row
     // that a 97px column simply guillotines. Fold them into a 2x2 grid of round
@@ -168,14 +180,45 @@ static const char kScriptTemplate[] = R"JS(
       var rows = document.querySelectorAll('#pane-side [role="row"]');
       for (var i = 0; i < rows.length; i++) {
         var spans = rows[i].querySelectorAll('span');
-        var count = '';
+        var count = '', source = null;
         for (var j = 0; j < spans.length; j++) {
           var t = (spans[j].textContent || '').trim();
-          if (spans[j].children.length === 0 && /^\d{1,4}$/.test(t)) count = t;
+          if (spans[j].children.length === 0 && /^\d{1,4}$/.test(t)) {
+            count = t;
+            source = spans[j];
+          }
         }
-        if (count) rows[i].setAttribute('data-whatly-unread', count);
-        else rows[i].removeAttribute('data-whatly-unread');
+        if (count) {
+          rows[i].setAttribute('data-whatly-unread', count);
+          // Take the badge's own colours from WhatsApp's, once, so ours matches
+          // whatever the theme paints instead of being a fixed green that is only
+          // right in one of them. The digits sit in a leaf span, but the fill is
+          // usually on an ancestor, so walk up until a real colour appears.
+          if (!window.__whatlyUnreadPainted) adoptBadgeColours(source);
+        } else {
+          rows[i].removeAttribute('data-whatly-unread');
+        }
       }
+    };
+
+    // Read the live badge's background and text colour and publish them as custom
+    // properties for the stylesheet above. Runs once per page: WhatsApp does not
+    // change these while it is open, and a theme switch reloads the page.
+    var adoptBadgeColours = function (el) {
+      try {
+        for (var n = el, up = 0; n && up < 4; n = n.parentElement, up++) {
+          var cs = getComputedStyle(n);
+          var bg = cs.backgroundColor;
+          // Anything transparent means the fill is further up.
+          if (!bg || bg === 'transparent' || /rgba\([^)]*,\s*0\s*\)$/.test(bg))
+            continue;
+          var root = document.documentElement;
+          root.style.setProperty('--whatly-unread-bg', bg);
+          if (cs.color) root.style.setProperty('--whatly-unread-fg', cs.color);
+          window.__whatlyUnreadPainted = true;
+          return;
+        }
+      } catch (e) { /* keep the built-in green */ }
     };
 
     var untag = function (attr) {

--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -63,6 +63,22 @@ static const char kCollapseCss[] =
     "min-width:%1!important;max-width:%1!important}"
     "#side,#pane-side{overflow-x:hidden!important}"
     "#pane-side [role=\"row\"]{overflow:hidden!important}"
+    // The unread count, put back. WhatsApp's own badge sits at the right-hand end
+    // of a full-width row, so a 97px column cuts it off — and losing it is losing
+    // the one thing the collapsed list most needs to tell you. Redrawn as a pill
+    // in the row's top-right corner from the count that markUnread() reads into
+    // the attribute, so there is no extra element to create, keep in step or leak
+    // when WhatsApp recycles the row. `position:relative` on the row is what the
+    // corner is measured against; rows carrying no attribute draw nothing, which
+    // is how "absent if zero" falls out for free.
+    "#pane-side [role=\"row\"]{position:relative!important}"
+    "#pane-side [role=\"row\"][data-whatly-unread]::after{"
+    "content:attr(data-whatly-unread);position:absolute!important;"
+    "top:2px;right:2px;z-index:5;"
+    "min-width:16px;height:16px;padding:0 4px;box-sizing:border-box;"
+    "border-radius:8px;background:#25d366;color:#fff;"
+    "font-size:11px;font-weight:600;line-height:16px;text-align:center;"
+    "pointer-events:none}"
     // The filter pills (All / Unread / Favourites / more) are a horizontal row
     // that a 97px column simply guillotines. Fold them into a 2x2 grid of round
     // buttons instead, each labelled with the first letter of its own caption —
@@ -134,6 +150,33 @@ static const char kScriptTemplate[] = R"JS(
     window.__whatlyStripCss = __CSS__;
     window.__whatlyStripZoom = __ZOOM__;
     var el = document.getElementById('whatly-chatlist-strip');
+
+    // Read each visible row's unread count into an attribute, which the
+    // stylesheet above draws as a corner pill.
+    //
+    // Cheap enough to run on the same one-second tick as everything else,
+    // because WhatsApp virtualises the list: #pane-side holds only the couple of
+    // dozen rows actually rendered, never the whole chat list. Re-running is also
+    // what makes it correct across row recycling — a row reused for a different
+    // chat gets its attribute rewritten on the next tick rather than keeping the
+    // previous chat's number.
+    //
+    // The count is found the way chatnav.cpp already finds it: a leaf span whose
+    // entire text is the number. Timestamps contain ":" and so are excluded, and
+    // it needs no knowledge of WhatsApp's class names or any localised string.
+    var markUnread = function () {
+      var rows = document.querySelectorAll('#pane-side [role="row"]');
+      for (var i = 0; i < rows.length; i++) {
+        var spans = rows[i].querySelectorAll('span');
+        var count = '';
+        for (var j = 0; j < spans.length; j++) {
+          var t = (spans[j].textContent || '').trim();
+          if (spans[j].children.length === 0 && /^\d{1,4}$/.test(t)) count = t;
+        }
+        if (count) rows[i].setAttribute('data-whatly-unread', count);
+        else rows[i].removeAttribute('data-whatly-unread');
+      }
+    };
 
     var untag = function (attr) {
       document.querySelectorAll('[' + attr + ']').forEach(function (e) {
@@ -338,9 +381,15 @@ R"JS(
         untag('data-whatly-filters');
         untag('data-whatly-cell');
         untag('data-whatly-hide');
+        // The uncollapsed list shows WhatsApp's own badge again, so ours must not
+        // linger beside it.
+        untag('data-whatly-unread');
         return false;
       }
       prepare();
+      // Straight away rather than on the next tick, so collapsing does not show a
+      // list with no counts on it for up to a second.
+      markUnread();
       // A fresh pane gets a fresh budget of catch-up attempts; see the timer.
       window.__whatlyStripTries = 0;
       if (!style) {
@@ -396,6 +445,9 @@ R"JS(
           window.__whatlyStripTries = (window.__whatlyStripTries || 0) + 1;
           prepare();
         }
+        // Only while collapsed, and only over the rows WhatsApp has rendered.
+        if (applied)
+          markUnread();
         // A net under the click handler: the panel can also be opened from the
         // keyboard, and this costs one querySelector on a node that is empty
         // whenever no panel is open.


### PR DESCRIPTION
**DRAFT — please do not merge yet.** Dogfooding on Linux now, Windows after. Opening it early so the Windows side knows what to build.

## The gap

Collapsing the chat list to a 97px strip of avatars puts WhatsApp's own unread badge past the right-hand edge of the row, and `#pane-side [role="row"]` clips its overflow — so the count vanishes. That removes the most useful thing a narrow list can tell you, which conversations are waiting, and the only way to see it was to hover each row for the preview clone.

## The change

Each collapsed row draws its count as a small green pill in the top-right corner, from a `data-whatly-unread` attribute. Rows without the attribute draw nothing, so "absent when there is nothing unread" needs no special case.

## Two decisions taken from what the code already knows

**Finding the count.** A leaf span whose entire text is the number — exactly how `chatnav.cpp` reads unread counts today. Timestamps contain `:` and are excluded. No class names, no localised strings.

**Running it on the existing one-second timer, not a MutationObserver.** The comment on that timer already records the reason: an observer over a tree WhatsApp mutates continuously *"cost 40% of a core once already"*. The pass is cheap because WhatsApp virtualises the list — `#pane-side` holds only the couple of dozen rendered rows, never the whole chat list. Re-running is also what keeps it correct when a row is recycled for a different chat: the attribute is rewritten rather than inherited.

Drawing through a pseudo-element means there is no element of ours to create, keep in step, or leak across that recycling.

The attribute is removed when the list expands, so ours never sits beside WhatsApp's own badge, and applied immediately on collapse rather than a tick later.

## Testing

Builds clean; `ui_assets`, `logic` and `settings` all pass. Entirely inside the existing chat-list-strip feature, so it does nothing unless that is switched on.

Not yet checked by eye, which is why this is a draft: how the pill sits against the avatar at each of the preview sizes, and that it tracks correctly while scrolling the list (the recycling case).