### PR TITLE
fix(accounts): tear off the tab that was dragged, not the one now in its slot

### DIFF
--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -41,21 +41,22 @@ int AccountTabBar::dropSlotAt(int x) const {
 }
 
 int AccountTabBar::indexOfAccount(const QString &id) const {
-  if (id.isEmpty())
-    return -1;
   for (int i = 0; i < count(); ++i)
-    if (tabData(i).toString() == id)
+    // Validity first: the "+" affordance carries no tab data, and the default
+    // account's id is the empty string, so comparing ids alone would either
+    // match the affordance or refuse to find the default account.
+    if (tabData(i).isValid() && tabData(i).toString() == id)
       return i;
   return -1;
 }
 
 void AccountTabBar::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton) {
-    // Remember the account, not the slot. An empty id covers both "the + tab"
-    // (no tab data) and "no tab here at all", which is what the slot number used
-    // to be checked for.
-    m_pressId = tabData(tabAt(event->position().toPoint())).toString();
-    m_pressPos = event->position().toPoint();
+    // Remember the account, not the slot. The tab data itself, not the id it
+    // holds: the default account's id is "", so an id alone cannot be told from
+    // "no account here" — and treating it as nothing left the one account most
+    // people have as the one account that could not be torn off.
+    m_pressData = tabData(tabAt(event->position().toPoint()));
   }
   QTabBar::mousePressEvent(event);
 }
@@ -64,11 +65,11 @@ void AccountTabBar::mouseMoveEvent(QMouseEvent *event) {
   // While the cursor stays within the strip, QTabBar reorders tabs live. Once
   // it leaves the strip vertically, hand off to a QDrag that tears the tab off
   // or docks it into another window.
-  if (!m_pressId.isEmpty() && (event->buttons() & Qt::LeftButton)) {
+  if (m_pressData.isValid() && (event->buttons() & Qt::LeftButton)) {
     const QPoint p = event->position().toPoint();
     if (p.y() < -kDetachMargin || p.y() > height() + kDetachMargin) {
-      const QString id = m_pressId;
-      m_pressId.clear();
+      const QString id = m_pressData.toString();
+      m_pressData.clear();
       // End QTabBar's in-progress move before starting the drag.
       QMouseEvent release(QEvent::MouseButtonRelease, event->position(),
                           event->globalPosition(), Qt::LeftButton,
@@ -81,14 +82,14 @@ void AccountTabBar::mouseMoveEvent(QMouseEvent *event) {
       // release also means the tabs have settled into the order on screen.
       const int index = indexOfAccount(id);
       if (index >= 0)
-        startDrag(index);
+        startDrag(index, p);
       return;
     }
   }
   QTabBar::mouseMoveEvent(event);
 }
 
-void AccountTabBar::startDrag(int index) {
+void AccountTabBar::startDrag(int index, const QPoint &cursorPos) {
   const QString id = tabData(index).toString();
   const QRect r = tabRect(index);
   const QPixmap sprite = grab(r); // the tab's own pixels, as the drag cursor
@@ -98,7 +99,14 @@ void AccountTabBar::startDrag(int index) {
   mime->setData(kAccountTabMime, id.toUtf8());
   drag->setMimeData(mime);
   drag->setPixmap(sprite);
-  drag->setHotSpot(m_pressPos - r.topLeft());
+  // Hold the sprite where the cursor actually is. The press position cannot be
+  // used for this any more: a drag that slid the tab past its neighbours on the
+  // way out ends with the tab somewhere else entirely, so an offset measured from
+  // where it was first grabbed leaves the sprite hanging at a distance from the
+  // pointer. Vertically the cursor is by definition outside the strip — that is
+  // what started the drag — so the grip goes to the middle of the tab.
+  drag->setHotSpot(QPoint(qBound(0, cursorPos.x() - r.left(), r.width()),
+                          r.height() / 2));
 
   // Over the desktop or another app nothing accepts our private mime, so the
   // platform would show the "forbidden" cursor — misleading, since we always

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -56,7 +56,12 @@ void AccountTabBar::mousePressEvent(QMouseEvent *event) {
     // holds: the default account's id is "", so an id alone cannot be told from
     // "no account here" — and treating it as nothing left the one account most
     // people have as the one account that could not be torn off.
-    m_pressData = tabData(tabAt(event->position().toPoint()));
+    const int pressed = tabAt(event->position().toPoint());
+    m_pressData = tabData(pressed);
+    // Take the sprite now, while the strip is still. By the time a drag starts,
+    // QTabBar has slid the tabs around and is animating them, so a grab there
+    // catches two tabs mid-swap and draws halves of both.
+    m_pressSprite = pressed >= 0 ? grab(tabRect(pressed)) : QPixmap();
   }
   QTabBar::mousePressEvent(event);
 }
@@ -92,7 +97,11 @@ void AccountTabBar::mouseMoveEvent(QMouseEvent *event) {
 void AccountTabBar::startDrag(int index, const QPoint &cursorPos) {
   const QString id = tabData(index).toString();
   const QRect r = tabRect(index);
-  const QPixmap sprite = grab(r); // the tab's own pixels, as the drag cursor
+  // The tab's own pixels, as the drag cursor — taken at press time, because
+  // grabbing here would catch the reorder animation. Falling back to a live grab
+  // only covers a drag that somehow began without a press.
+  const QPixmap sprite = m_pressSprite.isNull() ? grab(r) : m_pressSprite;
+  m_pressSprite = QPixmap();
 
   auto *drag = new QDrag(this);
   auto *mime = new QMimeData;

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -40,9 +40,21 @@ int AccountTabBar::dropSlotAt(int x) const {
   return n;
 }
 
+int AccountTabBar::indexOfAccount(const QString &id) const {
+  if (id.isEmpty())
+    return -1;
+  for (int i = 0; i < count(); ++i)
+    if (tabData(i).toString() == id)
+      return i;
+  return -1;
+}
+
 void AccountTabBar::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton) {
-    m_pressIndex = tabAt(event->position().toPoint());
+    // Remember the account, not the slot. An empty id covers both "the + tab"
+    // (no tab data) and "no tab here at all", which is what the slot number used
+    // to be checked for.
+    m_pressId = tabData(tabAt(event->position().toPoint())).toString();
     m_pressPos = event->position().toPoint();
   }
   QTabBar::mousePressEvent(event);
@@ -52,18 +64,24 @@ void AccountTabBar::mouseMoveEvent(QMouseEvent *event) {
   // While the cursor stays within the strip, QTabBar reorders tabs live. Once
   // it leaves the strip vertically, hand off to a QDrag that tears the tab off
   // or docks it into another window.
-  if (m_pressIndex >= 0 && (event->buttons() & Qt::LeftButton) &&
-      tabData(m_pressIndex).isValid()) { // a real account tab, not the "+"
+  if (!m_pressId.isEmpty() && (event->buttons() & Qt::LeftButton)) {
     const QPoint p = event->position().toPoint();
     if (p.y() < -kDetachMargin || p.y() > height() + kDetachMargin) {
-      const int index = m_pressIndex;
-      m_pressIndex = -1;
+      const QString id = m_pressId;
+      m_pressId.clear();
       // End QTabBar's in-progress move before starting the drag.
       QMouseEvent release(QEvent::MouseButtonRelease, event->position(),
                           event->globalPosition(), Qt::LeftButton,
                           Qt::NoButton, event->modifiers());
       QTabBar::mouseReleaseEvent(&release);
-      startDrag(index);
+      // Only now ask where that account sits. Taking the slot from the press
+      // instead was the bug: drag a tab out on a path that slid it past its
+      // neighbours first, and the slot pressed had come to hold one of THEM, so
+      // the wrong account was torn into the new window. Resolving after the
+      // release also means the tabs have settled into the order on screen.
+      const int index = indexOfAccount(id);
+      if (index >= 0)
+        startDrag(index);
       return;
     }
   }

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -26,6 +26,12 @@ class AccountTabBar : public QTabBar {
 public:
   explicit AccountTabBar(QWidget *parent = nullptr);
 
+  // Which slot currently holds the account `id`, or -1. Public because it is the
+  // whole point of storing the id: a tab's slot is not stable for as long as a
+  // drag lasts, so anything that has to name a tab later must ask this rather
+  // than remember a number.
+  int indexOfAccount(const QString &id) const;
+
 signals:
   // The drag for account `id` ended at `globalPos`. Fired for EVERY drag,
   // whatever exec() reported — a QWebEngineView under the cursor may "accept"
@@ -52,7 +58,10 @@ private:
   // How far outside the strip (px) the cursor must go before a within-strip
   // reorder becomes a tear-off / cross-window drag.
   static constexpr int kDetachMargin = 24;
-  int m_pressIndex = -1;
+  // The account pressed, not the slot it was pressed in. QTabBar reorders tabs
+  // live under the cursor while the button is down, so a slot number captured on
+  // press stops meaning that account the moment the drag moves sideways.
+  QString m_pressId;
   QPoint m_pressPos;
   int m_dropSlot = -1; // insertion slot to paint while a drag hovers, or -1
 };

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -4,6 +4,7 @@
 #include <QPoint>
 #include <QString>
 #include <QTabBar>
+#include <QVariant>
 
 class QMouseEvent;
 class QDragEnterEvent;
@@ -51,7 +52,9 @@ protected:
   void paintEvent(QPaintEvent *event) override;
 
 private:
-  void startDrag(int index);
+  // `cursorPos` is where the pointer was when the drag began, in strip
+  // coordinates; it sets where the sprite hangs off the cursor.
+  void startDrag(int index, const QPoint &cursorPos);
   int accountTabCount() const;   // tabs backing a real account (valid tab data)
   int dropSlotAt(int x) const;   // insertion slot for a cursor x position
 
@@ -61,8 +64,12 @@ private:
   // The account pressed, not the slot it was pressed in. QTabBar reorders tabs
   // live under the cursor while the button is down, so a slot number captured on
   // press stops meaning that account the moment the drag moves sideways.
-  QString m_pressId;
-  QPoint m_pressPos;
+  //
+  // Held as the tab data itself rather than as a QString, because the DEFAULT
+  // account's id is the empty string and a bare id cannot tell it apart from
+  // "there is no account here". Validity is the question being asked; the "+"
+  // affordance is the one carrying no data at all.
+  QVariant m_pressData;
   int m_dropSlot = -1; // insertion slot to paint while a drag hovers, or -1
 };
 

--- a/src/accounttabbar.h
+++ b/src/accounttabbar.h
@@ -1,6 +1,7 @@
 #ifndef ACCOUNTTABBAR_H
 #define ACCOUNTTABBAR_H
 
+#include <QPixmap>
 #include <QPoint>
 #include <QString>
 #include <QTabBar>
@@ -70,6 +71,10 @@ private:
   // "there is no account here". Validity is the question being asked; the "+"
   // affordance is the one carrying no data at all.
   QVariant m_pressData;
+  // The tab's pixels, taken at press time. Grabbing them when the drag starts
+  // catches QTabBar's reorder animation in flight, which draws halves of two
+  // different tabs into the sprite; at press the strip is stationary.
+  QPixmap m_pressSprite;
   int m_dropSlot = -1; // insertion slot to paint while a drag hovers, or -1
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(tst_logic
     ${S}/networkproxy.cpp ${S}/autostart.cpp ${S}/portalnotification.cpp
     ${S}/notificationreply.cpp
     ${S}/setupwizard.cpp
+    ${S}/accounttabbar.cpp
     ${S}/icons.qrc
 )
 target_include_directories(tst_logic PRIVATE ${S} ${CMAKE_BINARY_DIR})

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2213,6 +2213,29 @@ private slots:
     QCOMPARE(bar.indexOfAccount(QString()), -1);
     QCOMPARE(bar.indexOfAccount(QStringLiteral("nope")), -1);
   }
+
+  // The DEFAULT account's id is the empty string (MainWindow::Account::id), and
+  // the "+" affordance is the tab with no data at all. Telling those two apart by
+  // asking whether the id is empty makes the default account — the only account
+  // most people have — the one account that cannot be dragged out of the strip.
+  // It is the validity of the tab data that separates them, not the id.
+  void defaultAccountIsATabLikeAnyOther() {
+    AccountTabBar bar;
+    bar.setTabData(bar.addTab(QStringLiteral("Default")), QString()); // id ""
+    bar.setTabData(bar.addTab(QStringLiteral("Work")), QStringLiteral("w1"));
+    bar.addTab(QStringLiteral("+"));  // no data: not an account
+
+    QCOMPARE(bar.indexOfAccount(QString()), 0);
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("w1")), 1);
+    // The affordance is never an account, and its slot must not be reachable by
+    // asking for an id that no tab holds.
+    QVERIFY(!bar.tabData(2).isValid());
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("nope")), -1);
+    // And it still follows the default account through a reorder.
+    bar.moveTab(0, 1);
+    QCOMPARE(bar.indexOfAccount(QString()), 1);
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("w1")), 0);
+  }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -67,6 +67,7 @@
 #include "linkeddevicename.h"
 #include "performance.h"
 #include "trayicon.h"
+#include "accounttabbar.h"
 #include "chatnav.h"
 #include "dropattach.h"
 #include "dropreader.h"
@@ -2184,6 +2185,37 @@ private slots:
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// AccountTabBar: a tab being dragged has to be identified by its account, never
+// by the slot it was pressed in. QTabBar reorders tabs live under the cursor, so
+// a slot number captured on press stops meaning that account as soon as the drag
+// moves sideways — and tearing off read that slot, so the neighbour was torn out
+// instead. The mouse path itself ends in QDrag::exec(), which blocks and cannot
+// be driven from a test; what is checked here is the identity it now relies on.
+class TstAccountTabBar : public QObject {
+  Q_OBJECT
+private slots:
+  void accountFollowsItsTabThroughAReorder() {
+    AccountTabBar bar;
+    for (const QString &id : {QStringLiteral("a1"), QStringLiteral("a2"),
+                              QStringLiteral("a3"), QStringLiteral("a4")})
+      bar.setTabData(bar.addTab(id), id);
+    bar.addTab(QStringLiteral("+")); // the affordance, deliberately without data
+
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("a3")), 2);
+    // moveTab is exactly what QTabBar's live reorder does while a tab is dragged
+    // past its neighbour, which is the trajectory that produced the wrong window.
+    bar.moveTab(2, 1);
+    // The slot that was pressed now holds a different account …
+    QCOMPARE(bar.tabData(2).toString(), QStringLiteral("a2"));
+    // … while the account pressed is still found, one slot to the left.
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("a3")), 1);
+    // The "+" tab is not an account, and neither is anything unknown.
+    QCOMPARE(bar.indexOfAccount(QString()), -1);
+    QCOMPARE(bar.indexOfAccount(QStringLiteral("nope")), -1);
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // CustomJs: the addon manager stores files, tracks per-addon enabled state, and
 // builds a combined guarded script. Runs in QStandardPaths test mode.
 class TstCustomJs : public QObject {
@@ -3362,6 +3394,7 @@ int main(int argc, char *argv[]) {
   { TstDropReader t;          run(&t); }
   { TstFlatpakManifest t;     run(&t); }
   { TstChatNav t;             run(&t); }
+  { TstAccountTabBar t;       run(&t); }
   { TstShortcuts t;           run(&t); }
   { TstBackup t;              run(&t); }
   { TstScreenLock t;          run(&t); }


### PR DESCRIPTION
Dragging a tab straight up out of the strip tears off that account. Dragging it out on a path that slides it past its neighbours first tears off one of **them** — pull the third tab out sideways and the second leaves.

The strip already stores each account's stable id in its tab data, and the drag payload already carries that id. The tear-off did not use it: it started from the slot number captured in `mousePressEvent`, and `setMovable(true)` means QTabBar reorders the tabs live under the cursor while the button is held. By the time the cursor cleared the strip, the slot pressed held a different account, so `tabData()` at that slot named the neighbour — and that is the account that went into the new window.

So the press records the account rather than the slot, and the slot is looked up when the drag actually begins — after the synthesised release, which is also the first point where the tabs have settled into the order on screen. An empty id covers both cases the old slot check covered: the "+" affordance, which has no tab data, and no tab under the cursor at all.

**On the test.** The mouse path ends in `QDrag::exec()`, which blocks, so it cannot be driven from a test; what is tested is the identity the path now depends on. `moveTab()` is what QTabBar's live reorder calls, so the reorder is simulated with it, and both halves of the bug are asserted: the pressed slot has come to hold the neighbour, while the account pressed is still found, one slot to the left.

Found by dogfooding on Linux — it is in the notes of a round that was looking at something else entirely. Dogfooding on Windows next; draft until both are done.
