### PR TITLE
fix(media): point the codec notice at a build that exists

### DIFF
--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -1011,6 +1011,11 @@ Bonvolu unue agordi la pasvorton en la Agordoj.
         <translation>Ĉi tiu muntaĵo ne povas sendi H.264/MP4-videojn: ĝia retumila motoro estis muntita sen la proprietaj kodekoj. Fotoj kaj WebM/VP9-videoj funkcias; por MP4 uzu distribuan/denaskan pakon muntitan kun la kodekoj. (Alklaku por forigi.)</translation>
     </message>
     <message>
+        <location filename="../mainwindow_webengine.cpp" line="1104"/>
+        <source>This build cannot send H.264/MP4 videos: its browser engine was built without the proprietary codecs. Photos and WebM/VP9 videos work. For MP4, use the Flatpak, whose engine is built with them. (Click to dismiss.)</source>
+        <translation>Ĉi tiu muntaĵo ne povas sendi H.264/MP4-videojn: ĝia retumila motoro estis muntita sen la proprietaj kodekoj. Fotoj kaj WebM/VP9-videoj funkcias. Por MP4 uzu la Flatpak-version, kies motoro estas muntita kun ili. (Alklaku por forigi.)</translation>
+    </message>
+    <message>
         <location filename="../mainwindow_webengine.cpp" line="1379"/>
         <source>Inline translation is off (enable it in Settings → Translation).</source>
         <translation>Enteksta traduko estas malŝaltita (ŝaltu ĝin en Agordoj → Traduko).</translation>

--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -1101,10 +1101,27 @@ void MainWindow::checkMediaCodecs() {
                                                         true);
         if (m_webEngine && m_webEngine->page())
           m_webEngine->page()->runJavaScript(Translate::toastScript(
+#ifdef Q_OS_LINUX
+              // On the Debian family the advice below names something nobody can
+              // get: the app's floor is Qt 6.9, Ubuntu 24.04 — Mint 22.x's base —
+              // offers 6.4.2, and no current Debian or Ubuntu release ships a Qt
+              // WebEngine that is both new enough and codec-enabled. The Flatpak
+              // builds against io.qt.qtwebengine.BaseApp and does have them, so
+              // it is the one build a reader can act on today.
+              tr("This build cannot send H.264/MP4 videos: its browser engine "
+                 "was built without the proprietary codecs. Photos and WebM/VP9 "
+                 "videos work. For MP4, use the Flatpak, whose engine is built "
+                 "with them. (Click to dismiss.)"),
+#else
+              // Left exactly as it was everywhere else, and deliberately: there
+              // is no Flatpak off Linux, and this sentence already has its
+              // twenty translations. Naming the right build on Windows is a
+              // question for whoever makes them.
               tr("This build cannot send H.264/MP4 videos: its browser engine "
                  "was built without the proprietary codecs. Photos and WebM/VP9 "
                  "videos work; for MP4, use a distro/native package built with "
                  "the codecs. (Click to dismiss.)"),
+#endif
               /*persistent=*/true));
       });
 }


### PR DESCRIPTION
Closes nothing on its own, but it is the loose end from #53 "Can't send or view videos".

When the engine cannot play H.264, Whatly shows a one-time notice explaining why a video will not send. The explanation is right; the advice at the end is not. It says to "use a distro/native package built with the codecs", and on the Debian family that is not a thing anyone can do:

- Whatly's floor is Qt 6.9.
- Ubuntu 24.04 — Mint 22.x's base, and where most Debian-family desktops are — offers `libqt6webenginecore6` 6.4.2.

So there is no Debian or Ubuntu release currently shipping a Qt WebEngine that is both new enough for the app **and** codec-enabled. The sentence sent the reporter of #53 looking for a package that does not exist. It now names the Flatpak, which builds against `io.qt.qtwebengine.BaseApp` and does have the codecs compiled in — the one build a reader can actually go and get today.

The Esperanto string follows the change; the other locales fall back to English for it, as they do for any source string that changes.

**One thing I have left alone, and would rather you decided.** The notice is shown at most *once ever* — a flag is stored the first time and it never returns. That is why the reporter could not say whether he had seen it: if it appeared months ago and was dismissed, its absence now means nothing. Showing it once per session, or again when a video attach actually fails, would both be defensible; changing when a notice fires is a different decision from fixing what it says, so this PR only does the latter.

Nothing to dogfood on Linux: the Flatpak has the codecs, so it never shows this notice. Verified the string lands in the compiled `eo.qm` and that the old one is gone.

**Not a draft any more, and it is not going to become testable by waiting.** The only build that shows this notice is a codec-less one, which is exactly the build nobody here runs — so "look at it on a build that does show it" is a condition that would hold the PR open indefinitely. The change is text-only: one source string, the platform branch around it, and the matching `eo` translation. Nothing else can move. Good to merge as it stands.
