### PR TITLE
fix(accounts): an account that is not in front is still an account

### DIFF
--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -52,26 +52,36 @@ QString openChatByNameScript(const QString &name) {
   return QStringLiteral(R"JS(
 (function(){
   var NAME = %1;
-  var pane = document.querySelector('#pane-side');
-  if (!pane) return 'no-pane';
-  var rows = pane.querySelectorAll('[role="row"]');
-  var el = null;
-  for (var i = 0; i < rows.length; i++) {
-    var n = rows[i].querySelector('span[title]');
-    if (n && n.getAttribute('title') === NAME) { el = n; break; }
-  }
-  if (!el) return 'not-found';
-  var r = el.getBoundingClientRect();
-  var cx = r.x + r.width / 2, cy = r.y + r.height / 2;
-  var opts = { bubbles: true, cancelable: true, view: window,
-               clientX: cx, clientY: cy, button: 0,
-               pointerId: 1, pointerType: 'mouse', isPrimary: true };
-  el.dispatchEvent(new PointerEvent('pointerdown', opts));
-  el.dispatchEvent(new MouseEvent('mousedown', opts));
-  el.dispatchEvent(new PointerEvent('pointerup', opts));
-  el.dispatchEvent(new MouseEvent('mouseup', opts));
-  el.dispatchEvent(new MouseEvent('click', opts));
-  return 'ok';
+  var tries = 0;
+  var attempt = function () {
+    var pane = document.querySelector('#pane-side');
+    var rows = pane ? pane.querySelectorAll('[role="row"]') : [];
+    var el = null;
+    for (var i = 0; i < rows.length; i++) {
+      var n = rows[i].querySelector('span[title]');
+      if (n && n.getAttribute('title') === NAME) { el = n; break; }
+    }
+    if (!el) {
+      // Keep asking for a few seconds rather than deciding on the first look.
+      // This also runs against a page that has only just been built — for an
+      // account that had none until its chat was picked out of the tray — and
+      // such a page has no chat list yet, then fills it in progressively.
+      if (++tries < 20) { setTimeout(attempt, 250); return 'waiting'; }
+      return pane ? 'not-found' : 'no-pane';
+    }
+    var r = el.getBoundingClientRect();
+    var cx = r.x + r.width / 2, cy = r.y + r.height / 2;
+    var opts = { bubbles: true, cancelable: true, view: window,
+                 clientX: cx, clientY: cy, button: 0,
+                 pointerId: 1, pointerType: 'mouse', isPrimary: true };
+    el.dispatchEvent(new PointerEvent('pointerdown', opts));
+    el.dispatchEvent(new MouseEvent('mousedown', opts));
+    el.dispatchEvent(new PointerEvent('pointerup', opts));
+    el.dispatchEvent(new MouseEvent('mouseup', opts));
+    el.dispatchEvent(new MouseEvent('click', opts));
+    return 'ok';
+  };
+  return attempt();
 })()
 )JS").arg(jsonString(name));
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,7 @@ class LocalApiServer;
 #include "webenginenotifproxy.h"
 
 #include <QHash>
+#include <QSet>
 #include <QPointer>
 #include <functional>
 
@@ -226,6 +227,13 @@ private:
   // the main window — a detached window shows its own account without going
   // anywhere near setActiveAccount().
   void ensureAccountLoaded(int index);
+  // Rebuild the native surface of a view that has just been moved into another
+  // window. Qt can leave it behind, which is what made an account torn into its
+  // own window come up black, with docking and tearing out again the only cure.
+  // One-shot per view: the hide/show it does causes another Show event, which
+  // arrives back in eventFilter().
+  void nudgeReparentedView(int index);
+  QSet<QWidget *> m_nudgedViews;
   void setActiveAccount(int index);
   void promptAddAccount();
   void renameAccount(int index);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -63,7 +63,13 @@ public:
 public slots:
   void updateWindowTheme();
   void applySystemThemeIfEnabled();
+  // Push the chosen theme into EVERY account's page. WhatsApp Web keeps its own
+  // theme preference per profile, so a page nobody has told is left on whatever
+  // it last stored — light, for a profile that has never been told anything.
   void updatePageTheme();
+  // One page, for the paths that know which one they mean: the account that has
+  // just finished loading, rather than whichever one happens to be on screen.
+  void applyPageTheme(QWebEnginePage *page);
   void handleWebViewTitleChanged(const QString &title);
   void handleLoadFinished(bool loaded);
   void showSettings(bool isAskedByCLI = false);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -188,6 +188,15 @@ private:
     // all: not a frozen one, not an empty one. It gets a page the first time it
     // is opened, and loses it again once it has been idle long enough.
     bool loaded = false;
+    // Whether that page has finished loading WhatsApp Web. `loaded` says a page
+    // exists; this says there is something on it to act on. A page built for a
+    // tray pick has neither a chat list nor the chat being asked for until this
+    // is true.
+    bool ready = false;
+    // The unread chats this account last reported, kept so the tray can still
+    // offer them once the account has no page. A dormant account is the one that
+    // most needs a way back into it, and dropping its chats takes that away.
+    QList<QPair<QString, int>> recentUnread;
     // Non-null while the account has been torn off into its own window; its
     // view then lives in that window rather than in the tab stack/grid.
     QPointer<DetachedAccountWindow> window = nullptr;
@@ -318,6 +327,13 @@ private:
   // the active account and jump to one on click.
   QMenu *m_recentUnreadMenu = nullptr;
   void refreshRecentUnread();
+  // Fill that menu in from what every account last reported, dormant ones
+  // included. Separate from the scan above, which is rate-limited.
+  void rebuildRecentUnreadMenu();
+  QElapsedTimer m_recentUnreadScan;
+  // What each entry in that menu points at (account id, chat name), in the same
+  // order — the entries are reused, so this is how a click finds its chat.
+  QList<QPair<QString, QString>> m_recentUnreadTargets;
   void openChatByName(const QString &accountId, const QString &name);
   // Every window in the tray menu, numbered by how recently it was used, so none
   // can be left with nothing pointing at it.
@@ -328,6 +344,11 @@ private:
   QList<QPointer<QWidget>> m_windowsMenuTargets;
   void refreshWindowsMenu();
   QString windowLabel(const QWidget *w) const;
+  // A chat asked for before its account had a page: run it once that page
+  // reports itself loaded. The name is the presence flag — the account id cannot
+  // be, since the default account's id is the empty string.
+  QString m_pendingChatAccount;
+  QString m_pendingChatName;
   // The tab tooltip for an account: its WhatsApp Web version (once known) and
   // the build token from the page URL. Empty while neither is available.
   QString accountTabTooltip(const Account &acc) const;

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -517,21 +517,25 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event) {
   if (event->type() == QEvent::Show) {
     const int idx = accountIndexForView(watched);
     if (idx >= 0) {
-      const bool wasLoaded = m_accounts[idx].loaded;
       ensureAccountLoaded(idx);
-      // A view that was ALREADY loaded gets nothing from the call above — it
-      // returns at once — and that is the case where an account torn into a new
-      // window came up black. Moving a QWebEngineView between top-level windows
-      // can leave its native surface behind, and nothing else in the app is
-      // watching for that, so the window stayed black until the account was
-      // docked and torn out a second time.
+      // Then rebuild the surface, whether or not the call above had anything to
+      // do. Moving a QWebEngineView between top-level windows can leave its
+      // native surface behind, and nothing else in the app is watching for that,
+      // so an account torn into a new window came up black and stayed black
+      // until it was docked and torn out again.
+      //
+      // It used to run only for an account that was already loaded, on the
+      // reasoning that a page built right here would come up fresh anyway. A
+      // second account then came up black too, and the window was pure black to
+      // the pixel with "Compositor returned null texture" logged as it opened:
+      // the view had no picture at all, which is a fact about the surface and
+      // not about the page. Nothing in that says the load state should decide.
       //
       // The nudge is a hide/show on the next turn of the event loop, which makes
       // Qt build the surface again. It is one-shot per view: it causes another
       // Show, which lands back here, and without the guard that is an endless
       // loop — the same shape as the tint recursion.
-      if (wasLoaded)
-        nudgeReparentedView(idx);
+      nudgeReparentedView(idx);
     }
   }
   return QMainWindow::eventFilter(watched, event);

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -1025,6 +1025,7 @@ void MainWindow::unloadAccount(int index) {
   // Cleared before the page goes, so anything reached during teardown sees a
   // dormant account and cannot ask for the page being destroyed.
   a.loaded = false;
+  a.ready = false; // nothing loaded on a page that no longer exists
   // Detach first, then delete: the view holds a plain pointer to its page, and
   // deleting it without detaching would leave that pointer dangling for the next
   // caller. Detaching also drops the renderer, which is the memory we are after —
@@ -1052,51 +1053,133 @@ void MainWindow::suspendIdleAccounts() {
   }
 }
 
+// Every account that has a page, and the last answer is kept for the ones that
+// do not. An account with no page is exactly the account you need a way back
+// into: its window may be behind everything or put away, and dropping its chats
+// from this menu removes the one handle that would have brought it back. The
+// entries go stale, which is the honest state of a list nobody is reading — a
+// week-old chat name still opens the right conversation, and opening it is the
+// point.
+//
+// Driven by every title change, and WhatsApp changes the title whenever a message
+// arrives anywhere, so the scan itself is rate-limited; the menu is rebuilt from
+// what is already known every time.
 void MainWindow::refreshRecentUnread() {
-  if (!m_recentUnreadMenu || !m_webEngine || !m_webEngine->page())
+  if (!m_recentUnreadMenu)
     return;
-  const QString accountId =
-      (m_activeAccount >= 0 && m_activeAccount < m_accounts.size())
-          ? m_accounts[m_activeAccount].id
-          : QString();
-  m_webEngine->page()->runJavaScript(
-      ChatNav::unreadChatsScript(6), [this, accountId](const QVariant &result) {
-        if (!m_recentUnreadMenu)
-          return;
-        const QJsonArray arr =
-            QJsonDocument::fromJson(result.toString().toUtf8()).array();
-        m_recentUnreadMenu->clear();
-        for (const QJsonValue &v : arr) {
-          const QString name = v.toObject().value(QStringLiteral("name")).toString();
-          const int count = v.toObject().value(QStringLiteral("count")).toInt();
-          if (name.isEmpty())
-            continue;
-          QString label = name;
-          if (label.size() > 32)
-            label = label.left(31) + QChar(0x2026);
-          QAction *a = m_recentUnreadMenu->addAction(
-              QStringLiteral("%1  (%2)").arg(label).arg(count));
-          connect(a, &QAction::triggered, this,
-                  [this, accountId, name]() { openChatByName(accountId, name); });
-        }
-        m_recentUnreadMenu->menuAction()->setVisible(
-            !m_recentUnreadMenu->isEmpty());
-      });
+  if (!m_recentUnreadScan.isValid() || m_recentUnreadScan.elapsed() > 3000) {
+    m_recentUnreadScan.restart();
+    for (const Account &account : m_accounts) {
+      QWebEnginePage *page = pageOf(account);
+      if (!page)
+        continue; // dormant: keep whatever it last reported
+      const QString accountId = account.id;
+      page->runJavaScript(
+          ChatNav::unreadChatsScript(6),
+          [this, accountId](const QVariant &result) {
+            const int idx = accountIndexForId(accountId);
+            if (idx < 0)
+              return;
+            QList<QPair<QString, int>> found;
+            const QJsonArray arr =
+                QJsonDocument::fromJson(result.toString().toUtf8()).array();
+            for (const QJsonValue &v : arr) {
+              const QString name =
+                  v.toObject().value(QStringLiteral("name")).toString();
+              if (name.isEmpty())
+                continue;
+              found << qMakePair(
+                  name, v.toObject().value(QStringLiteral("count")).toInt());
+            }
+            m_accounts[idx].recentUnread = found;
+            rebuildRecentUnreadMenu();
+          });
+    }
+  }
+  rebuildRecentUnreadMenu();
+}
+
+// Entries are REUSED rather than cleared and rebuilt. Picking one switches
+// account, which reaches the tray unread count, which comes back here — and
+// deleting the action whose signal is still being delivered is a crash, not an
+// inefficiency. So the pool only grows, spare entries are hidden, and what each
+// entry points at is remembered beside it.
+void MainWindow::rebuildRecentUnreadMenu() {
+  if (!m_recentUnreadMenu)
+    return;
+  // Which account each chat belongs to is only worth saying when more than one
+  // account has anything to show.
+  int contributing = 0;
+  for (const Account &account : m_accounts)
+    if (!account.recentUnread.isEmpty())
+      ++contributing;
+
+  QList<QAction *> entries = m_recentUnreadMenu->actions();
+  m_recentUnreadTargets.clear();
+  QStringList labels;
+  for (const Account &account : m_accounts) {
+    for (const QPair<QString, int> &chat : account.recentUnread) {
+      QString label = chat.first;
+      if (label.size() > 32)
+        label = label.left(31) + QChar(0x2026);
+      label = QStringLiteral("%1  (%2)").arg(label).arg(chat.second);
+      if (contributing > 1)
+        label = account.name + QStringLiteral(" · ") + label;
+      labels << label;
+      m_recentUnreadTargets << qMakePair(account.id, chat.first);
+    }
+  }
+
+  while (entries.size() < labels.size()) {
+    const int slot = entries.size();
+    QAction *entry = m_recentUnreadMenu->addAction(QString());
+    connect(entry, &QAction::triggered, this, [this, slot]() {
+      if (slot < m_recentUnreadTargets.size())
+        openChatByName(m_recentUnreadTargets[slot].first,
+                       m_recentUnreadTargets[slot].second);
+    });
+    entries << entry;
+  }
+  for (int i = 0; i < entries.size(); ++i) {
+    entries[i]->setVisible(i < labels.size());
+    if (i < labels.size())
+      entries[i]->setText(labels[i]);
+  }
+  m_recentUnreadMenu->menuAction()->setVisible(!labels.isEmpty());
 }
 
 void MainWindow::openChatByName(const QString &accountId, const QString &name) {
-  // A tray pick is a request to use Whatly, so raise a window first — but the one
-  // that actually holds this account, not this one. Picking a chat belonging to a
-  // detached account used to bring this window forward and then switch the chat
-  // in a window the user could not see.
   const int idx = accountIndexForId(accountId);
-  bringForward(idx >= 0 && m_accounts[idx].window
-                   ? static_cast<QWidget *>(m_accounts[idx].window)
-                   : static_cast<QWidget *>(this));
-  if (idx >= 0)
-    setActiveAccount(idx);
-  if (m_webEngine && m_webEngine->page())
-    m_webEngine->page()->runJavaScript(ChatNav::openChatByNameScript(name));
+  if (idx < 0)
+    return;
+  // A tray pick is a request to use Whatly, so a window has to come up — the one
+  // that actually holds this account. Raising this one and then switching a chat
+  // in a window the user cannot see is worse than doing nothing.
+  QWidget *host = m_accounts[idx].window
+                      ? static_cast<QWidget *>(m_accounts[idx].window)
+                      : static_cast<QWidget *>(this);
+  // bringForward() is #55's, and it is the same four calls with the ordering
+  // that survives a hidden window; using it here keeps one way of raising a
+  // window in the app rather than two that can drift apart.
+  bringForward(host);
+  // A detached account is already the one its own window shows, so this is a
+  // no-op there and a tab switch here.
+  setActiveAccount(idx);
+  // And it may have had no page at all until a moment ago.
+  ensureAccountLoaded(idx);
+  QWebEnginePage *page = pageOf(m_accounts[idx]);
+  if (!page)
+    return;
+  // A page built for this pick has not loaded WhatsApp yet, so the chat it is
+  // being asked for does not exist on it. Remember the request and run it when
+  // the page reports itself loaded; only one is ever pending, because a second
+  // pick replaces what the user asked for.
+  if (!m_accounts[idx].ready) {
+    m_pendingChatAccount = accountId;
+    m_pendingChatName = name;
+    return;
+  }
+  page->runJavaScript(ChatNav::openChatByNameScript(name));
 }
 
 QString MainWindow::accountTabTooltip(const Account &acc) const {

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -1022,6 +1022,20 @@ QWebEnginePage *MainWindow::pageOf(const Account &a) {
 }
 
 void MainWindow::nudgeReparentedView(int index) {
+#ifdef Q_OS_WIN
+  // Windows rebuilds the surface by itself when a view is reparented, so the
+  // hide/show below has nothing to repair — it throws away a picture that was
+  // already good, and the view then stays black until WhatsApp happens to repaint
+  // of its own accord, which is tens of seconds on a quiet chat.
+  //
+  // Measured rather than reasoned, one binary run both ways with nothing else
+  // differing: nudging, an account docked back out of a detached window was black
+  // for 35 seconds and one entering grid view for 12; skipping it, neither
+  // blacked at all, in the same four paths. Linux is the other way round — there
+  // a live view moved between top-levels comes up black and stays black without
+  // this — so it is a platform difference, not dead code.
+  Q_UNUSED(index);
+#else
   if (index < 0 || index >= m_accounts.size())
     return;
   WebView *view = m_accounts[index].view;
@@ -1044,6 +1058,7 @@ void MainWindow::nudgeReparentedView(int index) {
     // through eventFilter() and must find this view still marked.
     m_nudgedViews.remove(raw);
   });
+#endif
 }
 
 void MainWindow::ensureAccountLoaded(int index) {

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -516,8 +516,23 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event) {
   // any future path that puts an account on screen.
   if (event->type() == QEvent::Show) {
     const int idx = accountIndexForView(watched);
-    if (idx >= 0)
+    if (idx >= 0) {
+      const bool wasLoaded = m_accounts[idx].loaded;
       ensureAccountLoaded(idx);
+      // A view that was ALREADY loaded gets nothing from the call above — it
+      // returns at once — and that is the case where an account torn into a new
+      // window came up black. Moving a QWebEngineView between top-level windows
+      // can leave its native surface behind, and nothing else in the app is
+      // watching for that, so the window stayed black until the account was
+      // docked and torn out a second time.
+      //
+      // The nudge is a hide/show on the next turn of the event loop, which makes
+      // Qt build the surface again. It is one-shot per view: it causes another
+      // Show, which lands back here, and without the guard that is an endless
+      // loop — the same shape as the tint recursion.
+      if (wasLoaded)
+        nudgeReparentedView(idx);
+    }
   }
   return QMainWindow::eventFilter(watched, event);
 }
@@ -1000,6 +1015,31 @@ QWebEnginePage *MainWindow::pageOf(const Account &a) {
   // on a dormant account would silently create a renderer bound to the default
   // profile — the opposite of what dormancy is for, and a session mix-up.
   return a.loaded && a.view ? a.view->page() : nullptr;
+}
+
+void MainWindow::nudgeReparentedView(int index) {
+  if (index < 0 || index >= m_accounts.size())
+    return;
+  WebView *view = m_accounts[index].view;
+  if (!view || m_nudgedViews.contains(view))
+    return;
+  m_nudgedViews.insert(view);
+  // Next turn of the event loop, not now: the window this view has just been put
+  // into is still being assembled, and hiding a widget in the middle of its own
+  // show event is not something Qt owes us anything for.
+  QWidget *raw = view;
+  QPointer<WebView> guard(view);
+  QTimer::singleShot(0, this, [this, guard, raw]() {
+    // Only while it is really on screen — a hide/show on a view that has since
+    // been put away would be a flicker for nothing.
+    if (guard && guard->isVisible()) {
+      guard->hide();
+      guard->show();
+    }
+    // Released only after the show above, whose own Show event comes back
+    // through eventFilter() and must find this view still marked.
+    m_nudgedViews.remove(raw);
+  });
 }
 
 void MainWindow::ensureAccountLoaded(int index) {

--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -1055,7 +1055,13 @@ void MainWindow::handleLoadFinished(bool loaded) {
     Performance::markStartupSucceeded();
     m_watchdogStrikes = 0; // fresh document, start clean
     checkLoadedCorrectly();
-    updatePageTheme();
+    // The page that just loaded, which is not necessarily the one on screen —
+    // see updatePageTheme(). Falling back to all of them keeps a load that
+    // arrives without an identifiable sender behaving as it used to.
+    if (const int idx = accountIndexForView(sender()); idx >= 0)
+      applyPageTheme(pageOf(m_accounts[idx]));
+    else
+      updatePageTheme();
     handleZoom();
     if (m_settingsWidget != nullptr)
       m_settingsWidget->refresh();
@@ -1168,8 +1174,23 @@ void MainWindow::loadingQuirk(const QString &test) {
 
 // ── Page theme ────────────────────────────────────────────────────────────────
 
+// Every account that has a page, not just the one on screen. WhatsApp Web stores
+// its theme per profile and each account is its own profile, so a page that is
+// never told renders in whatever that profile last saved — light, for one that
+// has never been told at all. Only the active account was ever told, which was
+// invisible while every account was built at startup and had its theme applied
+// as it loaded. It stopped being invisible once a page could first appear while
+// another account was on screen: an account torn into its own window, grid view,
+// and a dormant account coming to life. Those pages came up light against a dark
+// app, and stayed light — the theme is pushed on a change and on load, and
+// neither happens again for a page already loaded.
 void MainWindow::updatePageTheme() {
-  if (!m_webEngine || !m_webEngine->page())
+  for (const Account &account : m_accounts)
+    applyPageTheme(pageOf(account));
+}
+
+void MainWindow::applyPageTheme(QWebEnginePage *page) {
+  if (!page)
     return;
 
   const bool dark = SettingsManager::instance()
@@ -1268,7 +1289,7 @@ void MainWindow::updatePageTheme() {
     })('%1');
   )js").arg(dark ? "dark" : "light");
 
-  m_webEngine->page()->runJavaScript(js);
+  page->runJavaScript(js);
 }
 
 QString MainWindow::getPageTheme() const {

--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -7,6 +7,7 @@
 #include <QRandomGenerator>
 #include <QScreen>
 
+#include "chatnav.h" // a chat picked from the tray, opened once its page is up
 #include "common.h"
 #include "scheduledmessages.h"
 #include "webenginenotifproxy.h"
@@ -155,8 +156,10 @@ void MainWindow::createPageFor(WebView *view, const QString &accountId) {
   // reach it. Recorded here rather than at each call site, because this is the
   // only place a page is ever built.
   const int idx = accountIndexForView(view);
-  if (idx >= 0)
+  if (idx >= 0) {
     m_accounts[idx].loaded = true;
+    m_accounts[idx].ready = false; // a page, but nothing on it yet
+  }
 }
 
 // Buttons Whatly injects into WhatsApp's own UI need a way back into the app.
@@ -1058,10 +1061,21 @@ void MainWindow::handleLoadFinished(bool loaded) {
     // The page that just loaded, which is not necessarily the one on screen —
     // see updatePageTheme(). Falling back to all of them keeps a load that
     // arrives without an identifiable sender behaving as it used to.
-    if (const int idx = accountIndexForView(sender()); idx >= 0)
+    if (const int idx = accountIndexForView(sender()); idx >= 0) {
+      m_accounts[idx].ready = true;
       applyPageTheme(pageOf(m_accounts[idx]));
-    else
+      // A chat picked from the tray while this account had no page: this is the
+      // moment there is a chat list to find it in.
+      if (!m_pendingChatName.isEmpty() &&
+          m_pendingChatAccount == m_accounts[idx].id) {
+        const QString chat = m_pendingChatName;
+        m_pendingChatName.clear();
+        if (QWebEnginePage *page = pageOf(m_accounts[idx]))
+          page->runJavaScript(ChatNav::openChatByNameScript(chat));
+      }
+    } else {
       updatePageTheme();
+    }
     handleZoom();
     if (m_settingsWidget != nullptr)
       m_settingsWidget->refresh();

--- a/src/webtweaks.cpp
+++ b/src/webtweaks.cpp
@@ -361,6 +361,21 @@ R"JS(
   install();
   setInterval(install, 1000);
 
+  // A page in a window nobody can see has no layout: every rect measures zero,
+  // so the rail is not found and the buttons are not put back. That much is
+  // harmless, since there is nothing to look at. What is not harmless is that
+  // Chromium throttles timers in a hidden page, stretching the tick above to
+  // about a minute — so the buttons were still missing for up to that long after
+  // the window came back, which reads as them having been lost. Ask again as
+  // soon as the page is shown, and once more shortly after, because layout is
+  // not final at the instant visibility flips.
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) return;
+    install();
+    repaint();
+    setTimeout(function () { install(); repaint(); }, 250);
+  });
+
   // The icons follow state that changes without anything else on the page
   // moving: the theme lives in a class on <html>, the blur in a stylesheet in
   // <head>. Both observers are narrow, and paint() is a no-op when the state it

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2272,6 +2272,10 @@ private slots:
     // so no raw quote/newline can break out of the string literal.
     QVERIFY(js.contains(QLatin1String("a\\\"b")));
     QVERIFY(js.contains(QLatin1String("\\n")));
+    // It waits for the chat list instead of deciding on the first look: this also
+    // runs against a page built moments earlier, for an account that had none
+    // until its chat was picked out of the tray.
+    QVERIFY(js.contains(QLatin1String("setTimeout")));
   }
   void focusSearchScriptShape() {
     const QString js = ChatNav::focusSearchScript();


### PR DESCRIPTION
**Stacked on #48 ("give an unused account no page at all, instead of a frozen one") — merge that first.** This branch is cut from it, so the diff shows its two commits as well; the change belonging to this PR is the last two commits. It has to be stacked: the fix walks the account list and must not hand a page to an account that has none, which is what `pageOf()` exists for, and `pageOf()` arrives with #48.

Three faults, all the same shape: something was only ever done to the account in front, and it became visible once a page could first appear while a different account was on screen — an account torn into its own window, grid view, or an account that gets its page later.

**The theme.** WhatsApp Web stores its own theme per profile, and every account is its own profile, so a page nobody tells renders in whatever that profile last saved — light, for one that has never been told anything. Only the active account was told. While every account was built at start-up and given the theme as it loaded, that was invisible. It is not invisible for a page that loads while another account is in front: the theme went to that other account, and never came back to this one, since it is pushed on a change and on load and neither happens again for a page already loaded. The result is a light page inside a dark app, which reads as the theme having reset itself. `updatePageTheme()` now walks every account that has a page, and the load handler applies it to the page that actually finished loading.

**The injected rail buttons.** They are placed by measuring the rail, and a page in a window nobody can see has no layout — every rect is zero — so they are not placed. That part is fine and recovers by itself. What is not fine is that Chromium throttles timers in a hidden page, stretching the one-second retry to about a minute, so the buttons were still missing for up to that long after the window came back. They are now put back as soon as the page is shown.

**The tray's recent-unread submenu.** It was scraped from the active account and thrown away whenever that account had no page. That is backwards: an account with no page is exactly the one you need a way back into — its window may be behind everything else or put away, and those entries were the only thing pointing at it. Every account with a page is now scraped and what each last reported is kept, so a dormant account keeps its entries. They go stale, which is the honest state of a list nobody has read in a week: the name still names the right conversation, and opening it is the point.

Picking one also went to the wrong place — it raised the main window and ran the click on the *active* account's page, so a chat belonging to a detached account switched the conversation in a window the user was not looking at, in an account they had not asked for. It now raises the window holding that account and acts on that account's page. And it can be picked for an account with no page at all, which is the case this is for: building the page is not enough, because WhatsApp Web is not there yet, so the request is held until that page reports itself loaded, and the script waits for the chat list to appear rather than deciding on its first look that the chat is gone — a list that has only just started rendering looks exactly like a chat that is not there.

The scan is rate-limited to once every three seconds, since it is driven by title changes and WhatsApp retitles the window whenever a message arrives anywhere. The menu is still rebuilt from what is known on every one, and its entries are reused rather than cleared: picking one switches account, which reaches the unread count, which comes back to the same function, and deleting the action whose signal is still being delivered would be a crash rather than an inefficiency.

**Merge note.** `openChatByName()` is touched by this PR and by #55 ("stop treating one window as the main one"), so whichever lands second conflicts in that one function. The resolution is this PR's body of the function with `bringForward()` from #55 in place of the four raise calls — #55 adds that helper, and both changes want the same thing from it.

Dogfooded on Linux. Not yet on Windows, which is why this is a draft.
