### PR TITLE
fix(web): put the sidebar buttons back when WhatsApp rebuilds the rail around them

### DIFF
--- a/src/webtweaks.cpp
+++ b/src/webtweaks.cpp
@@ -276,12 +276,34 @@ R"JS(
     }
     return null;
   };
+  // The container our entries were inserted into, remembered so that "is the
+  // button still there?" can be answered without measuring anything.
+  var railParent = null;
   // Is every button that should be there, there — and none that should not be?
-  // Two getElementById calls. This runs on a timer, so it must not touch layout.
+  // Getting this wrong in the lenient direction is unrecoverable, because it is
+  // also the stop condition for the retry timer below: anything it calls settled
+  // is never looked at again for the life of the page.
+  //
+  // It used to ask only whether an element with the id existed and was connected
+  // to the document. That is not the same question. WhatsApp rebuilds this rail,
+  // and when it re-parents the container our entry is sitting in, the entry stays
+  // in the document — connected, findable by id, and nowhere near the sidebar. So
+  // the buttons vanished, the timer concluded there was nothing to do, and they
+  // stayed gone until the page was destroyed: a restart was the only cure, and
+  // toggling the setting did not help either, because that path calls install()
+  // too. Verified live over the debugging protocol: entries moved out of the rail
+  // but left in the document were never restored, through four ticks and an
+  // explicit reinstall.
+  //
+  // So require the entry to still be a child of the container we put it in. Both
+  // tests are pointer comparisons against a remembered node — no queries, and
+  // still nothing that forces layout, which is what this being on a timer demands.
   var settled = function () {
     for (var n = 0; n < BUTTONS.length; n++) {
       var entry = document.getElementById(BUTTONS[n].id);
-      if (BUTTONS[n].enabled() !== !!(entry && entry.isConnected)) return false;
+      var placed = !!(entry && entry.isConnected && railParent &&
+                      railParent.isConnected && entry.parentElement === railParent);
+      if (BUTTONS[n].enabled() !== placed) return false;
     }
     return true;
   };
@@ -299,7 +321,14 @@ R"JS(
           if (existing) existing.remove();
           continue;
         }
-        if (existing && existing.isConnected) continue;
+        // In place: nothing to do. Present but no longer in the rail: it is the
+        // stranded entry described above, and skipping it here was the second half
+        // of the same bug — the id was taken, so a replacement could never be
+        // built. Destroy it and fall through to make a new one.
+        if (existing && existing.isConnected && railParent &&
+            railParent.isConnected && existing.parentElement === railParent)
+          continue;
+        if (existing) existing.remove();
 
         var rail = railButtons();
         var avatar = null, template = null;
@@ -338,6 +367,9 @@ R"JS(
         })(spec), true);
 
         avatarWrapper.parentElement.insertBefore(entry, avatarWrapper);
+        // Remember where they went, so settled() can tell "still in the rail"
+        // from "still in the document".
+        railParent = avatarWrapper.parentElement;
       }
     } catch (e) { /* never break the page */ }
   };

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -537,6 +537,28 @@ private slots:
     QVERIFY(src.contains(QLatin1String("emoji-variant")));
   }
 
+  // The rail buttons' retry must be able to tell "still in the rail" from "still
+  // in the document". Asking only the latter made a stranded entry permanent:
+  // it is the stop condition for the retry timer, so once satisfied the buttons
+  // were never rebuilt, and only destroying the page brought them back. Confirmed
+  // live before the fix, so this guards the shape of the condition.
+  void webTweaksRailButtonsRecoverFromReparenting() {
+    const QString src = WebTweaks::scriptSource();
+    // The remembered container, and the two comparisons against it.
+    QVERIFY(src.contains(QLatin1String("railParent")));
+    QVERIFY(src.contains(QLatin1String("entry.parentElement === railParent")));
+    QVERIFY(src.contains(QLatin1String("existing.parentElement === railParent")));
+    // A stranded entry must be removed rather than skipped, or its id stays taken
+    // and no replacement can be built.
+    QVERIFY(src.contains(QLatin1String("if (existing) existing.remove();")));
+    // Still nothing on the timer path that forces layout.
+    const int settledAt = src.indexOf(QLatin1String("var settled = function"));
+    const int installAt = src.indexOf(QLatin1String("var install = function"));
+    QVERIFY(settledAt > 0 && installAt > settledAt);
+    QVERIFY(!src.mid(settledAt, installAt - settledAt)
+                 .contains(QLatin1String("getBoundingClientRect")));
+  }
+
   // #7: the always-on HD receive flag script overrides wa_web_show_hd_photo.
   void webTweaksHdFlagScript() {
     const QString hd = WebTweaks::hdFlagScriptSource();


### PR DESCRIPTION
The buttons Whatly adds to WhatsApp's nav rail sometimes never appear, or vanish and stay gone, with a restart the only cure. This has been reported from Linux dogfooding more than once and read as flaky placement. It is not: placement is fine, the **stop condition** is wrong.

A timer calls `install()` every second, and `install()` returns at once when `settled()` says there is nothing to do. `settled()` asked whether an element with each id exists and is connected to the document. That is not the same question as *is the button in the sidebar*. WhatsApp rebuilds this rail; when it re-parents the container an entry sits in, the entry stays in the document — connected, findable by id, and nowhere near the sidebar. From then on `settled()` reported success forever, and the retry that exists for exactly this case never ran again.

`install()` carried the second half of the same mistake: `if (existing && existing.isConnected) continue` **skipped** the stranded entry, so even a corrected `settled()` could not have rebuilt it — the id was already taken.

## Confirmed on a live page before changing anything

Reproduced over the remote debugging protocol against a running build, by moving the six entries out of the rail into a hidden container while leaving them in the document — the state WhatsApp's own re-parenting produces:

| | rail buttons | ours in rail | present | visible | `settled()` |
|---|---|---|---|---|---|
| before | 13 | 6 | 6 | 6 | true |
| entries stranded | 7 | 0 | 6 | **0** | **true** |
| four ticks later | 7 | 0 | 6 | **0** | **true** |
| after calling the reinstall hook Settings uses | 7 | 0 | 6 | **0** | **true** |
| entries deleted outright | 13 | 6 | 6 | 6 | true |

Four seconds is four ticks of the installer and it did nothing. The explicit reinstall hook did nothing either — which is why toggling the setting off and on is not a workaround. Destroying the nodes was the only recovery, and that is precisely what a restart does.

## The fix

Remember the container the entries were inserted into, and require an entry to still be a child of it; remove a stranded entry instead of skipping it. Both tests are pointer comparisons against a remembered node — **no queries, nothing that forces layout**, which is what running on a timer demands and the reason the original check was written as loosely as it was. The comment above `settled()` says so, since that constraint is the whole reason this went wrong.

The test asserts the shape of the condition and, separately, that nothing between `settled()` and `install()` calls `getBoundingClientRect` — the property that must not regress.

Independent of the other open PRs. It touches the same file as #57 "fix(accounts): an account that is not in front is still an account", which adds a `visibilitychange` handler further down; different region, so they should merge cleanly either way round.

Dogfooding on Linux next, then Windows; draft until both.
