### PR TITLE
refactor(settings): file the "Performance & Privacy" grab-bag where each setting belongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ accounts, which stops their timers and scripts but keeps every byte of the
 renderer, so the memory it was meant to save stayed allocated. The trade is
 unchanged and still opt-in: an account with no page cannot notify you, so with
 this off — the default — every account loads at startup exactly as before.
+**Settings: the things in "Performance & Privacy" are now where you would look for
+them.** That one section had grown into a grab-bag holding, besides the GPU and
+memory options its name suggests, the entire AI assistant and inline translation
+panels, whether photos are sent in HD, whether Enter holds a message briefly, the
+chat-list preview blanking and the WebRTC privacy shield — so the thing you wanted
+was almost never under the heading you would have guessed. **AI & translation** is
+now a section of its own, the two privacy settings have joined **Privacy & Lock**,
+the two messaging ones have joined **Chatting**, and what remains is genuinely
+performance, so the section is simply called that. **Interface scale** has also
+moved from "Network & Startup", where it sat beside the autostart checkbox, to
+**Window & zoom** beside the other zoom controls. No setting changed its meaning and
+nothing was renamed; they are only in sensible places now.
 
 ## 7.0.0 (2026-08-03)
 

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -2025,13 +2025,13 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2026"/>
-        <source>Suspend inactive accounts</source>
-        <translation>Prokrasti neaktivajn kontojn</translation>
+        <source>Unload inactive accounts from memory</source>
+        <translation>Malŝarĝi neaktivajn kontojn el la memoro</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2023"/>
-        <source>Free memory by suspending accounts you are not viewing. A suspended account does not receive messages until you switch back to it. Single-account setups are unaffected.</source>
-        <translation>Liberigas memoron prokrastante kontojn kiujn vi ne rigardas. Prokrastita konto ne ricevas mesaĝojn ĝis vi reiras al ĝi. Unukontaj agordoj ne estas influataj.</translation>
+        <source>Free memory by unloading accounts you are not viewing. An unloaded account does not receive messages, and reloads to where it was when you switch back to it. Single-account setups are unaffected.</source>
+        <translation>Malŝarĝi neaktivajn kontojn el la memoro post X minutoj. Ĉi tio ŝparas spacon, kaj la konto aŭtomate reŝarĝiĝos al sia antaŭa stato kiam vi revenos al la langeto. Unukontaj agordoj ne estas influataj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2033"/>

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -3262,6 +3262,10 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
         <translation>Privateco kaj ŝloso</translation>
     </message>
     <message>
+        <source>AI &amp;&amp; translation</source>
+        <translation>AI kaj tradukado</translation>
+    </message>
+    <message>
         <location filename="../settingswidget.cpp" line="511"/>
         <source>Window &amp;&amp; zoom</source>
         <translation>Fenestro &amp;&amp; zomo</translation>
@@ -3605,8 +3609,8 @@ Eble vi ankaŭ bezonos kompletan restartigon de la aplikaĵo!</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="1539"/>
-        <source>Performance &amp; Privacy (requires restart)</source>
-        <translation>Rendimento kaj privateco (postulas restartigon)</translation>
+        <source>Performance (requires restart)</source>
+        <translation>Rendimento (postulas restartigon)</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="2074"/>

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -500,12 +500,27 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(chatting), ui->autoPlayMediaCheckBox, G);
     moveWidget(body(chatting), ui->dismissEmojiPanelCheckBox, G);
     moveWidget(body(chatting), ui->hideMutedStatusCheckBox, G);
+    // Two everyday messaging preferences that were filed under "Performance &
+    // Privacy", where nobody would think to look for them: how photos are sent,
+    // and whether Enter holds a message briefly before it goes. Neither has
+    // anything to do with performance.
+    moveWidget(body(chatting), ui->hdMediaCheckBox,
+               ui->verticalLayoutPerformance);
+    moveLayout(body(chatting), ui->horizontalLayoutUndoSend);
 
     // ── Privacy & Lock ──────────────────────────────────────
     auto *privacy = newSection(tr("Privacy & Lock"));
     moveRow(body(privacy), ui->privacyBlurLabel, ui->privacyBlurComboBox, G);
     moveWidget(body(privacy), ui->privacyBlurButtonCheckBox, G);
     moveLayout(body(privacy), ui->gridLayout_3); // app-lock block
+    // The two genuinely privacy settings out of the old "Performance & Privacy"
+    // group — which is what the "& Privacy" in its name was promising. Focus mode
+    // hides chat-list previews from anyone looking at the screen, and the WebRTC
+    // shield stops calls leaking the local address.
+    moveWidget(body(privacy), ui->focusModeCheckBox,
+               ui->verticalLayoutPerformance);
+    moveWidget(body(privacy), ui->webrtcShieldCheckBox,
+               ui->verticalLayoutPerformance);
 
     // ── Window & zoom ───────────────────────────────────────
     auto *window = newSection(tr("Window && zoom"));
@@ -523,6 +538,22 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                ui->restartNowButton);
     moveWidget(body(window), ui->tabsInTitleBarCheckBox, G);
     moveLayout(body(window), ui->gridLayout_9); // zoom block
+    // Interface scale belongs beside the zoom controls, not under "Network &
+    // Startup" where it sat next to the autostart checkbox — the same mistake the
+    // frame checkbox made, and this section already carries the Restart-now
+    // button its label asks for.
+    moveLayout(body(window), ui->horizontalLayoutScale);
+
+    // ── AI & translation ────────────────────────────────────
+    // The largest thing in the old "Performance & Privacy" group by far: two
+    // whole feature panels, each with an endpoint, a model or target language and
+    // an API key. They are neither performance nor privacy, and burying them
+    // there is most of why that group was impossible to navigate.
+    auto *aiTranslation = newSection(tr("AI && translation"));
+    moveWidget(body(aiTranslation), ui->aiGroupBox,
+               ui->verticalLayoutPerformance);
+    moveWidget(body(aiTranslation), ui->translationGroupBox,
+               ui->verticalLayoutPerformance);
 
     // ── Advanced ────────────────────────────────────────────
     auto *advanced = newSection(tr("Advanced"));
@@ -542,8 +573,9 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     outer->insertWidget(1, appearance);
     outer->insertWidget(2, notifications);
     outer->insertWidget(3, chatting);
-    outer->insertWidget(4, privacy);
-    outer->insertWidget(5, window);
+    outer->insertWidget(4, aiTranslation);
+    outer->insertWidget(5, privacy);
+    outer->insertWidget(6, window);
     outer->addWidget(advanced);
 
     QScrollArea *scrollArea = ui->scrollArea;
@@ -630,6 +662,7 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     makeCollapsible(appearance, false);
     makeCollapsible(notifications, false);
     makeCollapsible(chatting, false);
+    makeCollapsible(aiTranslation, false);
     makeCollapsible(privacy, false);
     makeCollapsible(window, false);
     makeCollapsible(advanced, false);
@@ -650,7 +683,7 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     addGroupRestart(ui->verticalLayoutShortcuts);
 
     makeCollapsible(ui->groupBox_7, false);          // Storage
-    makeCollapsible(ui->groupBoxPerformance, false); // Performance & Privacy
+    makeCollapsible(ui->groupBoxPerformance, false); // Performance
     makeCollapsible(ui->groupBoxNetwork, false);     // Network & Startup
     makeCollapsible(ui->groupBoxJsAddons, false);    // JS Addons
     makeCollapsible(ui->groupBoxCanned, false);      // Canned responses

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -1536,7 +1536,7 @@ background:transparent;
        <item>
         <widget class="QGroupBox" name="groupBoxPerformance">
          <property name="title">
-          <string>Performance &amp; Privacy (requires restart)</string>
+          <string>Performance (requires restart)</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutPerformance">
           <item>

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -2020,10 +2020,10 @@ background:transparent;
             <item>
              <widget class="QCheckBox" name="suspendInactiveAccountsCheckBox">
               <property name="toolTip">
-               <string>Free memory by suspending accounts you are not viewing. A suspended account does not receive messages until you switch back to it. Single-account setups are unaffected.</string>
+               <string>Free memory by unloading accounts you are not viewing. An unloaded account does not receive messages, and reloads to where it was when you switch back to it. Single-account setups are unaffected.</string>
               </property>
               <property name="text">
-               <string>Suspend inactive accounts</string>
+               <string>Unload inactive accounts from memory</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
**DRAFT — dogfooding on Linux next, Windows after.**

## What was wrong

"Performance & Privacy" promised two topics and held seven. Besides the five GPU switches and three memory options its name suggests, it contained:

- the **entire AI assistant panel** — endpoint, model, API key, Ollama detection
- the **entire inline translation panel** — endpoint, API key, target language
- **Send photos and videos in HD by default**
- **Undo send**
- **Focus mode** (hide chat-list previews)
- the **WebRTC privacy shield** — the only actually-privacy item in there

So whatever you wanted was usually not under the heading you would have guessed. That is the same failure the comment in `settingswidget.cpp` already records for the custom-frame checkbox, which had ended up under "Network & Startup" next to the autostart option and *"was not where anyone looked for it"*.

## What this does

Nothing is renamed and no stored key moves — the settings are only filed where they belong:

| Setting | New home |
|---|---|
| AI assistant, inline translation | **AI & translation** (new section) |
| Focus mode, WebRTC shield | **Privacy & Lock** |
| HD media, Undo send | **Chatting** |
| Interface scale | **Window & zoom** (from "Network & Startup") |
| GPU / process / memory / cache / fonts / idle accounts | **Performance** (renamed, since that is now all it holds) |

**Interface scale** was the other half of the same problem: a display setting sitting beside the autostart checkbox. "Window & zoom" already carries the Restart-now button its label asks for.

## How

Entirely through the re-sectioning helpers already in `settingswidget.cpp` (`moveWidget` / `moveLayout`), which is how the existing sections are built. No `.ui` restructuring, so the diff is the moves themselves, no widget is rebuilt, and every setting keeps its object name, signal connections and stored key. The only `.ui` change is the group title.

## One nuance left alone

"Suspend inactive accounts" lives in a group titled "(requires restart)", but it is read live by the idle timer and applies immediately. Over-promising a restart is harmless where under-promising would not be, so it is left as it is rather than widening this change.

## Testing

Builds clean; `ui_assets`, `logic` and `settings` all pass. The settings dialog was also opened headlessly (`--open-settings` under an offscreen platform, isolated HOME) to check the moves produce no layout warnings — none.

Not yet checked by eye, which is why this is a draft: that each section reads sensibly and nothing landed in an odd order.