### PR TITLE
feat(window): stop treating one window as the main one

### DIFF
--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -76,4 +76,47 @@ QString openChatByNameScript(const QString &name) {
 )JS").arg(jsonString(name));
 }
 
+QString focusSearchScript() {
+  return QStringLiteral(R"JS(
+(function(){
+  var tries = 0;
+  function box() {
+    // Named first, because it is unambiguous — but only in the languages we can
+    // name, so the structural fallbacks below carry every other locale: the
+    // search field is the one text input inside #side and above the chat list.
+    return document.querySelector('input[aria-label*="Search" i]')
+      || document.querySelector('input[aria-label*="Buscar" i]')
+      || document.querySelector('input[data-tab="3"]')
+      || document.querySelector('#side [contenteditable="true"]')
+      || document.querySelector('#side [role="textbox"]')
+      || document.querySelector('#side input');
+  }
+  function attempt() {
+    var b = box();
+    if (b) {
+      b.focus();
+      // Select what is already there, so typing replaces the old term instead of
+      // appending to it. Not every element type has select().
+      if (typeof b.select === 'function') { try { b.select(); } catch (e) {} }
+      else {
+        try {
+          var r = document.createRange();
+          r.selectNodeContents(b);
+          var s = window.getSelection();
+          s.removeAllRanges();
+          s.addRange(r);
+        } catch (e) {}
+      }
+      return 'ok';
+    }
+    // The page may still be building, and the chat list may have just been
+    // expanded on our own account, which is a round trip through the app.
+    if (++tries < 12) { setTimeout(attempt, 150); return 'waiting'; }
+    return 'not-found';
+  }
+  return attempt();
+})()
+)JS");
+}
+
 } // namespace ChatNav

--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -79,11 +79,90 @@ QString openChatByNameScript(const QString &name) {
 QString focusSearchScript() {
   return QStringLiteral(R"JS(
 (function(){
+  // Ctrl+F means "find in what I am looking at". With a conversation open, that
+  // is the conversation — WhatsApp's own search-within-chat, the magnifier in the
+  // chat header — and not the chat list's search box, which is a different
+  // question entirely. The list search is what it falls back to when there is no
+  // conversation open to search.
   var tries = 0;
-  function box() {
-    // Named first, because it is unambiguous — but only in the languages we can
-    // name, so the structural fallbacks below carry every other locale: the
-    // search field is the one text input inside #side and above the chat list.
+  function vis(e) {
+    var r = e.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  }
+  function focusIn(el) {
+    el.focus();
+    // Select what is already there, so typing replaces the old term rather than
+    // appending to it. Not every element type has select().
+    if (typeof el.select === 'function') { try { el.select(); } catch (e) {} }
+    else {
+      try {
+        var r = document.createRange();
+        r.selectNodeContents(el);
+        var s = window.getSelection();
+        s.removeAllRanges();
+        s.addRange(r);
+      } catch (e) {}
+    }
+  }
+  // The magnifier in the open conversation's header. data-icon is WhatsApp's own
+  // attribute and survives their builds; every class around it is obfuscated and
+  // does not. The aria-label pass is for builds that drop the attribute, and it
+  // can only cover the languages it names, which is why it is second.
+  function headerSearch() {
+    var main = document.querySelector('#main');
+    var header = main && main.querySelector('header');
+    if (!header) return null;
+    var icon = header.querySelector('[data-icon^="search"]');
+    if (icon) return icon.closest('button') || icon;
+    var btns = header.querySelectorAll('button');
+    for (var i = 0; i < btns.length; i++) {
+      var l = (btns[i].getAttribute('aria-label') || '').toLowerCase();
+      if (/search|buscar|recherch|such|cerca|procur|ricerc|zoek|поиск|szukaj|serĉ/.test(l))
+        return btns[i];
+    }
+    return null;
+  }
+  // The field the search panel opens with: it is in neither the chat list
+  // (#side) nor the conversation (#main), because WhatsApp puts the panel in its
+  // own pane beside them. That places it without naming a single class, and it
+  // is also what keeps this off the message composer, which lives inside #main.
+  function panelBox() {
+    var all = document.querySelectorAll(
+      'input,[contenteditable="true"],[role="textbox"]');
+    for (var i = 0; i < all.length; i++) {
+      var e = all[i];
+      if (e.closest('#side') || e.closest('#main')) continue;
+      if (vis(e)) return e;
+    }
+    return null;
+  }
+  // A plain click is ignored by parts of this UI, so send the sequence it does
+  // react to, the same one the chat-opening script uses.
+  function press(el) {
+    var r = el.getBoundingClientRect();
+    var o = { bubbles: true, cancelable: true, view: window,
+              clientX: r.x + r.width / 2, clientY: r.y + r.height / 2,
+              button: 0, pointerId: 1, pointerType: 'mouse', isPrimary: true };
+    el.dispatchEvent(new PointerEvent('pointerdown', o));
+    el.dispatchEvent(new MouseEvent('mousedown', o));
+    el.dispatchEvent(new PointerEvent('pointerup', o));
+    el.dispatchEvent(new MouseEvent('mouseup', o));
+    el.dispatchEvent(new MouseEvent('click', o));
+  }
+  function waitForPanel() {
+    var b = panelBox();
+    if (b) { focusIn(b); return 'chat-search'; }
+    if (++tries < 15) { setTimeout(waitForPanel, 100); return 'waiting'; }
+    return 'chat-search-no-field';
+  }
+
+  var btn = headerSearch();
+  if (btn) { press(btn); return waitForPanel(); }
+
+  // No conversation open. The chat list's own search box is the sensible answer,
+  // named by aria-label in the languages we can name and found structurally
+  // otherwise — the one input inside #side — so the key is not dead elsewhere.
+  function listBox() {
     return document.querySelector('input[aria-label*="Search" i]')
       || document.querySelector('input[aria-label*="Buscar" i]')
       || document.querySelector('input[data-tab="3"]')
@@ -91,30 +170,21 @@ QString focusSearchScript() {
       || document.querySelector('#side [role="textbox"]')
       || document.querySelector('#side input');
   }
-  function attempt() {
-    var b = box();
-    if (b) {
-      b.focus();
-      // Select what is already there, so typing replaces the old term instead of
-      // appending to it. Not every element type has select().
-      if (typeof b.select === 'function') { try { b.select(); } catch (e) {} }
-      else {
-        try {
-          var r = document.createRange();
-          r.selectNodeContents(b);
-          var s = window.getSelection();
-          s.removeAllRanges();
-          s.addRange(r);
-        } catch (e) {}
-      }
-      return 'ok';
-    }
-    // The page may still be building, and the chat list may have just been
-    // expanded on our own account, which is a round trip through the app.
-    if (++tries < 12) { setTimeout(attempt, 150); return 'waiting'; }
+  function attemptList() {
+    var b = listBox();
+    if (b && vis(b)) { focusIn(b); return 'list-search'; }
+    if (++tries < 15) { setTimeout(attemptList, 150); return 'waiting'; }
     return 'not-found';
   }
-  return attempt();
+  // Collapsed, that box is clipped to a sliver, so focusing it is no use: open
+  // the list first, which is what a click up there does. Same test the sidebar
+  // buttons use for the collapsed state. Expanding is a round trip through the
+  // app, hence the retry.
+  var strip = document.getElementById('whatly-chatlist-strip');
+  if (strip && strip.textContent && window.__whatlyBridge &&
+      window.__whatlyBridge.toggleChatListStrip)
+    window.__whatlyBridge.toggleChatListStrip();
+  return attemptList();
 })()
 )JS");
 }

--- a/src/chatnav.h
+++ b/src/chatnav.h
@@ -20,6 +20,13 @@ QString unreadChatsScript(int limit);
 // any characters are safe.
 QString openChatByNameScript(const QString &name);
 
+// JS that puts the keyboard into WhatsApp Web's own chat-list search box and
+// selects whatever is in it, so typing replaces it — what Ctrl+F does in a
+// browser. WhatsApp Web itself binds no key for this: in a browser Ctrl+F is the
+// browser's find bar, and Qt WebEngine has none, so the key did nothing at all.
+// Returns "ok" / "not-found".
+QString focusSearchScript();
+
 } // namespace ChatNav
 
 #endif // CHATNAV_H

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -2297,8 +2297,8 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="520"/>
-        <source>Ctrl+W hides only the focused window.</source>
-        <translation>Ctrl+W kaŝas nur la fokusitan fenestron.</translation>
+        <source>Ctrl+W hides only the last focused window.</source>
+        <translation>Ctrl+W kaŝas nur la laste fokusitan fenestron.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="517"/>

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -532,6 +532,31 @@ Do you wish to override the security check and continue ?   </source>
         <translation>Lastaj nelegitaj</translation>
     </message>
     <message>
+        <location filename="../mainwindow_tray.cpp" line="130"/>
+        <source>&amp;Find in chats</source>
+        <translation>&amp;Serĉi en babiloj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="275"/>
+        <source>Find in chats</source>
+        <translation>Serĉi en babiloj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="311"/>
+        <source>Windows</source>
+        <translation>Fenestroj</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="481"/>
+        <source>hidden</source>
+        <translation>kaŝita</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_tray.cpp" line="483"/>
+        <source>minimised</source>
+        <translation>minimumigita</translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="106"/>
         <location filename="../mainwindow.cpp" line="1140"/>
         <location filename="../mainwindow.cpp" line="1236"/>
@@ -2264,6 +2289,16 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
         <location filename="../settingswidget.ui" line="510"/>
         <source>Remember multiple window positions on restart</source>
         <translation>Memori la poziciojn de pluraj fenestroj ĉe restarto</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="517"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Off by default, so &amp;quot;Minimise to tray&amp;quot; puts the whole app away: with several windows open, leaving the others on screen while the tray reports Whatly as away is the same confusion as one window being treated as the real one. Tick this to have it put away only the window you are in. Follows whatever key &amp;quot;Minimise to tray&amp;quot; is bound to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Defaŭlte malŝaltita, do &amp;quot;Minimumigi al la sistempleto&amp;quot; kaŝas la tutan aplikaĵon: kiam pluraj fenestroj estas malfermitaj, lasi la aliajn sur la ekrano dum la sistempleto montras Whatly kiel forestantan estas la sama konfuzo kiel trakti unu fenestron kiel la veran. Marku ĉi tion por ke ĝi kaŝu nur la fenestron en kiu vi estas. Ĝi sekvas kiun ajn klavon vi asignis al &amp;quot;Minimumigi al la sistempleto&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../settingswidget.ui" line="520"/>
+        <source>Ctrl+W hides only the focused window.</source>
+        <translation>Ctrl+W kaŝas nur la fokusitan fenestron.</translation>
     </message>
     <message>
         <location filename="../settingswidget.ui" line="517"/>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,7 @@
 #include <QMessageBox>
 #include <QProcess>
 #include "chatliststrip.h"
+#include "chatnav.h"
 #include "privacyblur.h"
 #include "localapi.h"
 #include "cloudapi.h"
@@ -1430,6 +1431,25 @@ void MainWindow::toggleChatListStrip() {
     if (account.view && account.view->page())
       account.view->page()->runJavaScript(ChatListStrip::scriptSource());
   refreshChatListStripAction();
+}
+
+void MainWindow::focusChatSearch() {
+  // The account in the window being typed into, not the app-wide "active" one:
+  // with a detached window in front, those are different accounts, and searching
+  // the wrong one is worse than doing nothing.
+  const int idx = focusedAccountIndex();
+  if (idx < 0)
+    return;
+  // Collapsed, the search box is clipped to a sliver above the chat list — the
+  // same reason a click up there expands the list instead of typing into it.
+  // Expanding is a round trip through the app, which is why the script retries
+  // rather than assuming the box is there the moment it runs.
+  if (ChatListStrip::isCollapsed())
+    toggleChatListStrip();
+  // Safe to ask the view for its page here, unlike a loop over every account:
+  // this account is the one on screen, so its page already exists.
+  if (m_accounts[idx].view && m_accounts[idx].view->page())
+    m_accounts[idx].view->page()->runJavaScript(ChatNav::focusSearchScript());
 }
 
 // ── Chat / URL helpers ────────────────────────────────────────────────────────

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -175,11 +175,10 @@ MainWindow::MainWindow(QWidget *parent)
                 showQuickCompose();
                 return;
               }
-              setWindowState((windowState() & ~Qt::WindowMinimized) |
-                             Qt::WindowActive);
-              show();
-              raise();
-              activateWindow();
+              // The last window used, not this one: the shortcut means "show me
+              // Whatly", and which window happens to own the tray icon is not
+              // something the user should be made aware of.
+              bringForward(frontWindow());
             });
   } else {
     qInfo() << "No global-shortcut backend available; bind a desktop shortcut "
@@ -975,12 +974,10 @@ void MainWindow::showNotification(QString title, QString message) {
 }
 
 void MainWindow::notificationClicked() {
-  show();
+  QWidget *w = frontWindow();
+  w->show();
   QCoreApplication::processEvents();
-  if (windowState().testFlag(Qt::WindowMinimized))
-    setWindowState(windowState() & ~Qt::WindowMinimized);
-  raise();
-  activateWindow();
+  bringForward(w);
   // Quick reply: put the caret in the message box so the user can just type.
   if (m_webEngine && m_webEngine->page())
     m_webEngine->page()->runJavaScript(QuickReply::focusComposerScript());
@@ -1277,12 +1274,36 @@ void MainWindow::sendAttachmentViaWeb(const QString &number,
   m_webEngine->page()->runJavaScript(js);
 }
 
-void MainWindow::raiseWindow() {
-  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-  show();
-  raise();
-  activateWindow();
+QWidget *MainWindow::frontWindow() const {
+  // m_focusOrder is most-recently-focused first, with a null entry standing for
+  // this window. Both this window and every detached one record their own
+  // activation, so the front entry is the last window the user touched.
+  DetachedAccountWindow *front =
+      m_focusOrder.isEmpty() ? nullptr : m_focusOrder.first();
+  return front ? static_cast<QWidget *>(front)
+               : static_cast<QWidget *>(const_cast<MainWindow *>(this));
 }
+
+QList<QWidget *> MainWindow::allWindows() const {
+  QList<QWidget *> out;
+  out << const_cast<MainWindow *>(this);
+  for (const Account &a : m_accounts)
+    if (a.window && !out.contains(a.window))
+      out << a.window;
+  return out;
+}
+
+void MainWindow::bringForward(QWidget *w) {
+  if (!w)
+    return;
+  w->setWindowState((w->windowState() & ~Qt::WindowMinimized) |
+                    Qt::WindowActive);
+  w->show();
+  w->raise();
+  w->activateWindow();
+}
+
+void MainWindow::raiseWindow() { bringForward(frontWindow()); }
 
 // Come back as the SAME program, launched the SAME way. applicationFilePath()
 // rather than argv[0] (which can be a bare name found on PATH), and the real

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1440,12 +1440,11 @@ void MainWindow::focusChatSearch() {
   const int idx = focusedAccountIndex();
   if (idx < 0)
     return;
-  // Collapsed, the search box is clipped to a sliver above the chat list — the
-  // same reason a click up there expands the list instead of typing into it.
-  // Expanding is a round trip through the app, which is why the script retries
-  // rather than assuming the box is there the moment it runs.
-  if (ChatListStrip::isCollapsed())
-    toggleChatListStrip();
+  // Which search to open is the page's decision, not ours: with a conversation
+  // open the answer is the search within it, and only with none open is it the
+  // chat list's box — which the script also has to expand the list for when it is
+  // collapsed. All three of those are questions only the DOM can answer.
+  //
   // Safe to ask the view for its page here, unlike a loop over every account:
   // this account is the one on screen, so its page already exists.
   if (m_accounts[idx].view && m_accounts[idx].view->page())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1293,6 +1293,36 @@ QList<QWidget *> MainWindow::allWindows() const {
   return out;
 }
 
+QList<QWidget *> MainWindow::windowsByFocus() const {
+  // m_focusOrder is most-recently-focused first, with a null entry standing for
+  // this window (see frontWindow()). Translate that, then let the pure helper do
+  // the ordering — it is the part with the rules in it (repeats, windows since
+  // closed, windows never focused) and the part worth testing.
+  QList<QWidget *> history;
+  for (DetachedAccountWindow *win : m_focusOrder)
+    history << (win ? static_cast<QWidget *>(win)
+                    : static_cast<QWidget *>(const_cast<MainWindow *>(this)));
+  return Utils::orderedByHistory(history, allWindows());
+}
+
+void MainWindow::hideAllWindows() {
+  for (QWidget *w : allWindows())
+    w->hide();
+}
+
+void MainWindow::restoreAllWindows() {
+  // Least-recently-used first, so what comes back is stacked the way it was
+  // left, and the window the user was actually in ends up on top.
+  const QList<QWidget *> order = windowsByFocus();
+  for (int i = order.size() - 1; i > 0; --i) {
+    QWidget *w = order[i];
+    w->setWindowState(w->windowState() & ~Qt::WindowMinimized);
+    w->show();
+    w->raise();
+  }
+  bringForward(order.isEmpty() ? this : order.first());
+}
+
 void MainWindow::bringForward(QWidget *w) {
   if (!w)
     return;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -99,6 +99,17 @@ public slots:
   // Every Whatly window, so "hide to tray" takes the whole app away rather than
   // just this one, which would be another way of showing which is special.
   QList<QWidget *> allWindows() const;
+  // The same windows, most-recently-used first. Hiding is what makes the order
+  // matter: it takes the whole app away, so bringing it back has to bring all of
+  // it back, and in the order the user left it.
+  QList<QWidget *> windowsByFocus() const;
+  // Bring the whole app back: every window that is hidden or minimised, with the
+  // one last used raised on top. Showing only that one is what stranded the
+  // others — hidden, with no window left to click and no entry pointing at them.
+  void restoreAllWindows();
+  // Put the whole app in the tray: every window, for the same reason hiding one
+  // and leaving the rest would say one of them is the real one.
+  void hideAllWindows();
   void newChat();
   // Whether the account strip stays up with only one account, where it is a row
   // of chrome carrying a single tab. Off by default; the "+" it holds is also
@@ -257,6 +268,15 @@ private:
   QMenu *m_recentUnreadMenu = nullptr;
   void refreshRecentUnread();
   void openChatByName(const QString &accountId, const QString &name);
+  // Every window in the tray menu, numbered by how recently it was used, so none
+  // can be left with nothing pointing at it.
+  QMenu *m_windowsMenu = nullptr;
+  // What each entry in that menu points at, in the same order — so a click goes
+  // to the window whose label was read, and to nothing at all if that window has
+  // since closed.
+  QList<QPointer<QWidget>> m_windowsMenuTargets;
+  void refreshWindowsMenu();
+  QString windowLabel(const QWidget *w) const;
   // The tab tooltip for an account: its WhatsApp Web version (once known) and
   // the build token from the page URL. Empty while neither is available.
   QString accountTabTooltip(const Account &acc) const;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -80,6 +80,11 @@ public slots:
   void toggleChatListStrip();
   // Keep that action's text saying what it will do next, for the palette.
   void refreshChatListStripAction();
+  // Put the keyboard into WhatsApp Web's own chat search, in the account the
+  // window in front is showing. Expands the chat list first when it is
+  // collapsed, since the search box is clipped to a sliver there and focusing
+  // something invisible is not a usable answer to the key.
+  void focusChatSearch();
   // Relaunch this same executable with this same command line, so the settings
   // that only apply at startup take effect without the user having to quit and
   // find Whatly again. Everything about how the desk looks is saved first and
@@ -223,6 +228,12 @@ private:
   // Rebuild every detached window's tab strip from m_accounts.
   void refreshDetachedStrips();
   int accountIndexForId(const QString &id) const;
+  // The account the user is actually looking at: the one shown by whichever
+  // window has the keyboard, which is not m_activeAccount — switching tabs in a
+  // detached window swaps that window's stack without touching the app-wide
+  // "active" account. Any shared action triggered by a key has to ask this, or it
+  // acts on whatever was last clicked in the main window. -1 if there is none.
+  int focusedAccountIndex() const;
   // Most-recently-focused-first list of windows (nullptr = the main window). The
   // front is the "main" window: it receives newly-added accounts, and a closed
   // window's tabs dock into the front-most surviving window.
@@ -488,6 +499,7 @@ private:
   QAction *m_zoomOutAction = nullptr;
   QAction *m_zoomResetAction = nullptr;
   QAction *m_chatListStripAction = nullptr;
+  QAction *m_findChatAction = nullptr;
   QAction *m_translateSelectionAction = nullptr;
   QAction *m_translateComposerAction = nullptr;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -88,6 +88,17 @@ public slots:
   // Bring the window up and give it focus. The tray menu uses it: an action
   // picked from there used to run with the window still behind everything.
   void raiseWindow();
+  // The window the user should be brought to, which is simply the last one they
+  // touched. There is deliberately no "main" window from the user's side: this
+  // one owns the tray icon and the account list, but that is an implementation
+  // detail, and a tray click, a notification or a global shortcut must never haul
+  // it out from behind the window actually being worked in.
+  QWidget *frontWindow() const;
+  // Show, unminimise, raise and activate one window — and nothing else.
+  static void bringForward(QWidget *w);
+  // Every Whatly window, so "hide to tray" takes the whole app away rather than
+  // just this one, which would be another way of showing which is special.
+  QList<QWidget *> allWindows() const;
   void newChat();
   // Whether the account strip stays up with only one account, where it is a row
   // of chrome carrying a single tab. Off by default; the "+" it holds is also

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -941,12 +941,14 @@ void MainWindow::refreshRecentUnread() {
 }
 
 void MainWindow::openChatByName(const QString &accountId, const QString &name) {
-  // A tray pick is a request to use Whatly: raise the window first.
-  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-  show();
-  raise();
-  activateWindow();
+  // A tray pick is a request to use Whatly, so raise a window first — but the one
+  // that actually holds this account, not this one. Picking a chat belonging to a
+  // detached account used to bring this window forward and then switch the chat
+  // in a window the user could not see.
   const int idx = accountIndexForId(accountId);
+  bringForward(idx >= 0 && m_accounts[idx].window
+                   ? static_cast<QWidget *>(m_accounts[idx].window)
+                   : static_cast<QWidget *>(this));
   if (idx >= 0)
     setActiveAccount(idx);
   if (m_webEngine && m_webEngine->page())

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -8,6 +8,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QStandardPaths>
+#include <QApplication>
 #include <QMenu>
 #include <QStackedWidget>
 #include <QPointer>
@@ -737,6 +738,24 @@ int MainWindow::accountIndexForId(const QString &id) const {
   return -1;
 }
 
+int MainWindow::focusedAccountIndex() const {
+  // A detached window shows whatever its own stack is on. Its tab strip swaps
+  // that stack directly and never sets m_activeAccount, so for any window other
+  // than this one the app-wide "active" account is simply the wrong answer.
+  if (auto *win =
+          qobject_cast<DetachedAccountWindow *>(QApplication::activeWindow())) {
+    const QWidget *shown = win->stack()->currentWidget();
+    for (int i = 0; i < m_accounts.size(); ++i)
+      if (m_accounts[i].view == shown)
+        return i;
+  }
+  // The main window, or a key that arrived with no active window at all (a tray
+  // menu item, say) — then the account this window is on is the best answer.
+  if (m_activeAccount >= 0 && m_activeAccount < m_accounts.size())
+    return m_activeAccount;
+  return -1;
+}
+
 // A tab was dropped onto the main strip. Move that account into the main window
 // at slot `insertSlot` among the docked tabs — either reordering a tab already
 // here, or bringing a detached account back in. The just-dropped tab takes
@@ -1263,10 +1282,15 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
   // current account" are deliberately left out: reload, zoom and fullscreen would
   // silently mean the main window's account rather than the one being looked at,
   // which is worse than the shortcut not working.
+  // Find is the one account action that is safe to share, because it asks
+  // focusedAccountIndex() which account the window with the keyboard is showing
+  // instead of assuming the app-wide one. Reload, zoom and fullscreen have no
+  // such answer yet, so they stay out.
   for (QAction *shared :
        {m_settingsAction, m_commandPaletteAction, m_aboutAction, m_quitAction,
         m_toggleThemeAction, m_muteAction, m_lockAction,
-        m_scheduledMessagesAction, m_addAccountAction, m_chatListStripAction})
+        m_scheduledMessagesAction, m_addAccountAction, m_chatListStripAction,
+        m_findChatAction})
     if (shared)
       win->addAction(shared);
   // Moving/resizing the window updates the saved arrangement (debounced).

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -1252,6 +1252,23 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
   // Becoming active makes this window "main" (front of the focus order).
   connect(win, &DetachedAccountWindow::activated, this,
           [this, win]() { noteWindowFocused(win); });
+  // The application-wide actions are carried by the main window, and Qt only
+  // fires a shortcut while a window carrying it is up and active — so with the
+  // main window hidden in the tray and this window in front, Ctrl+P and the rest
+  // did nothing at all, which is the "one window is special" this PR is about.
+  // Attaching the same actions here fixes that: a shortcut fires if ANY window
+  // holding the action qualifies.
+  //
+  // Only the actions that are about the application. The ones that act on "the
+  // current account" are deliberately left out: reload, zoom and fullscreen would
+  // silently mean the main window's account rather than the one being looked at,
+  // which is worse than the shortcut not working.
+  for (QAction *shared :
+       {m_settingsAction, m_commandPaletteAction, m_aboutAction, m_quitAction,
+        m_toggleThemeAction, m_muteAction, m_lockAction,
+        m_scheduledMessagesAction, m_addAccountAction, m_chatListStripAction})
+    if (shared)
+      win->addAction(shared);
   // Moving/resizing the window updates the saved arrangement (debounced).
   connect(win, &DetachedAccountWindow::geometryChanged, this, [this]() {
     if (m_layoutSaveTimer)
@@ -1266,12 +1283,14 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
 void MainWindow::noteWindowFocused(DetachedAccountWindow *win) {
   m_focusOrder.removeAll(win);
   m_focusOrder.prepend(win); // most-recently-focused first; front is "main"
+  refreshWindowsMenu();      // the numbering IS this order
 }
 
 void MainWindow::destroyDetachedWindow(DetachedAccountWindow *win) {
   if (!win)
     return;
   m_focusOrder.removeAll(win);
+  refreshWindowsMenu(); // one window fewer to offer
   win->disconnect(this);
   win->deleteLater();
 }

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -388,9 +388,14 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
 #else
   constexpr int kFrontmostGraceMs = 0;
 #endif
+  // Act on the window the user last touched, not on this one. This window owns
+  // the tray icon, but nothing about the icon says so, and hauling it out from
+  // behind the window actually being worked in is the clearest way of telling the
+  // user that one of their windows is secretly special.
+  QWidget *front = frontWindow();
   const bool frontmost =
-      isVisible() && !isMinimized() &&
-      Utils::wasFrontmostRecently(isActiveWindow(), m_lastDeactivationMs,
+      front->isVisible() && !front->isMinimized() &&
+      Utils::wasFrontmostRecently(front->isActiveWindow(), m_lastDeactivationMs,
                                   QDateTime::currentMSecsSinceEpoch(),
                                   kFrontmostGraceMs);
   const bool minimizeOnClick = SettingsManager::instance()
@@ -400,14 +405,14 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
   if (frontmost) {
     if (minimizeOnClick) {
       lockOnHideIfEnabled();
-      hide();
+      // Every window, not just this one: hiding one and leaving the others is
+      // itself a statement about which window matters.
+      for (QWidget *w : allWindows())
+        w->hide();
     }
     return;
   }
-  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-  show();
-  raise();
-  activateWindow();
+  bringForward(front);
 }
 
 // The tray icon in three independent dimensions: monochrome vs the colourful

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -42,15 +42,30 @@ void MainWindow::createActions() {
   // window, so fall back to an ordinary minimise to the taskbar. This also
   // covers the "minimize in tray on start" setting, which triggers this action.
   //
-  // Every window, not just this one — this action IS the tray's own "put Whatly
-  // away", and leaving the other windows up while the tray shows the app as away
-  // is the same "one window is the real one" that the rest of this PR removes.
+  // Every window by default, not just this one — this action IS the tray's own
+  // "put Whatly away", and leaving the other windows up while the tray shows the
+  // app as away is the same "one window is the real one" that the rest of this
+  // branch removes. Which of the two is wanted is taste rather than correctness,
+  // though, so "minimizeOnlyFocusedWindow" takes it back to one window.
   connect(m_minimizeAction, &QAction::triggered, this, [this]() {
+    const bool onlyFront = SettingsManager::instance()
+                               .settings()
+                               .value("minimizeOnlyFocusedWindow", false)
+                               .toBool();
     if (QSystemTrayIcon::isSystemTrayAvailable() && m_systemTrayIcon &&
-        m_systemTrayIcon->isVisible())
-      hideAllWindows();
-    else
-      showMinimized();
+        m_systemTrayIcon->isVisible()) {
+      if (onlyFront)
+        frontWindow()->hide();
+      else
+        hideAllWindows();
+      return;
+    }
+    // No tray to bring anything back from, so minimise to the taskbar instead —
+    // and the window in front rather than this one, which is the same assumption
+    // again: with a detached window being worked in, Ctrl+W used to minimise the
+    // main window sitting behind it and appear to do nothing.
+    QWidget *w = frontWindow();
+    w->setWindowState(w->windowState() | Qt::WindowMinimized);
   });
   addAction(m_minimizeAction);
 

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include "appprofile.h"
 #include "common.h"
+#include "detachedaccountwindow.h" // windowLabel() compares against a real window
 #include "trayicon.h"
 
 #include <algorithm>
@@ -40,17 +41,24 @@ void MainWindow::createActions() {
   // Ctrl+W — which reads as "close tab" in a tabbed app — would strand the
   // window, so fall back to an ordinary minimise to the taskbar. This also
   // covers the "minimize in tray on start" setting, which triggers this action.
+  //
+  // Every window, not just this one — this action IS the tray's own "put Whatly
+  // away", and leaving the other windows up while the tray shows the app as away
+  // is the same "one window is the real one" that the rest of this PR removes.
   connect(m_minimizeAction, &QAction::triggered, this, [this]() {
     if (QSystemTrayIcon::isSystemTrayAvailable() && m_systemTrayIcon &&
         m_systemTrayIcon->isVisible())
-      hide();
+      hideAllWindows();
     else
       showMinimized();
   });
   addAction(m_minimizeAction);
 
   m_restoreAction = new QAction(tr("&Restore"), this);
-  connect(m_restoreAction, &QAction::triggered, this, &QMainWindow::show);
+  // Restores the whole app, for the same reason: it is the counterpart of the
+  // action above, and it used to show this window alone.
+  connect(m_restoreAction, &QAction::triggered, this,
+          &MainWindow::restoreAllWindows);
   addAction(m_restoreAction);
 
   m_reloadAction = new QAction(tr("Re&load"), this);
@@ -265,6 +273,13 @@ void MainWindow::createTrayIcon() {
   m_trayIconMenu->setObjectName("trayIconMenu");
   m_trayIconMenu->addAction(m_minimizeAction);
   m_trayIconMenu->addAction(m_restoreAction);
+  // Every window, numbered by how recently it was used, so each one can be
+  // reached directly. With no "main" window there is no window the tray is
+  // guaranteed to bring up, and a window can end up behind everything else or
+  // minimised with nothing pointing at it; a list of them is the handle. It hides
+  // itself while there is only one window, which is a list of nothing useful.
+  m_windowsMenu = m_trayIconMenu->addMenu(tr("Windows"));
+  m_windowsMenu->menuAction()->setVisible(false);
   m_trayIconMenu->addSeparator();
   // Recent unread chats (idea #3): populated live from the active account; the
   // submenu hides itself when there is nothing unread.
@@ -296,6 +311,11 @@ void MainWindow::createTrayIcon() {
   connect(m_trayIconMenu, &QMenu::triggered, this, [this](QAction *action) {
     if (action == m_quitAction || action == m_minimizeAction ||
         action == m_toggleThemeAction)
+      return;
+    // The window list names the window to come up, and this signal reaches
+    // submenu entries too — so without this the front window would be hauled up
+    // first and the chosen one only afterwards.
+    if (m_windowsMenu && m_windowsMenu->actions().contains(action))
       return;
     raiseWindow();
     // Settings opens a window of its own, and raising the main window above it
@@ -357,13 +377,85 @@ void MainWindow::createTrayIcon() {
 // harmless: it just raises it. Enabling it unconditionally removes the trap
 // rather than relying on the refresh always happening.
 void MainWindow::checkWindowState() {
-  const bool visible = isVisible();
+  // Any window, not this one: with this window hidden and another in front,
+  // "Minimise to tray" was greyed out while there was plainly something to put
+  // away, and putting it away is exactly what it now does.
+  bool visible = false;
+  for (QWidget *w : allWindows())
+    if (w->isVisible()) {
+      visible = true;
+      break;
+    }
   if (m_minimizeAction)
     m_minimizeAction->setEnabled(visible);
   if (m_restoreAction)
     m_restoreAction->setEnabled(true);
   if (m_lockAction)
     m_lockAction->setEnabled(!(m_lockWidget && m_lockWidget->getIsLocked()));
+  refreshWindowsMenu();
+}
+
+// What a window is called in that list: the accounts it holds. A title would be
+// the WhatsApp page title, which is the chat being read and changes under the
+// user; the accounts are what they arranged the windows BY.
+QString MainWindow::windowLabel(const QWidget *w) const {
+  QStringList names;
+  for (const Account &a : m_accounts) {
+    const bool here = a.window
+                          ? static_cast<const QWidget *>(a.window.data()) == w
+                          : w == this;
+    if (here && !a.name.isEmpty())
+      names << a.name;
+  }
+  if (names.isEmpty())
+    return QApplication::applicationDisplayName();
+  QString label = names.join(QStringLiteral(", "));
+  if (label.size() > 40)
+    label = label.left(39) + QChar(0x2026);
+  return label;
+}
+
+// Entries are REUSED, never cleared and rebuilt, and that is a correctness
+// requirement rather than an economy: picking one brings a window forward, which
+// makes it the most recently used, which comes straight back here — and deleting
+// the action whose signal is still being delivered is a crash. So the pool only
+// grows, spare entries are hidden, and each entry's target is remembered
+// alongside it so a click goes to the window the label described.
+void MainWindow::refreshWindowsMenu() {
+  if (!m_windowsMenu)
+    return;
+  const QList<QWidget *> order = windowsByFocus();
+  QList<QAction *> entries = m_windowsMenu->actions();
+  while (entries.size() < order.size()) {
+    const int slot = entries.size();
+    QAction *entry = m_windowsMenu->addAction(QString());
+    connect(entry, &QAction::triggered, this, [this, slot]() {
+      // Weakly held: a detached window can be closed between the menu being
+      // filled in and an entry being picked, and closing one hands its accounts
+      // back rather than taking them with it — so a stale entry does nothing.
+      if (QWidget *target = m_windowsMenuTargets.value(slot))
+        bringForward(target);
+    });
+    entries << entry;
+  }
+  m_windowsMenuTargets.clear();
+  for (int i = 0; i < entries.size(); ++i) {
+    if (i >= order.size()) {
+      entries[i]->setVisible(false);
+      continue;
+    }
+    QString text = QStringLiteral("%1. %2").arg(i + 1).arg(windowLabel(order[i]));
+    // Hidden and minimised windows are the case this list exists for, so say
+    // which ones those are rather than leaving the user to guess.
+    if (!order[i]->isVisible())
+      text += QStringLiteral("  (") + tr("hidden") + QStringLiteral(")");
+    else if (order[i]->isMinimized())
+      text += QStringLiteral("  (") + tr("minimised") + QStringLiteral(")");
+    entries[i]->setText(text);
+    entries[i]->setVisible(true);
+    m_windowsMenuTargets << QPointer<QWidget>(order[i]);
+  }
+  m_windowsMenu->menuAction()->setVisible(order.size() > 1);
 }
 
 void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
@@ -407,12 +499,15 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
       lockOnHideIfEnabled();
       // Every window, not just this one: hiding one and leaving the others is
       // itself a statement about which window matters.
-      for (QWidget *w : allWindows())
-        w->hide();
+      hideAllWindows();
     }
     return;
   }
-  bringForward(front);
+  // All of it, not just the front one. The click above hides every window, so
+  // this has to show every window: bringing back only the one last used left the
+  // rest hidden, with no window to click and nothing in the tray pointing at
+  // them, so they stayed buried until the app was restarted.
+  restoreAllWindows();
 }
 
 // The tray icon in three independent dimensions: monochrome vs the colourful

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -107,6 +107,20 @@ void MainWindow::createActions() {
           &MainWindow::toggleChatListStrip);
   addAction(m_chatListStripAction);
 
+  // Ctrl+F. WhatsApp Web binds nothing to it: in a browser that key opens the
+  // browser's own find bar, and Qt WebEngine has no find bar, so pressing it in
+  // Whatly did nothing whatsoever. An app whose whole content is a chat list has
+  // to answer Ctrl+F, so we answer it ourselves, with the search box the list
+  // already has.
+  m_findChatAction = new QAction(tr("&Find in chats"), this);
+  m_findChatAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_F));
+  // Reaches whichever window has the keyboard, like the palette: the search box
+  // wanted is the one in the window being typed into.
+  m_findChatAction->setShortcutContext(Qt::ApplicationShortcut);
+  connect(m_findChatAction, &QAction::triggered, this,
+          &MainWindow::focusChatSearch);
+  addAction(m_findChatAction);
+
   m_settingsAction = new QAction(tr("&Settings"), this);
   m_settingsAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_P));
   connect(m_settingsAction, &QAction::triggered, this,
@@ -243,6 +257,7 @@ void MainWindow::createActions() {
       // Registered with no default so it appears in the shortcut sheet and can
       // be bound to whatever the user likes.
       {m_chatListStripAction, "chatListStrip", tr("Collapse the chat list")},
+      {m_findChatAction, "findChat", tr("Find in chats")},
       {m_translateSelectionAction, "translateSelection",
        tr("Translate selection")},
       {m_translateComposerAction, "translateComposer",

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -275,6 +275,13 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           .value("minimizeOnTrayIconClick", false)
           .toBool());
   ui->minimizeOnTrayIconClick->blockSignals(false);
+  ui->minimizeOnlyFocusedWindowCheckBox->blockSignals(true);
+  ui->minimizeOnlyFocusedWindowCheckBox->setChecked(
+      SettingsManager::instance()
+          .settings()
+          .value("minimizeOnlyFocusedWindow", false)
+          .toBool());
+  ui->minimizeOnlyFocusedWindowCheckBox->blockSignals(false);
   ui->defaultDownloadLocation->setText(QDir::toNativeSeparators(
       SettingsManager::instance()
           .settings()
@@ -523,6 +530,9 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                ui->restartNowButton);
     moveWidget(body(window), ui->tabsInTitleBarCheckBox, G);
     moveLayout(body(window), ui->gridLayout_9); // zoom block
+    // Last in the section: it qualifies how the windows this section configures
+    // are put away, rather than being one more of the tray checkboxes above.
+    moveWidget(body(window), ui->minimizeOnlyFocusedWindowCheckBox, G);
 
     // ── Advanced ────────────────────────────────────────────
     auto *advanced = newSection(tr("Advanced"));
@@ -2303,6 +2313,11 @@ void SettingsWidget::on_minimizeOnTrayIconClick_toggled(bool checked) {
                                                   checked);
   if (checked) // needs a tray icon — see on_hideTrayIconCheckBox_toggled
     ui->hideTrayIconCheckBox->setChecked(false);
+}
+
+void SettingsWidget::on_minimizeOnlyFocusedWindowCheckBox_toggled(bool checked) {
+  SettingsManager::instance().settings().setValue("minimizeOnlyFocusedWindow",
+                                                  checked);
 }
 
 void SettingsWidget::on_styleComboBox_currentTextChanged(const QString &arg1) {

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -2479,8 +2479,16 @@ void SettingsWidget::on_chnageCurrentPasswordPushButton_clicked() {
 }
 
 void SettingsWidget::keyPressEvent(QKeyEvent *e) {
-  if (e->key() == Qt::Key_Escape)
+  // Ctrl+W closes this page, exactly as Escape does. Everywhere else in Whatly
+  // that key means "put the window away", and reading it as "put the app in the
+  // tray" while Settings is the window in front is not what anyone pressing it
+  // here means — this is a page you close, and it is the only window that is.
+  if (e->key() == Qt::Key_Escape ||
+      (e->key() == Qt::Key_W && e->modifiers().testFlag(Qt::ControlModifier))) {
     this->close();
+    e->accept();
+    return;
+  }
 
   QWidget::keyPressEvent(e);
 }

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -96,6 +96,7 @@ private slots:
   void on_defaultUserAgentButton_clicked();
   void on_identifyInLinkedDevicesCheckBox_toggled(bool checked);
   void on_minimizeOnTrayIconClick_toggled(bool checked);
+  void on_minimizeOnlyFocusedWindowCheckBox_toggled(bool checked);
   void on_muteAudioCheckBox_toggled(bool checked);
   void on_dismissEmojiPanelCheckBox_toggled(bool checked);
   void on_languageComboBox_currentIndexChanged(int index);

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -517,7 +517,7 @@ background:transparent;
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Off by default, so &amp;quot;Minimise to tray&amp;quot; puts the whole app away: with several windows open, leaving the others on screen while the tray reports Whatly as away is the same confusion as one window being treated as the real one. Tick this to have it put away only the window you are in. Follows whatever key &amp;quot;Minimise to tray&amp;quot; is bound to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
-               <string>Ctrl+W hides only the focused window.</string>
+               <string>Ctrl+W hides only the last focused window.</string>
               </property>
              </widget>
             </item>

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -511,6 +511,16 @@ background:transparent;
               </property>
              </widget>
             </item>
+            <item row="51" column="0">
+             <widget class="QCheckBox" name="minimizeOnlyFocusedWindowCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Off by default, so &amp;quot;Minimise to tray&amp;quot; puts the whole app away: with several windows open, leaving the others on screen while the tray reports Whatly as away is the same confusion as one window being treated as the real one. Tick this to have it put away only the window you are in. Follows whatever key &amp;quot;Minimise to tray&amp;quot; is bound to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Ctrl+W hides only the focused window.</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="0">
              <widget class="QCheckBox" name="minimizeOnTrayIconClick">
               <property name="text">

--- a/src/utils.h
+++ b/src/utils.h
@@ -71,6 +71,26 @@ public:
   // Pure, so it is unit-tested (#8).
   static bool wasFrontmostRecently(bool active, qint64 lastDeactivationMs,
                                    qint64 nowMs, int graceMs);
+
+  // Put `all` in most-recently-used order, given a `history` that is also
+  // most-recent-first and may repeat itself, name things no longer in `all`, and
+  // miss things that have never been used. Anything the history does not mention
+  // goes on the end in `all`'s own order — being unmentioned must not mean being
+  // left out, since this order is what offers the windows to the user, and a
+  // window nothing offers is a window with no way back to it. Pure and a
+  // template, so it is unit-tested without a window in sight.
+  template <typename T>
+  static QList<T> orderedByHistory(const QList<T> &history,
+                                   const QList<T> &all) {
+    QList<T> out;
+    for (const T &item : history)
+      if (all.contains(item) && !out.contains(item))
+        out << item;
+    for (const T &item : all)
+      if (!out.contains(item))
+        out << item;
+    return out;
+  }
 };
 
 #endif // UTILS_H

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2205,6 +2205,16 @@ private slots:
     QVERIFY(js.contains(QLatin1String("a\\\"b")));
     QVERIFY(js.contains(QLatin1String("\\n")));
   }
+  void focusSearchScriptShape() {
+    const QString js = ChatNav::focusSearchScript();
+    QVERIFY(js.contains(QLatin1String(".focus()")));
+    // A locale-independent fallback is required: naming the English (or Spanish)
+    // aria-label alone would leave the key dead on every other language.
+    QVERIFY(js.contains(QLatin1String("#side input")));
+    // Retries, because expanding a collapsed chat list is a round trip through
+    // the app and the box does not exist yet when the script first runs.
+    QVERIFY(js.contains(QLatin1String("setTimeout")));
+  }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2208,8 +2208,16 @@ private slots:
   void focusSearchScriptShape() {
     const QString js = ChatNav::focusSearchScript();
     QVERIFY(js.contains(QLatin1String(".focus()")));
-    // A locale-independent fallback is required: naming the English (or Spanish)
-    // aria-label alone would leave the key dead on every other language.
+    // With a conversation open, Ctrl+F must mean the search WITHIN it — the
+    // magnifier in the chat header — not the chat list's box. data-icon is
+    // WhatsApp's own attribute; the classes around it are obfuscated.
+    QVERIFY(js.contains(QLatin1String("[data-icon^=\"search\"]")));
+    QVERIFY(js.contains(QLatin1String("#main")));
+    // The panel's field is identified by being in neither pane, which is also
+    // what keeps this off the message composer — that lives inside #main.
+    QVERIFY(js.contains(QLatin1String("e.closest('#main')")));
+    // A locale-independent fallback is required for the list search: naming the
+    // English (or Spanish) aria-label alone would leave the key dead elsewhere.
     QVERIFY(js.contains(QLatin1String("#side input")));
     // Retries, because expanding a collapsed chat list is a round trip through
     // the app and the box does not exist yet when the script first runs.

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -714,6 +714,30 @@ private slots:
     // the behaviour is exactly the pre-change isActiveWindow() check.
     QVERIFY(!Utils::wasFrontmostRecently(false, 100000, 100010, 0));
   }
+
+  // The order the tray offers the windows in, and the order they are brought back
+  // in. Strings stand in for windows: the rule is about the two lists, not about
+  // anything a window does.
+  void windowsOrderedByUse() {
+    using L = QList<QString>;
+    const L all{"main", "a", "b", "c"};
+
+    // Most-recently-used first, and the history repeats itself — every window is
+    // re-recorded each time it is activated, so "b, a, b" is the normal shape.
+    QCOMPARE(Utils::orderedByHistory(L{"b", "a", "b"}, all),
+             (L{"b", "a", "main", "c"}));
+
+    // A window never activated is still offered, on the end: leaving it out is
+    // how a window ends up with nothing pointing at it, which is the whole bug.
+    QCOMPARE(Utils::orderedByHistory(L{"c"}, all), (L{"c", "main", "a", "b"}));
+
+    // A history naming a window that has since closed does not resurrect it.
+    QCOMPARE(Utils::orderedByHistory(L{"gone", "a"}, all),
+             (L{"a", "main", "b", "c"}));
+
+    // No history at all: the list as it stands, which is what a fresh start has.
+    QCOMPARE(Utils::orderedByHistory(L{}, all), all);
+  }
   void installTypeFromEnv() {
     qputenv("INSTALL_TYPE", "snap");
     QCOMPARE(Utils::getInstallType(), QStringLiteral("snap"));


### PR DESCRIPTION
**DRAFT — dogfooding on Linux next.**

With accounts torn off into their own windows, every Whatly window is a peer as far as the user is concerned. But one of them owns the tray icon and the account list, and that was visible in a way that reads as a bug: **a tray click raised that window specifically**, so it would jump out from behind whichever window was actually being worked in — with nothing about the tray icon to suggest a link to it.

Reported as: *"the main window comes to the forefront even if it was on the very back, and I find this preposterous."*

## What changes

Everything that brings Whatly forward now brings forward **the window the user last touched**, through a new `frontWindow()`, instead of this one:

- the tray-icon click
- the global "show Whatly" shortcut
- a clicked notification
- `raiseWindow()`, which the tray menu actions use

**A chat picked from the tray menu goes further and raises the window that actually holds that account.** Previously, picking a chat belonging to a detached account raised this window and then switched the chat in a window the user could not see.

**Hiding to the tray now hides every window**, not just this one — hiding one and leaving the others is another way of saying which window is special.

## Already correct, so left alone

The tray *context* menu does not raise anything: `iconActivated()` returns early for the `Context` reason. That was the other half of the report — a right-click leaves the stacking order untouched.

`closeDetachedWindow()` still raises this window when it absorbs a closing window's accounts, which is right: the accounts genuinely moved here, so this is where the user should be looking.

## Note

`m_focusOrder` already tracked activation for both this window and every detached one, so "last touched" needed no new bookkeeping — only for the raise paths to consult it instead of assuming.

Builds clean; `ui_assets`, `logic` and `settings` pass.