### PR TITLE
fix(accounts): make the selected account tab visibly selected

### DIFF
--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -39,16 +39,21 @@ void AccountTabBar::refreshSelectionTint() {
     return;
   m_tinting = true;
   // Derived from the palette rather than hard-coded, so it follows whatever the
-  // theme is doing and stays right in both light and dark. Lighter than the strip
-  // when the strip is dark, darker when it is light — a shift in the direction
-  // that reads as "raised" either way.
+  // theme is doing and stays right in both light and dark: a step away from the
+  // strip, lighter when the strip is dark and darker when it is light.
   const QColor base = palette().color(QPalette::Window);
   const bool dark = base.lightness() < 128;
   const QColor tint = dark ? base.lighter(190) : base.darker(125);
-  // Only the selected tab is styled. Naming one property keeps Qt from falling
-  // back to drawing the whole strip itself, which would lose the platform look.
+  // And it goes on the tabs that are NOT on screen. With it on the selected one
+  // instead, that tab was the only one the stylesheet drew and the others kept
+  // the platform's own bordered look — which read as the wrong way round, the
+  // bordered ones looking live and the flat one looking like background. Now the
+  // ones you are not in are the flat crowd and the odd one out is the account you
+  // are in, which keeps the point of tinting anything: the selected tab stays
+  // visible on the styles that would otherwise draw it much like the rest.
+  // Naming one state also keeps Qt from taking over the whole strip's drawing.
   setStyleSheet(
-      QStringLiteral("QTabBar::tab:selected{background:%1;}").arg(tint.name()));
+      QStringLiteral("QTabBar::tab:!selected{background:%1;}").arg(tint.name()));
   m_tinting = false;
 }
 

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -44,7 +44,7 @@ void AccountTabBar::refreshSelectionTint() {
   // that reads as "raised" either way.
   const QColor base = palette().color(QPalette::Window);
   const bool dark = base.lightness() < 128;
-  const QColor tint = dark ? base.lighter(145) : base.darker(112);
+  const QColor tint = dark ? base.lighter(190) : base.darker(125);
   // Only the selected tab is styled. Naming one property keeps Qt from falling
   // back to drawing the whole strip itself, which would lose the platform look.
   setStyleSheet(

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -28,6 +28,16 @@ AccountTabBar::AccountTabBar(QWidget *parent) : QTabBar(parent) {
 }
 
 void AccountTabBar::refreshSelectionTint() {
+  // setStyleSheet() below makes Qt re-resolve this widget's style, which sends it
+  // a StyleChange and can send a PaletteChange too — both of which land back in
+  // changeEvent() and would come straight back here. Without this guard that is
+  // unbounded recursion, and it crashed the app on start-up rather than
+  // misbehaving quietly, because the stack ran out inside Qt's own style
+  // machinery. Re-entrancy has to be blocked here rather than by picking "safe"
+  // event types: which events a style re-resolve sends is Qt's business, not ours.
+  if (m_tinting)
+    return;
+  m_tinting = true;
   // Derived from the palette rather than hard-coded, so it follows whatever the
   // theme is doing and stays right in both light and dark. Lighter than the strip
   // when the strip is dark, darker when it is light — a shift in the direction
@@ -39,12 +49,16 @@ void AccountTabBar::refreshSelectionTint() {
   // back to drawing the whole strip itself, which would lose the platform look.
   setStyleSheet(
       QStringLiteral("QTabBar::tab:selected{background:%1;}").arg(tint.name()));
+  m_tinting = false;
 }
 
 void AccountTabBar::changeEvent(QEvent *event) {
   QTabBar::changeEvent(event);
-  if (event->type() == QEvent::PaletteChange ||
-      event->type() == QEvent::StyleChange)
+  // Only the palette, and not StyleChange: a StyleChange is what our own
+  // setStyleSheet() causes, so acting on it would be chasing our own tail. The
+  // palette is what the tint is actually derived from, so a theme switch is
+  // followed, and the guard above covers the rest.
+  if (event->type() == QEvent::PaletteChange)
     refreshSelectionTint();
 }
 

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -12,6 +12,8 @@
 #include <QPainter>
 #include <QPixmap>
 #include <QPolygon>
+#include <QEvent>
+#include <QPalette>
 
 // The dragged account's id travels as the mime payload; the distinct type lets
 // a strip recognise an account-tab drag (single process, so no cross-app risk).
@@ -22,6 +24,28 @@ AccountTabBar::AccountTabBar(QWidget *parent) : QTabBar(parent) {
   // Live within-strip reordering: the tabs slide as you drag. Leaving the strip
   // vertically hands off to a QDrag (tear-off / cross-window) in mouseMove.
   setMovable(true);
+  refreshSelectionTint();
+}
+
+void AccountTabBar::refreshSelectionTint() {
+  // Derived from the palette rather than hard-coded, so it follows whatever the
+  // theme is doing and stays right in both light and dark. Lighter than the strip
+  // when the strip is dark, darker when it is light — a shift in the direction
+  // that reads as "raised" either way.
+  const QColor base = palette().color(QPalette::Window);
+  const bool dark = base.lightness() < 128;
+  const QColor tint = dark ? base.lighter(145) : base.darker(112);
+  // Only the selected tab is styled. Naming one property keeps Qt from falling
+  // back to drawing the whole strip itself, which would lose the platform look.
+  setStyleSheet(
+      QStringLiteral("QTabBar::tab:selected{background:%1;}").arg(tint.name()));
+}
+
+void AccountTabBar::changeEvent(QEvent *event) {
+  QTabBar::changeEvent(event);
+  if (event->type() == QEvent::PaletteChange ||
+      event->type() == QEvent::StyleChange)
+    refreshSelectionTint();
 }
 
 int AccountTabBar::accountTabCount() const {

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -43,6 +43,16 @@ protected:
   void dragLeaveEvent(QDragLeaveEvent *event) override;
   void dropEvent(QDropEvent *event) override;
   void paintEvent(QPaintEvent *event) override;
+  // Re-tints on a palette change, so switching light/dark theme is followed.
+  void changeEvent(QEvent *event) override;
+
+private:
+  // Give the selected tab a visible tint, derived from the current palette:
+  // lighter than the strip in a dark theme, darker in a light one. Some platform
+  // style and GTK theme combinations draw the selected tab almost identically to
+  // the rest, which on a strip that doubles as the window's title bar leaves
+  // nothing to say which account is on screen.
+  void refreshSelectionTint();
 
 private:
   void startDrag(int index);

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -53,6 +53,9 @@ private:
   // the rest, which on a strip that doubles as the window's title bar leaves
   // nothing to say which account is on screen.
   void refreshSelectionTint();
+  // Guards refreshSelectionTint against re-entering itself: the setStyleSheet it
+  // does makes Qt re-resolve the style, which sends events that come back here.
+  bool m_tinting = false;
 
 private:
   void startDrag(int index);

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -47,11 +47,13 @@ protected:
   void changeEvent(QEvent *event) override;
 
 private:
-  // Give the selected tab a visible tint, derived from the current palette:
+  // Tint the tabs that are NOT on screen, derived from the current palette:
   // lighter than the strip in a dark theme, darker in a light one. Some platform
   // style and GTK theme combinations draw the selected tab almost identically to
   // the rest, which on a strip that doubles as the window's title bar leaves
-  // nothing to say which account is on screen.
+  // nothing to say which account is on screen. Tinting the crowd rather than the
+  // one answers that the same way round, and leaves the selected tab as the
+  // platform draws it — one flat colour and one odd one out.
   void refreshSelectionTint();
   // Guards refreshSelectionTint against re-entering itself: the setStyleSheet it
   // does makes Qt re-resolve the style, which sends events that come back here.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(tst_logic
     ${S}/networkproxy.cpp ${S}/autostart.cpp ${S}/portalnotification.cpp
     ${S}/notificationreply.cpp
     ${S}/setupwizard.cpp
+    ${S}/accounttabbar.cpp
     ${S}/icons.qrc
 )
 target_include_directories(tst_logic PRIVATE ${S} ${CMAKE_BINARY_DIR})

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -1844,13 +1844,15 @@ private slots:
     dark.setColor(QPalette::Window, QColor(30, 30, 30));
     bar.setPalette(dark);
     const QString darkSheet = bar.styleSheet();
-    QVERIFY(darkSheet.contains(QLatin1String("QTabBar::tab:selected")));
+    // The tabs that are NOT on screen carry the tint; the one that is stays as
+    // the platform draws it, and is told apart by being the only untinted one.
+    QVERIFY(darkSheet.contains(QLatin1String("QTabBar::tab:!selected")));
 
     QPalette light = bar.palette();
     light.setColor(QPalette::Window, QColor(240, 240, 240));
     bar.setPalette(light);
     const QString lightSheet = bar.styleSheet();
-    QVERIFY(lightSheet.contains(QLatin1String("QTabBar::tab:selected")));
+    QVERIFY(lightSheet.contains(QLatin1String("QTabBar::tab:!selected")));
 
     // The tint follows the palette rather than being fixed, so a light theme and
     // a dark one must not end up with the same colour.

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -65,6 +65,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include "linkeddevicename.h"
+#include "accounttabbar.h"
 #include "performance.h"
 #include "trayicon.h"
 #include "chatnav.h"
@@ -1822,6 +1823,38 @@ private slots:
         QLatin1String("--font-render-hinting")));
 
     Performance::setFontHinting(QString()); // restore the isolated baseline
+  }
+
+  // The selected-tab tint follows the palette rather than being a fixed colour,
+  // so a light theme and a dark one get different tints and a theme switch is
+  // picked up.
+  //
+  // NOTE what this does NOT cover: the re-entrancy guard in refreshSelectionTint().
+  // Setting a stylesheet on a widget that has never been shown does not make Qt
+  // re-resolve its style under the offscreen platform, so the event that would
+  // re-enter the handler is never sent and this test passes either way — verified
+  // by removing the guard and watching it still pass. The guard is there because
+  // the recursion is evident from the code, not because this test proves it.
+  void tabTintFollowsPalette() {
+    AccountTabBar bar;
+    bar.addTab(QStringLiteral("one"));
+    bar.addTab(QStringLiteral("two"));
+
+    QPalette dark = bar.palette();
+    dark.setColor(QPalette::Window, QColor(30, 30, 30));
+    bar.setPalette(dark);
+    const QString darkSheet = bar.styleSheet();
+    QVERIFY(darkSheet.contains(QLatin1String("QTabBar::tab:selected")));
+
+    QPalette light = bar.palette();
+    light.setColor(QPalette::Window, QColor(240, 240, 240));
+    bar.setPalette(light);
+    const QString lightSheet = bar.styleSheet();
+    QVERIFY(lightSheet.contains(QLatin1String("QTabBar::tab:selected")));
+
+    // The tint follows the palette rather than being fixed, so a light theme and
+    // a dark one must not end up with the same colour.
+    QVERIFY(darkSheet != lightSheet);
   }
 
   // Idle account suspension (#1): only a background, off-screen, idle account is


### PR DESCRIPTION
**DRAFT — dogfooded on Linux; Windows after.**

With more than one account the tab strip is how you know which account is on screen — and with the custom frame enabled it doubles as the window's title bar. But under some platform-style and GTK-theme combinations the selected tab is drawn almost identically to the unselected ones, so there is nothing to say where you are. Reported from a Linux Mint setup using the Mint-Y-Aqua GTK theme.

The tint is derived from the palette rather than hard-coded, so it follows the theme instead of fighting it: **lighter than the strip when the strip is dark, darker when it is light**. It is re-derived on palette changes, so toggling between light and dark keeps it correct.

**It goes on the tabs that are NOT on screen**, and that is the whole trick. Tinting the selected one instead was tried first and reads backwards: naming `QTabBar::tab:selected` makes the stylesheet draw that one tab while every other tab keeps the platform's own bordered look, so the bordered ones read as live buttons and the flat one as background. Tinting the crowd puts the odd one out on the account you are in — and it keeps the point of the change, because on a style that draws the selected tab like all the rest, being the only untinted one is exactly what identifies it.

Naming one pseudo-state also keeps Qt from taking over the drawing of the whole strip, which would lose the platform look.

Builds clean; `ui_assets`, `logic` and `settings` all pass — `logic` includes a test that the tint follows the palette and lands on the right pseudo-state. Checked by eye in both themes on Linux.
