### PR TITLE
feat(window): say which version is running, where someone would look for it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ set(SOURCES
     src/mainwindow_webengine.cpp
     src/detachedaccountwindow.cpp
     src/accounttabbar.cpp
+    src/lingertip.cpp
     src/permissiondialog.cpp
     src/rateapp.cpp
     src/settingswidget.cpp
@@ -265,6 +266,7 @@ set(HEADERS
     src/mainwindow.h
     src/detachedaccountwindow.h
     src/accounttabbar.h
+    src/lingertip.h
     src/notificationpopup.h
     src/permissiondialog.h
     src/rateapp.h

--- a/src/accounttabbar.cpp
+++ b/src/accounttabbar.cpp
@@ -1,5 +1,8 @@
 #include "accounttabbar.h"
 
+#include "lingertip.h"
+#include "utils.h"
+
 #include <QApplication>
 #include <QCursor>
 #include <QDrag>
@@ -22,6 +25,13 @@ AccountTabBar::AccountTabBar(QWidget *parent) : QTabBar(parent) {
   // Live within-strip reordering: the tabs slide as you drag. Leaving the strip
   // vertically hands off to a QDrag (tear-off / cross-window) in mouseMove.
   setMovable(true);
+  // Which build this is, for whoever asks. This strip is where it lives because
+  // it is the one piece of chrome that is ours in every window: the title bar
+  // above may be the system's, and then nothing on it could carry an answer.
+  // Off the tabs themselves, which have their own names to show, and only for a
+  // pointer that has stopped — see LingerTip for why five seconds.
+  LingerTip::install(this, Utils::appNameWithVersion(),
+                     [this](const QPoint &p) { return tabAt(p) < 0; });
 }
 
 int AccountTabBar::accountTabCount() const {

--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -1,9 +1,12 @@
 #include "customtitlebar.h"
 #include "settingsmanager.h"
+#include "utils.h"
 
 #include <QApplication>
+#include <QFont>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QPalette>
 #include <QMouseEvent>
 #include <QStyle>
 #include <QToolButton>
@@ -38,7 +41,38 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     // here would either clip the tabs or paint a band that does not match them.
     // The empty space left of the buttons is what the window is dragged by.
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    layout->addStretch(1);
+    // With the title bar gone there is nowhere else the version could be shown,
+    // so it goes in the space the tabs do not use — the same run of empty strip
+    // that the window is dragged by. Three things make that work:
+    //   * Ignored horizontally with no minimum, so the layout may shrink it to
+    //     nothing. The text is then simply cut off, which is the right answer
+    //     here: the tabs are what the row is for, and this must never push them.
+    //   * Transparent to mouse events, or it would swallow the presses that drag
+    //     the window and this area would stop working.
+    //   * Dimmed, because it is a label and not a control.
+    m_version = new QLabel(Utils::versionLabel(), this);
+    m_version->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    m_version->setMinimumWidth(0);
+    m_version->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    m_version->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_version->setToolTip(Utils::appNameWithVersion());
+    // Small and faint on purpose: it sits in the same row as the tabs, so it has
+    // to read as a watermark rather than as another label competing with them.
+    // Being small is also what lets a long build label fit before the space runs
+    // out. Point and pixel sizes both handled — a font set in pixels reports -1
+    // for its point size, and scaling that would make the text vanish.
+    QFont vf = m_version->font();
+    if (vf.pointSizeF() > 0)
+      vf.setPointSizeF(qMax(6.0, vf.pointSizeF() * 0.78));
+    else if (vf.pixelSize() > 0)
+      vf.setPixelSize(qMax(8, int(vf.pixelSize() * 0.78)));
+    m_version->setFont(vf);
+    QPalette vp = m_version->palette();
+    QColor dim = vp.color(QPalette::WindowText);
+    dim.setAlphaF(0.45);
+    vp.setColor(QPalette::WindowText, dim);
+    m_version->setPalette(vp);
+    layout->addWidget(m_version, 1);
   }
 
   const QStyle *st = style();

--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -3,13 +3,16 @@
 #include "utils.h"
 
 #include <QApplication>
+#include <QCursor>
 #include <QFont>
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QPalette>
 #include <QMouseEvent>
 #include <QStyle>
+#include <QTimer>
 #include <QToolButton>
+#include <QToolTip>
 #include <QWindow>
 
 namespace {
@@ -36,13 +39,11 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     m_title = new QLabel(window->windowTitle(), this);
     layout->addWidget(m_title, 1);
 
-    // The version goes at the far end of the row, so the title keeps the whole
-    // left-hand side it has always had and the two never fight for the middle.
-    // Same watermark treatment as the merged strip, so the answer to "which
-    // build is this?" looks the same wherever it is read.
-    m_version = new QLabel(Utils::versionLabel(), this);
-    m_version->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    layout->addWidget(m_version);
+    // Neither of them takes the mouse. The whole row left of the buttons is what
+    // the window is dragged by, and a label that answered a press would put a
+    // dead patch in the middle of it — and swallow the hover the bar answers.
+    m_icon->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    m_title->setAttribute(Qt::WA_TransparentForMouseEvents, true);
   } else {
     // No fixed height and no background of its own: the tab strip beside it
     // sets the row's height and draws the row's background, and anything else
@@ -81,24 +82,37 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     else if (vf.pixelSize() > 0)
       vf.setPixelSize(qMax(8, int(vf.pixelSize() * 0.78)));
     m_version->setFont(vf);
-    // The colour is the background nudged a fifth of the way towards the text
-    // colour. Dimming the text colour instead was still too loud, and it also
+    // A fifth of the way from the background towards the text colour, which
     // needs no light/dark special case: whichever way round the theme is, this
-    // lands just off the background.
-    QPalette vp = m_version->palette();
-    const QColor bg = vp.color(QPalette::Window);
-    const QColor fg = vp.color(QPalette::WindowText);
-    const auto toward = [](int from, int to) {
-      return from + int(0.2 * (to - from));
-    };
-    vp.setColor(QPalette::WindowText,
-                QColor(toward(bg.red(), fg.red()), toward(bg.green(), fg.green()),
-                       toward(bg.blue(), fg.blue())));
-    m_version->setPalette(vp);
-    // The whole bar answers the hover: the label is transparent to the mouse,
-    // and the version is the only thing in this row anyone would hover for.
-    setToolTip(Utils::appNameWithVersion());
+    // lands just off the background. Done with opacity rather than by working
+    // the colour out and setting it, because a colour here does not survive:
+    // updateWindowTheme() hands the application palette to every child of the
+    // main window, and this is one of them, so the main window's copy came out
+    // at full strength while a detached window's — which that loop never
+    // reaches — was the quiet one this is meant to be. Opacity is not a
+    // palette, and it blends against whatever is really painted behind.
+    auto *fade = new QGraphicsOpacityEffect(m_version);
+    fade->setOpacity(0.2);
+    m_version->setGraphicsEffect(fade);
   }
+
+  // Which build this is, on demand. The bar answers the hover in both modes:
+  // merged, because the label is transparent to the mouse and cannot; and
+  // standalone, because there the version is not on show at all. Five seconds
+  // of stillness rather than the usual fraction of one — nobody rests a hand
+  // here by accident, and a tip that appeared every time one crossed the strip
+  // on its way to the tabs would be worse than the loud label it replaced.
+  setMouseTracking(true);
+  m_tipTimer = new QTimer(this);
+  m_tipTimer->setSingleShot(true);
+  m_tipTimer->setInterval(5000);
+  connect(m_tipTimer, &QTimer::timeout, this, [this]() {
+    const QPoint p = mapFromGlobal(QCursor::pos());
+    // Not over a button: those have tooltips of their own, and childAt() passes
+    // straight through the version label, which is transparent to the mouse.
+    if (rect().contains(p) && !childAt(p))
+      QToolTip::showText(QCursor::pos(), Utils::appNameWithVersion(), this);
+  });
 
   const QStyle *st = style();
   auto makeButton = [&](QStyle::StandardPixmap pm, const QString &tip) {
@@ -175,6 +189,25 @@ void CustomTitleBar::mouseDoubleClickEvent(QMouseEvent *event) {
     return;
   }
   QWidget::mouseDoubleClickEvent(event);
+}
+
+void CustomTitleBar::enterEvent(QEnterEvent *event) {
+  m_tipTimer->start();
+  QWidget::enterEvent(event);
+}
+
+void CustomTitleBar::mouseMoveEvent(QMouseEvent *event) {
+  // Every move puts the wait back to the beginning, so the tip answers a hand
+  // that has stopped here rather than one on its way somewhere else.
+  QToolTip::hideText();
+  m_tipTimer->start();
+  QWidget::mouseMoveEvent(event);
+}
+
+void CustomTitleBar::leaveEvent(QEvent *event) {
+  m_tipTimer->stop();
+  QToolTip::hideText();
+  QWidget::leaveEvent(event);
 }
 
 void CustomTitleBar::toggleMaximized() {

--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -1,18 +1,14 @@
 #include "customtitlebar.h"
+#include "lingertip.h"
 #include "settingsmanager.h"
 #include "utils.h"
 
 #include <QApplication>
-#include <QCursor>
-#include <QFont>
-#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QStyle>
-#include <QTimer>
 #include <QToolButton>
-#include <QToolTip>
 #include <QWindow>
 
 namespace {
@@ -50,69 +46,32 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     // here would either clip the tabs or paint a band that does not match them.
     // The empty space left of the buttons is what the window is dragged by.
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    // With the title bar gone there is nowhere else the version could be shown,
-    // so it goes in the space the tabs do not use — the same run of empty strip
-    // that the window is dragged by. Ignored horizontally with no minimum, so
-    // the layout may shrink it to nothing: the text is then simply cut off,
-    // which is the right answer here. The tabs are what the row is for, and this
-    // must never push them.
-    m_version = new QLabel(Utils::versionLabel(), this);
-    m_version->setMinimumWidth(0);
-    m_version->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-    m_version->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    layout->addWidget(m_version, 1);
-  }
+    // The same title a standalone bar shows, in the space the tabs do not use —
+    // this row is the title bar, so it should say what a title bar says. Small
+    // and faint: the tabs are what the row is for, and this must not read as
+    // another label competing with them. Ignored horizontally with no minimum,
+    // so the layout may shrink it to nothing and the text is simply cut off,
+    // which is the right answer here — it must never push the tabs.
+    m_title = new QLabel(window->windowTitle(), this);
+    m_title->setMinimumWidth(0);
+    m_title->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    m_title->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    Utils::makeWatermark(m_title);
+    layout->addWidget(m_title, 1);
 
-  if (m_version) {
     // Transparent to mouse events, or it would swallow the presses that drag the
-    // window and the strip it sits in would stop working. That costs it its own
-    // tooltip, so the tooltip goes on the bar instead — see below, where it also
-    // answers a hover anywhere in the empty run, which is where a hand goes
-    // looking.
-    m_version->setAttribute(Qt::WA_TransparentForMouseEvents, true);
-    // Small and faint on purpose: it shares a row with the tabs or the title, so
-    // it has to read as a watermark rather than as another label competing with
-    // them. Being small is also what lets a long build label fit before the
-    // space runs out. Point and pixel sizes both handled — a font set in pixels
-    // reports -1 for its point size, and scaling that would make the text
-    // vanish.
-    QFont vf = m_version->font();
-    if (vf.pointSizeF() > 0)
-      vf.setPointSizeF(qMax(6.0, vf.pointSizeF() * 0.78));
-    else if (vf.pixelSize() > 0)
-      vf.setPixelSize(qMax(8, int(vf.pixelSize() * 0.78)));
-    m_version->setFont(vf);
-    // A fifth of the way from the background towards the text colour, which
-    // needs no light/dark special case: whichever way round the theme is, this
-    // lands just off the background. Done with opacity rather than by working
-    // the colour out and setting it, because a colour here does not survive:
-    // updateWindowTheme() hands the application palette to every child of the
-    // main window, and this is one of them, so the main window's copy came out
-    // at full strength while a detached window's — which that loop never
-    // reaches — was the quiet one this is meant to be. Opacity is not a
-    // palette, and it blends against whatever is really painted behind.
-    auto *fade = new QGraphicsOpacityEffect(m_version);
-    fade->setOpacity(0.2);
-    m_version->setGraphicsEffect(fade);
+    // window and the run of strip it sits in would stop working. That costs it
+    // its own tooltip, which is no loss: the one worth having here belongs to
+    // the whole run, not to wherever the text happens to reach.
+    m_title->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    // Which build this is, for the one person in a hundred who wants to know.
+    // Only in this mode: a bar the system draws has no such run and no tooltip
+    // either, so putting it on a bar of ours as well would make it an answer
+    // that appears and disappears with a setting.
+    LingerTip::install(this, Utils::appNameWithVersion(),
+                       // Not over the window buttons; they have their own tips.
+                       [this](const QPoint &p) { return childAt(p) == nullptr; });
   }
-
-  // Which build this is, on demand. The bar answers the hover in both modes:
-  // merged, because the label is transparent to the mouse and cannot; and
-  // standalone, because there the version is not on show at all. Five seconds
-  // of stillness rather than the usual fraction of one — nobody rests a hand
-  // here by accident, and a tip that appeared every time one crossed the strip
-  // on its way to the tabs would be worse than the loud label it replaced.
-  setMouseTracking(true);
-  m_tipTimer = new QTimer(this);
-  m_tipTimer->setSingleShot(true);
-  m_tipTimer->setInterval(5000);
-  connect(m_tipTimer, &QTimer::timeout, this, [this]() {
-    const QPoint p = mapFromGlobal(QCursor::pos());
-    // Not over a button: those have tooltips of their own, and childAt() passes
-    // straight through the version label, which is transparent to the mouse.
-    if (rect().contains(p) && !childAt(p))
-      QToolTip::showText(QCursor::pos(), Utils::appNameWithVersion(), this);
-  });
 
   const QStyle *st = style();
   auto makeButton = [&](QStyle::StandardPixmap pm, const QString &tip) {
@@ -191,25 +150,6 @@ void CustomTitleBar::mouseDoubleClickEvent(QMouseEvent *event) {
   QWidget::mouseDoubleClickEvent(event);
 }
 
-void CustomTitleBar::enterEvent(QEnterEvent *event) {
-  m_tipTimer->start();
-  QWidget::enterEvent(event);
-}
-
-void CustomTitleBar::mouseMoveEvent(QMouseEvent *event) {
-  // Every move puts the wait back to the beginning, so the tip answers a hand
-  // that has stopped here rather than one on its way somewhere else.
-  QToolTip::hideText();
-  m_tipTimer->start();
-  QWidget::mouseMoveEvent(event);
-}
-
-void CustomTitleBar::leaveEvent(QEvent *event) {
-  m_tipTimer->stop();
-  QToolTip::hideText();
-  QWidget::leaveEvent(event);
-}
-
 void CustomTitleBar::toggleMaximized() {
   if (m_window->isMaximized())
     m_window->showNormal();
@@ -228,7 +168,7 @@ void CustomTitleBar::refreshMaximizeIcon() {
 
 bool CustomTitleBar::eventFilter(QObject *watched, QEvent *event) {
   if (watched == m_window) {
-    // Merged mode has neither label — the tabs say which window this is.
+    // Both modes have a title; only a standalone bar has the icon beside it.
     if (event->type() == QEvent::WindowTitleChange && m_title)
       m_title->setText(m_window->windowTitle());
     else if (event->type() == QEvent::WindowIconChange && m_icon)

--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -35,6 +35,14 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
 
     m_title = new QLabel(window->windowTitle(), this);
     layout->addWidget(m_title, 1);
+
+    // The version goes at the far end of the row, so the title keeps the whole
+    // left-hand side it has always had and the two never fight for the middle.
+    // Same watermark treatment as the merged strip, so the answer to "which
+    // build is this?" looks the same wherever it is read.
+    m_version = new QLabel(Utils::versionLabel(), this);
+    m_version->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    layout->addWidget(m_version);
   } else {
     // No fixed height and no background of its own: the tab strip beside it
     // sets the row's height and draws the row's background, and anything else
@@ -43,36 +51,53 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     // With the title bar gone there is nowhere else the version could be shown,
     // so it goes in the space the tabs do not use — the same run of empty strip
-    // that the window is dragged by. Three things make that work:
-    //   * Ignored horizontally with no minimum, so the layout may shrink it to
-    //     nothing. The text is then simply cut off, which is the right answer
-    //     here: the tabs are what the row is for, and this must never push them.
-    //   * Transparent to mouse events, or it would swallow the presses that drag
-    //     the window and this area would stop working.
-    //   * Dimmed, because it is a label and not a control.
+    // that the window is dragged by. Ignored horizontally with no minimum, so
+    // the layout may shrink it to nothing: the text is then simply cut off,
+    // which is the right answer here. The tabs are what the row is for, and this
+    // must never push them.
     m_version = new QLabel(Utils::versionLabel(), this);
-    m_version->setAttribute(Qt::WA_TransparentForMouseEvents, true);
     m_version->setMinimumWidth(0);
     m_version->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     m_version->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    m_version->setToolTip(Utils::appNameWithVersion());
-    // Small and faint on purpose: it sits in the same row as the tabs, so it has
-    // to read as a watermark rather than as another label competing with them.
-    // Being small is also what lets a long build label fit before the space runs
-    // out. Point and pixel sizes both handled — a font set in pixels reports -1
-    // for its point size, and scaling that would make the text vanish.
+    layout->addWidget(m_version, 1);
+  }
+
+  if (m_version) {
+    // Transparent to mouse events, or it would swallow the presses that drag the
+    // window and the strip it sits in would stop working. That costs it its own
+    // tooltip, so the tooltip goes on the bar instead — see below, where it also
+    // answers a hover anywhere in the empty run, which is where a hand goes
+    // looking.
+    m_version->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    // Small and faint on purpose: it shares a row with the tabs or the title, so
+    // it has to read as a watermark rather than as another label competing with
+    // them. Being small is also what lets a long build label fit before the
+    // space runs out. Point and pixel sizes both handled — a font set in pixels
+    // reports -1 for its point size, and scaling that would make the text
+    // vanish.
     QFont vf = m_version->font();
     if (vf.pointSizeF() > 0)
       vf.setPointSizeF(qMax(6.0, vf.pointSizeF() * 0.78));
     else if (vf.pixelSize() > 0)
       vf.setPixelSize(qMax(8, int(vf.pixelSize() * 0.78)));
     m_version->setFont(vf);
+    // The colour is the background nudged a fifth of the way towards the text
+    // colour. Dimming the text colour instead was still too loud, and it also
+    // needs no light/dark special case: whichever way round the theme is, this
+    // lands just off the background.
     QPalette vp = m_version->palette();
-    QColor dim = vp.color(QPalette::WindowText);
-    dim.setAlphaF(0.45);
-    vp.setColor(QPalette::WindowText, dim);
+    const QColor bg = vp.color(QPalette::Window);
+    const QColor fg = vp.color(QPalette::WindowText);
+    const auto toward = [](int from, int to) {
+      return from + int(0.2 * (to - from));
+    };
+    vp.setColor(QPalette::WindowText,
+                QColor(toward(bg.red(), fg.red()), toward(bg.green(), fg.green()),
+                       toward(bg.blue(), fg.blue())));
     m_version->setPalette(vp);
-    layout->addWidget(m_version, 1);
+    // The whole bar answers the hover: the label is transparent to the mouse,
+    // and the version is the only thing in this row anyone would hover for.
+    setToolTip(Utils::appNameWithVersion());
   }
 
   const QStyle *st = style();

--- a/src/customtitlebar.cpp
+++ b/src/customtitlebar.cpp
@@ -32,7 +32,7 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     m_icon->setPixmap(window->windowIcon().pixmap(18, 18));
     layout->addWidget(m_icon);
 
-    m_title = new QLabel(window->windowTitle(), this);
+    m_title = new QLabel(barTitle(), this);
     layout->addWidget(m_title, 1);
 
     // Neither of them takes the mouse. The whole row left of the buttons is what
@@ -52,7 +52,7 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
     // another label competing with them. Ignored horizontally with no minimum,
     // so the layout may shrink it to nothing and the text is simply cut off,
     // which is the right answer here — it must never push the tabs.
-    m_title = new QLabel(window->windowTitle(), this);
+    m_title = new QLabel(barTitle(), this);
     m_title->setMinimumWidth(0);
     m_title->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     m_title->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
@@ -102,6 +102,18 @@ CustomTitleBar::CustomTitleBar(QWidget *window, QWidget *parent, Mode mode)
   // Keep the icon/title/maximise glyph in sync with the window.
   m_window->installEventFilter(this);
   refreshMaximizeIcon();
+}
+
+QString CustomTitleBar::barTitle() const {
+  // What the platform writes on a frame it draws, written here because on this
+  // one nothing else will: the application's name and the window's own title,
+  // once each. Qt appends the name to every window title at the platform layer,
+  // so the title itself must not carry one — that is what made the system's own
+  // title bar read "Whatly: WhatsApp — Whatly", and a detached window's read the
+  // name twice with a dash on either side of it.
+  const QString title = m_window->windowTitle();
+  const QString name = QApplication::applicationDisplayName();
+  return title.isEmpty() ? name : name + QStringLiteral(": ") + title;
 }
 
 bool CustomTitleBar::isEnabled() {
@@ -170,7 +182,7 @@ bool CustomTitleBar::eventFilter(QObject *watched, QEvent *event) {
   if (watched == m_window) {
     // Both modes have a title; only a standalone bar has the icon beside it.
     if (event->type() == QEvent::WindowTitleChange && m_title)
-      m_title->setText(m_window->windowTitle());
+      m_title->setText(barTitle());
     else if (event->type() == QEvent::WindowIconChange && m_icon)
       m_icon->setPixmap(m_window->windowIcon().pixmap(18, 18));
     else if (event->type() == QEvent::WindowStateChange)

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -41,6 +41,11 @@ protected:
   bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
+  // The window's title with the application's name in front of it. Window titles
+  // themselves no longer carry the name, because Qt appends it to every one of
+  // them for the system's title bar, the task list and Alt-Tab; a bar we draw
+  // has no such platform behind it, so it puts the name back itself.
+  QString barTitle() const;
   void toggleMaximized();
   void refreshMaximizeIcon();
 

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -47,6 +47,8 @@ private:
   QWidget *m_window = nullptr;
   QLabel *m_icon = nullptr;
   QLabel *m_title = nullptr;
+  // Merged mode only: the version, in the strip space the tabs leave.
+  QLabel *m_version = nullptr;
   QToolButton *m_maxButton = nullptr;
 };
 

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -4,7 +4,6 @@
 #include <QWidget>
 
 class QLabel;
-class QTimer;
 class QToolButton;
 
 // A slim client-side title bar for the optional frameless-window mode. It is only
@@ -17,9 +16,9 @@ class CustomTitleBar : public QWidget {
   Q_OBJECT
 public:
   // Standalone is the bar described above: its own row, with the icon and the
-  // window title. Merged drops both and keeps only the window buttons, so it
-  // can sit at the right-hand end of the account tab strip and let the tabs
-  // themselves be the title bar — Chrome-style, one row instead of two.
+  // window title. Merged drops the icon and shrinks the title to a watermark,
+  // so it can sit at the right-hand end of the account tab strip and let the
+  // tabs themselves be the title bar — Chrome-style, one row instead of two.
   enum class Mode { Standalone, Merged };
 
   // `window` is the top-level window this bar decorates.
@@ -39,9 +38,6 @@ public:
 protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
-  void mouseMoveEvent(QMouseEvent *event) override;
-  void enterEvent(QEnterEvent *event) override;
-  void leaveEvent(QEvent *event) override;
   bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
@@ -50,14 +46,11 @@ private:
 
   QWidget *m_window = nullptr;
   QLabel *m_icon = nullptr;
+  // The window title. Its own row in a standalone bar, beside the app icon; in
+  // the run of strip the tabs leave in a merged one, small and faint, because
+  // there it is sharing a row that has a job already.
   QLabel *m_title = nullptr;
-  // The version, in the strip space the tabs leave in a merged bar. A standalone
-  // one has a title to show instead, and shows only that: the version there was
-  // a second thing in a row that already had a job, and it read as one.
-  QLabel *m_version = nullptr;
   QToolButton *m_maxButton = nullptr;
-  // Counts out the stillness a hover has to hold before the tooltip appears.
-  QTimer *m_tipTimer = nullptr;
 };
 
 #endif // CUSTOMTITLEBAR_H

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -47,7 +47,8 @@ private:
   QWidget *m_window = nullptr;
   QLabel *m_icon = nullptr;
   QLabel *m_title = nullptr;
-  // Merged mode only: the version, in the strip space the tabs leave.
+  // The version: at the right-hand end of a standalone bar, and in the strip
+  // space the tabs leave in a merged one.
   QLabel *m_version = nullptr;
   QToolButton *m_maxButton = nullptr;
 };

--- a/src/customtitlebar.h
+++ b/src/customtitlebar.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class QLabel;
+class QTimer;
 class QToolButton;
 
 // A slim client-side title bar for the optional frameless-window mode. It is only
@@ -38,6 +39,9 @@ public:
 protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
+  void mouseMoveEvent(QMouseEvent *event) override;
+  void enterEvent(QEnterEvent *event) override;
+  void leaveEvent(QEvent *event) override;
   bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
@@ -47,10 +51,13 @@ private:
   QWidget *m_window = nullptr;
   QLabel *m_icon = nullptr;
   QLabel *m_title = nullptr;
-  // The version: at the right-hand end of a standalone bar, and in the strip
-  // space the tabs leave in a merged one.
+  // The version, in the strip space the tabs leave in a merged bar. A standalone
+  // one has a title to show instead, and shows only that: the version there was
+  // a second thing in a row that already had a job, and it read as one.
   QLabel *m_version = nullptr;
   QToolButton *m_maxButton = nullptr;
+  // Counts out the stillness a hover has to hold before the tooltip appears.
+  QTimer *m_tipTimer = nullptr;
 };
 
 #endif // CUSTOMTITLEBAR_H

--- a/src/lingertip.cpp
+++ b/src/lingertip.cpp
@@ -1,0 +1,74 @@
+#include "lingertip.h"
+
+#include <QCursor>
+#include <QEnterEvent>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QTimer>
+#include <QToolTip>
+#include <QWidget>
+
+namespace {
+// Long enough that nobody arrives at it on the way somewhere else.
+const int kDelayMs = 5000;
+} // namespace
+
+void LingerTip::install(QWidget *widget, QString text,
+                        std::function<bool(const QPoint &)> eligible) {
+  if (widget)
+    new LingerTip(widget, std::move(text), std::move(eligible));
+}
+
+LingerTip::LingerTip(QWidget *widget, QString text,
+                     std::function<bool(const QPoint &)> eligible)
+    : QObject(widget), m_widget(widget), m_text(std::move(text)),
+      m_eligible(std::move(eligible)) {
+  // Without this a move only arrives while a button is held, and this is about a
+  // hand resting on something rather than pressing it.
+  m_widget->setMouseTracking(true);
+  m_widget->installEventFilter(this);
+
+  m_timer = new QTimer(this);
+  m_timer->setSingleShot(true);
+  m_timer->setInterval(kDelayMs);
+  connect(m_timer, &QTimer::timeout, this, [this]() {
+    const QPoint pos = m_widget->mapFromGlobal(QCursor::pos());
+    if (m_widget->isVisible() && m_widget->rect().contains(pos) &&
+        eligibleAt(pos))
+      QToolTip::showText(QCursor::pos(), m_text, m_widget);
+  });
+}
+
+bool LingerTip::eligibleAt(const QPoint &pos) const {
+  return !m_eligible || m_eligible(pos);
+}
+
+bool LingerTip::eventFilter(QObject *watched, QEvent *event) {
+  if (watched == m_widget) {
+    switch (event->type()) {
+    case QEvent::Enter:
+      if (eligibleAt(static_cast<QEnterEvent *>(event)->position().toPoint()))
+        m_timer->start();
+      break;
+    case QEvent::MouseMove: {
+      // Only ever take back this tip. Hiding whatever happens to be on screen
+      // would put out the tooltip of the tab the pointer has just moved onto.
+      if (QToolTip::isVisible() && QToolTip::text() == m_text)
+        QToolTip::hideText();
+      if (eligibleAt(static_cast<QMouseEvent *>(event)->position().toPoint()))
+        m_timer->start();
+      else
+        m_timer->stop();
+      break;
+    }
+    case QEvent::Leave:
+      if (QToolTip::isVisible() && QToolTip::text() == m_text)
+        QToolTip::hideText();
+      m_timer->stop();
+      break;
+    default:
+      break;
+    }
+  }
+  return QObject::eventFilter(watched, event);
+}

--- a/src/lingertip.h
+++ b/src/lingertip.h
@@ -1,0 +1,45 @@
+#ifndef LINGERTIP_H
+#define LINGERTIP_H
+
+#include <QObject>
+#include <QPoint>
+#include <QString>
+
+#include <functional>
+
+class QTimer;
+class QWidget;
+
+// A tooltip that waits for the pointer to stop. Qt's own appears after a
+// fraction of a second, which is right for a control with something to explain
+// and wrong for a run of chrome someone is only crossing: what this answers is
+// not urgent, and a tip that flashed up every time a hand passed over the tabs
+// would be worse than no answer at all.
+//
+// Five seconds of stillness, put back to the beginning by every move, and gone
+// again the moment the pointer moves.
+class LingerTip : public QObject {
+  Q_OBJECT
+public:
+  // Watch `widget` and show `text` over it. `eligible` says which of its points
+  // answer at all, so the parts that have tooltips of their own — the tabs, the
+  // window buttons — keep them. The instance is owned by the widget.
+  static void install(QWidget *widget, QString text,
+                      std::function<bool(const QPoint &)> eligible = {});
+
+protected:
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+  LingerTip(QWidget *widget, QString text,
+            std::function<bool(const QPoint &)> eligible);
+  // Whether a point of the widget answers, given the caller's rule.
+  bool eligibleAt(const QPoint &pos) const;
+
+  QWidget *m_widget = nullptr;
+  QString m_text;
+  std::function<bool(const QPoint &)> m_eligible;
+  QTimer *m_timer = nullptr;
+};
+
+#endif // LINGERTIP_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,7 +80,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
 
   setObjectName("MainWindow");
-  setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());
+  setWindowTitle(titlePrefix() + AppProfile::label());
   setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // Optional client-side decoration: drop the native frame so buildAccountArea
   // can add its own title bar. Off by default, so nothing changes for anyone who
@@ -1295,6 +1295,11 @@ void MainWindow::raiseWindow() {
 // It is handed the current process id instead and waits for it to go before
 // claiming the key. Nothing is killed: this window closes through the ordinary
 // quit path, which is also what writes the window layout out.
+QString MainWindow::titlePrefix() {
+  return CustomTitleBar::isEnabled() ? QApplication::applicationDisplayName()
+                                     : Utils::appNameWithVersion();
+}
+
 void MainWindow::restartApp() {
   QStringList args = QCoreApplication::arguments();
   if (!args.isEmpty())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,7 +80,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
 
   setObjectName("MainWindow");
-  setWindowTitle(titlePrefix() + AppProfile::label());
+  setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());
   setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // Optional client-side decoration: drop the native frame so buildAccountArea
   // can add its own title bar. Off by default, so nothing changes for anyone who
@@ -1295,11 +1295,6 @@ void MainWindow::raiseWindow() {
 // It is handed the current process id instead and waits for it to go before
 // claiming the key. Nothing is killed: this window closes through the ordinary
 // quit path, which is also what writes the window layout out.
-QString MainWindow::titlePrefix() {
-  return CustomTitleBar::isEnabled() ? QApplication::applicationDisplayName()
-                                     : Utils::appNameWithVersion();
-}
-
 void MainWindow::restartApp() {
   QStringList args = QCoreApplication::arguments();
   if (!args.isEmpty())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,7 +80,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
 
   setObjectName("MainWindow");
-  setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());
+  setWindowTitle(Utils::appNameWithVersion() + AppProfile::label());
   setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // Optional client-side decoration: drop the native frame so buildAccountArea
   // can add its own title bar. Off by default, so nothing changes for anyone who

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,7 +80,12 @@ MainWindow::MainWindow(QWidget *parent)
       m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
 
   setObjectName("MainWindow");
-  setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());
+  // No application name in here: Qt appends it to every window title at the
+  // platform layer, so a title that carried one too would read "Whatly … Whatly"
+  // in the system's title bar, the task list and Alt-Tab alike. What a bar of
+  // ours writes is CustomTitleBar::barTitle(), which puts the name back exactly
+  // once, because there no platform is going to.
+  setWindowTitle(AppProfile::label().trimmed());
   setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // Optional client-side decoration: drop the native frame so buildAccountArea
   // can add its own title bar. Off by default, so nothing changes for anyone who

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,7 +80,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
 
   setObjectName("MainWindow");
-  setWindowTitle(Utils::appNameWithVersion() + AppProfile::label());
+  setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());
   setWindowIcon(themeIcon("whatly", ":/icons/app/icon-64.png"));
   // Optional client-side decoration: drop the native frame so buildAccountArea
   // can add its own title bar. Off by default, so nothing changes for anyone who

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -234,11 +234,11 @@ private:
   QTimer *m_layoutSaveTimer = nullptr; // debounces layout saves on window moves
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();
-  // What a window title starts with. The version belongs wherever the app draws
-  // its own chrome — the title bar it draws itself, or the tab strip standing in
-  // for one — because there it can be small and faint. With the system's frame
-  // there is no such place and the title is the only one left, so it goes there
-  // instead of nowhere.
+  // What a window title starts with. Where the app draws its own chrome the
+  // version has somewhere quieter to be — the tab strip, or the tooltip the bar
+  // answers a settled hover with — so the title is left as the plain name. With
+  // the system's frame there is no bar of ours and no tooltip either, and the
+  // title is the only place left, so it goes there instead of nowhere.
   static QString titlePrefix();
   // Ask a freshly loaded account's page for its WhatsApp Web version and cache
   // it on the Account, then refresh the tab tooltips.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -232,6 +232,18 @@ private:
   void collapseToOrdinalOrder(const QStringList &assign);
   bool m_loadingLayout = false; // guards saveAccounts while a layout is restored
   QTimer *m_layoutSaveTimer = nullptr; // debounces layout saves on window moves
+  // How every window is titled: the account it is showing, with its unread count
+  // when it has one — the same string that account's tab carries. Which window
+  // is which is the only question a title has to answer, and it is the same
+  // question whether the window holds one account or a strip of them. No
+  // application name in it: Qt appends that itself for the system's title bar,
+  // the task list and Alt-Tab, and CustomTitleBar puts it in front where the
+  // frame is ours to draw.
+  QString accountTitle(int idx) const;
+  // The window in which this account is the one on screen, or nothing — which
+  // is the question a title change has to ask, since an account sitting behind
+  // another account's tab must not retitle the window in front of it.
+  QWidget *windowShowingAccount(int idx) const;
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();
   // Ask a freshly loaded account's page for its WhatsApp Web version and cache

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -234,12 +234,6 @@ private:
   QTimer *m_layoutSaveTimer = nullptr; // debounces layout saves on window moves
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();
-  // What a window title starts with. Where the app draws its own chrome the
-  // version has somewhere quieter to be — the tab strip, or the tooltip the bar
-  // answers a settled hover with — so the title is left as the plain name. With
-  // the system's frame there is no bar of ours and no tooltip either, and the
-  // title is the only place left, so it goes there instead of nowhere.
-  static QString titlePrefix();
   // Ask a freshly loaded account's page for its WhatsApp Web version and cache
   // it on the Account, then refresh the tab tooltips.
   void captureAccountVersion(WebView *view);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -234,6 +234,12 @@ private:
   QTimer *m_layoutSaveTimer = nullptr; // debounces layout saves on window moves
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();
+  // What a window title starts with. The version belongs wherever the app draws
+  // its own chrome — the title bar it draws itself, or the tab strip standing in
+  // for one — because there it can be small and faint. With the system's frame
+  // there is no such place and the title is the only one left, so it goes there
+  // instead of nowhere.
+  static QString titlePrefix();
   // Ask a freshly loaded account's page for its WhatsApp Web version and cache
   // it on the Account, then refresh the tab tooltips.
   void captureAccountVersion(WebView *view);

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -719,7 +719,7 @@ void MainWindow::setActiveAccount(int index) {
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
+    setWindowTitle(Utils::appNameWithVersion() + AppProfile::label() +
                    ": " + m_webEngine->page()->title());
 }
 
@@ -1192,7 +1192,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
       win->setWindowTitle(m_accounts[idx].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+                          Utils::appNameWithVersion());
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1444,7 +1444,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
     targetWin->setWindowTitle(m_accounts[mi].name + QStringLiteral(" — ") +
-                              QApplication::applicationDisplayName());
+                              Utils::appNameWithVersion());
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1604,7 +1604,7 @@ void MainWindow::refreshDetachedStrips() {
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
       win->setWindowTitle(m_accounts[i].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+                          Utils::appNameWithVersion());
     }
   }
 }

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -719,7 +719,7 @@ void MainWindow::setActiveAccount(int index) {
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
-    setWindowTitle(titlePrefix() + AppProfile::label() +
+    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
                    ": " + m_webEngine->page()->title());
 }
 
@@ -1192,7 +1192,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
       win->setWindowTitle(m_accounts[idx].name + QStringLiteral(" — ") +
-                          titlePrefix());
+                          QApplication::applicationDisplayName());
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1444,7 +1444,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
     targetWin->setWindowTitle(m_accounts[mi].name + QStringLiteral(" — ") +
-                              titlePrefix());
+                              QApplication::applicationDisplayName());
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1604,7 +1604,7 @@ void MainWindow::refreshDetachedStrips() {
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
       win->setWindowTitle(m_accounts[i].name + QStringLiteral(" — ") +
-                          titlePrefix());
+                          QApplication::applicationDisplayName());
     }
   }
 }

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -719,7 +719,7 @@ void MainWindow::setActiveAccount(int index) {
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
-    setWindowTitle(Utils::appNameWithVersion() + AppProfile::label() +
+    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
                    ": " + m_webEngine->page()->title());
 }
 
@@ -1192,7 +1192,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
       win->setWindowTitle(m_accounts[idx].name + QStringLiteral(" — ") +
-                          Utils::appNameWithVersion());
+                          QApplication::applicationDisplayName());
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1444,7 +1444,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
     targetWin->setWindowTitle(m_accounts[mi].name + QStringLiteral(" — ") +
-                              Utils::appNameWithVersion());
+                              QApplication::applicationDisplayName());
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1604,7 +1604,7 @@ void MainWindow::refreshDetachedStrips() {
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
       win->setWindowTitle(m_accounts[i].name + QStringLiteral(" — ") +
-                          Utils::appNameWithVersion());
+                          QApplication::applicationDisplayName());
     }
   }
 }

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -719,8 +719,7 @@ void MainWindow::setActiveAccount(int index) {
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
-                   ": " + m_webEngine->page()->title());
+    setWindowTitle(m_webEngine->page()->title() + AppProfile::label());
 }
 
 int MainWindow::accountIndexForView(const QObject *view) const {
@@ -1191,8 +1190,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     const int idx = accountIndexForId(d.toString());
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
-      win->setWindowTitle(m_accounts[idx].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+      win->setWindowTitle(m_accounts[idx].name);
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1443,8 +1441,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
       }
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
-    targetWin->setWindowTitle(m_accounts[mi].name + QStringLiteral(" — ") +
-                              QApplication::applicationDisplayName());
+    targetWin->setWindowTitle(m_accounts[mi].name);
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1603,8 +1600,7 @@ void MainWindow::refreshDetachedStrips() {
       bar->setCurrentIndex(activeTab);
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
-      win->setWindowTitle(m_accounts[i].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+      win->setWindowTitle(m_accounts[i].name);
     }
   }
 }

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -718,8 +718,35 @@ void MainWindow::setActiveAccount(int index) {
         QStringLiteral("accounts/active"), id.isEmpty() ? kDefault : id);
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
-  if (m_webEngine && m_webEngine->page())
-    setWindowTitle(m_webEngine->page()->title() + AppProfile::label());
+  setWindowTitle(accountTitle(m_activeAccount));
+}
+
+QString MainWindow::accountTitle(int idx) const {
+  if (idx < 0 || idx >= m_accounts.size())
+    return AppProfile::label().trimmed();
+  const Account &a = m_accounts[idx];
+  QString title = a.name;
+  if (a.unread > 0)
+    title += QStringLiteral(" (%1)").arg(a.unread);
+  return title + AppProfile::label();
+}
+
+QWidget *MainWindow::windowShowingAccount(int idx) const {
+  if (idx < 0 || idx >= m_accounts.size())
+    return nullptr;
+  const Account &a = m_accounts[idx];
+  if (!a.window)
+    return idx == m_activeAccount ? const_cast<MainWindow *>(this) : nullptr;
+  AccountTabBar *bar = a.window->bar();
+  if (!bar)
+    return nullptr;
+  // Validity first, as everywhere the strip is asked about an account: the "+"
+  // affordance carries no tab data and the default account's id is the empty
+  // string, so comparing ids alone would answer yes for the affordance.
+  const QVariant data = bar->tabData(bar->currentIndex());
+  return data.isValid() && data.toString() == a.id
+             ? static_cast<QWidget *>(a.window.data())
+             : nullptr;
 }
 
 int MainWindow::accountIndexForView(const QObject *view) const {
@@ -1190,7 +1217,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     const int idx = accountIndexForId(d.toString());
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
-      win->setWindowTitle(m_accounts[idx].name);
+      win->setWindowTitle(accountTitle(idx));
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1441,7 +1468,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
       }
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
-    targetWin->setWindowTitle(m_accounts[mi].name);
+    targetWin->setWindowTitle(accountTitle(mi));
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1600,7 +1627,7 @@ void MainWindow::refreshDetachedStrips() {
       bar->setCurrentIndex(activeTab);
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
-      win->setWindowTitle(m_accounts[i].name);
+      win->setWindowTitle(accountTitle(i));
     }
   }
 }

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -719,7 +719,7 @@ void MainWindow::setActiveAccount(int index) {
   }
   // Re-point the lock overlay and refresh the title to the now-active account.
   if (m_webEngine && m_webEngine->page())
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
+    setWindowTitle(titlePrefix() + AppProfile::label() +
                    ": " + m_webEngine->page()->title());
 }
 
@@ -1192,7 +1192,7 @@ DetachedAccountWindow *MainWindow::createDetachedWindow() {
     if (idx >= 0 && m_accounts[idx].view) {
       win->stack()->setCurrentWidget(m_accounts[idx].view);
       win->setWindowTitle(m_accounts[idx].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+                          titlePrefix());
     }
   });
   // A tab dropped onto this window's strip -> move that account in here.
@@ -1444,7 +1444,7 @@ void MainWindow::moveAccountToWindow(const QString &id,
   }
   if (const int mi = accountIndexForId(id); mi >= 0)
     targetWin->setWindowTitle(m_accounts[mi].name + QStringLiteral(" — ") +
-                              QApplication::applicationDisplayName());
+                              titlePrefix());
   targetWin->show();
   targetWin->raise();
   targetWin->activateWindow();
@@ -1604,7 +1604,7 @@ void MainWindow::refreshDetachedStrips() {
       const int i = members[qBound(0, activeTab, members.size() - 1)];
       win->stack()->setCurrentWidget(m_accounts[i].view);
       win->setWindowTitle(m_accounts[i].name + QStringLiteral(" — ") +
-                          QApplication::applicationDisplayName());
+                          titlePrefix());
     }
   }
 }

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -448,8 +448,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
-                   ": " + title);
+    setWindowTitle(title + AppProfile::label());
 
   refreshAccountTabs();   // per-account badge on each tab
   updateTrayUnread();     // summed badge on the single tray icon

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -448,7 +448,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)
-    setWindowTitle(Utils::appNameWithVersion() + AppProfile::label() +
+    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
                    ": " + title);
 
   refreshAccountTabs();   // per-account badge on each tab

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -448,7 +448,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
+    setWindowTitle(Utils::appNameWithVersion() + AppProfile::label() +
                    ": " + title);
 
   refreshAccountTabs();   // per-account badge on each tab

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -446,9 +446,11 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
   }
   m_accounts[idx].unread = unread;
 
-  // The window title follows the active account only.
-  if (idx == m_activeAccount)
-    setWindowTitle(title + AppProfile::label());
+  // Every window's title follows the account that window is showing, and a
+  // detached window is not a lesser kind of window: it gets the same treatment
+  // as this one, from the same string.
+  if (QWidget *win = windowShowingAccount(idx))
+    win->setWindowTitle(accountTitle(idx));
 
   refreshAccountTabs();   // per-account badge on each tab
   updateTrayUnread();     // summed badge on the single tray icon

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -448,7 +448,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)
-    setWindowTitle(titlePrefix() + AppProfile::label() +
+    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
                    ": " + title);
 
   refreshAccountTabs();   // per-account badge on each tab

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -448,7 +448,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)
-    setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label() +
+    setWindowTitle(titlePrefix() + AppProfile::label() +
                    ": " + title);
 
   refreshAccountTabs();   // per-account badge on each tab

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -91,6 +91,13 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     : QWidget(parent), ui(new Ui::SettingsWidget) {
   ui->setupUi(this);
 
+  // Which build this is, under the window's own title, where someone who wants
+  // it knows to look and nobody else has to see it. This is the one place it is
+  // written out: a window with messages in it says nothing about builds, and
+  // almost nobody reading messages has ever wanted to know.
+  ui->buildLabel->setText(Utils::versionLabel());
+  Utils::makeWatermark(ui->buildLabel);
+
 #ifdef Q_OS_WIN
   // The Qt "widget style" chooser is a Linux desktop-theming nicety; on Windows
   // the native style is expected, so the control is hidden there.

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -56,31 +56,60 @@ padding: 8px 0px 8px 8px;</string>
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label_7">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <layout class="QVBoxLayout" name="titleColumn">
+        <property name="spacing">
+         <number>0</number>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>16</pointsize>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">QLabel{
+        <item>
+         <widget class="QLabel" name="label_7">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QLabel{
 padding: 0px 8px 0px 8px;
 background:transparent;
 }</string>
-        </property>
-        <property name="text">
-         <string>Settings</string>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-       </widget>
+          </property>
+          <property name="text">
+           <string>Settings</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::PlainText</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="buildLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QLabel{
+padding: 0px 8px 4px 8px;
+background:transparent;
+}</string>
+          </property>
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::PlainText</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -281,6 +281,23 @@ QString Utils::decodeXML(const QString &decodeMe) {
  * @return The installation type as a QString. It can be "snap", "flatpak", or
  * an empty string if the installation type could not be determined.
  */
+QString Utils::versionLabel() {
+  QString s = QString::fromLatin1(VERSIONSTR);
+  // Defined by the build system, and empty for an ordinary build. Guarded rather
+  // than assumed: the test binaries compile this file without it.
+#ifdef WHATLY_BUILD_LABEL
+  const QString label = QString::fromLatin1(WHATLY_BUILD_LABEL).trimmed();
+  if (!label.isEmpty())
+    s += QLatin1Char(' ') + label;
+#endif
+  return s;
+}
+
+QString Utils::appNameWithVersion() {
+  return QApplication::applicationDisplayName() + QLatin1Char(' ') +
+         versionLabel();
+}
+
 QString Utils::getInstallType() {
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,9 @@
 #include "utils.h"
 #include "debuglog.h"
 #include "def.h"
+#include <QFont>
+#include <QGraphicsOpacityEffect>
+#include <QLabel>
 #include <QStandardPaths>
 #include <QHash>
 #include <time.h>
@@ -296,6 +299,28 @@ QString Utils::versionLabel() {
 QString Utils::appNameWithVersion() {
   return QApplication::applicationDisplayName() + QLatin1Char(' ') +
          versionLabel();
+}
+
+void Utils::makeWatermark(QLabel *label) {
+  if (!label)
+    return;
+  // Point and pixel sizes both handled — a font set in pixels reports -1 for its
+  // point size, and scaling that would make the text vanish.
+  QFont f = label->font();
+  if (f.pointSizeF() > 0)
+    f.setPointSizeF(qMax(6.0, f.pointSizeF() * 0.78));
+  else if (f.pixelSize() > 0)
+    f.setPixelSize(qMax(8, int(f.pixelSize() * 0.78)));
+  label->setFont(f);
+
+  // A fifth of the way from the background to the text colour, which needs no
+  // light/dark case: whichever way round the theme is, this lands just off the
+  // background. Opacity rather than a colour worked out here and set, because a
+  // colour does not survive — updateWindowTheme() hands the application palette
+  // back to every child of the main window, and these labels are children.
+  auto *fade = new QGraphicsOpacityEffect(label);
+  fade->setOpacity(0.2);
+  label->setGraphicsEffect(fade);
 }
 
 QString Utils::getInstallType() {

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,14 @@ public:
   Utils(QObject *parent = 0);
   virtual ~Utils();
   static QString getInstallType();
+  // The version, with the build label appended when a build sets one. Shown in
+  // the window title, and beside the tabs when they stand in for the title bar,
+  // so which build is running can be read off the window instead of dug out of
+  // About — the question every dogfooding round starts with.
+  static QString versionLabel();
+  // The application's display name followed by that: what a window title starts
+  // with. One place, so the title bar and every window agree.
+  static QString appNameWithVersion();
   static QString refreshCacheSize(const QString cache_dir);
   static bool delete_cache(const QString cache_dir);
   static QString toCamelCase(const QString &s);

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,12 +25,15 @@ public:
   virtual ~Utils();
   static QString getInstallType();
   // The version, with the build label appended when a build sets one. Shown in
-  // the window title, and beside the tabs when they stand in for the title bar,
-  // so which build is running can be read off the window instead of dug out of
-  // About — the question every dogfooding round starts with.
+  // whichever bar the app draws itself — the custom title bar, or the tab strip
+  // when the tabs stand in for one — so which build is running can be read off
+  // the window instead of dug out of About, the question every dogfooding round
+  // starts with. Deliberately NOT in the window title: with the system's own
+  // title bar the text is the window manager's to draw, and a build label there
+  // is a long shout in a place we cannot make quiet.
   static QString versionLabel();
-  // The application's display name followed by that: what a window title starts
-  // with. One place, so the title bar and every window agree.
+  // The application's display name followed by that. The long form, for the
+  // tooltip that spells out what the small text in the bar is.
   static QString appNameWithVersion();
   static QString refreshCacheSize(const QString cache_dir);
   static bool delete_cache(const QString cache_dir);

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,6 +17,8 @@
 #include <QTextDocument>
 #include <QUuid>
 
+class QLabel;
+
 class Utils : public QObject {
   Q_OBJECT
 
@@ -24,19 +26,20 @@ public:
   Utils(QObject *parent = 0);
   virtual ~Utils();
   static QString getInstallType();
-  // The version, with the build label appended when a build sets one. Shown in
-  // the run of account tab strip the tabs leave empty, when the tabs stand in
-  // for a title bar — so which build is running can be read off the window
-  // instead of dug out of About, the question every dogfooding round starts
-  // with. There it can be small and faint. Not in a title bar: one has a title
-  // to show, and in one the system draws nothing about this would be ours to
-  // make quiet.
+  // The version, with the build label appended when a build sets one. Under the
+  // Settings window's title, small and faint, where the app's own icon and name
+  // are already saying whose version it is — so which build is running can be
+  // read off the app instead of dug out of About, the question every test round
+  // starts with. Nowhere in a window anyone is reading messages in: nearly
+  // nobody wants this, and there it would be in front of them always.
   static QString versionLabel();
-  // The application's display name followed by that. The long form: the tooltip
-  // a drawn bar answers a settled hover with — the only place it is written out
-  // when that bar has a title in it already — and the window title of a window
-  // whose frame the system draws, where there is no bar of ours at all.
+  // The application's display name followed by that. The long form, for the
+  // tooltip the account strip answers a settled hover with — a tip floats free
+  // of anything that would say which application it belongs to.
   static QString appNameWithVersion();
+  // Small and faint: a label that has to sit beside something with a job to do
+  // without competing with it. Used for both of the above.
+  static void makeWatermark(QLabel *label);
   static QString refreshCacheSize(const QString cache_dir);
   static bool delete_cache(const QString cache_dir);
   static QString toCamelCase(const QString &s);

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,12 +28,12 @@ public:
   // whichever bar the app draws itself — the custom title bar, or the tab strip
   // when the tabs stand in for one — so which build is running can be read off
   // the window instead of dug out of About, the question every dogfooding round
-  // starts with. Deliberately NOT in the window title: with the system's own
-  // title bar the text is the window manager's to draw, and a build label there
-  // is a long shout in a place we cannot make quiet.
+  // starts with. There it can be small and faint; in a title bar the system
+  // draws, nothing about it would be ours to make quiet.
   static QString versionLabel();
-  // The application's display name followed by that. The long form, for the
-  // tooltip that spells out what the small text in the bar is.
+  // The application's display name followed by that. The long form: the tooltip
+  // that spells out what the small text in the bar is, and the window title of a
+  // window whose frame the system draws, where there is no bar to put it in.
   static QString appNameWithVersion();
   static QString refreshCacheSize(const QString cache_dir);
   static bool delete_cache(const QString cache_dir);

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,15 +25,17 @@ public:
   virtual ~Utils();
   static QString getInstallType();
   // The version, with the build label appended when a build sets one. Shown in
-  // whichever bar the app draws itself — the custom title bar, or the tab strip
-  // when the tabs stand in for one — so which build is running can be read off
-  // the window instead of dug out of About, the question every dogfooding round
-  // starts with. There it can be small and faint; in a title bar the system
-  // draws, nothing about it would be ours to make quiet.
+  // the run of account tab strip the tabs leave empty, when the tabs stand in
+  // for a title bar — so which build is running can be read off the window
+  // instead of dug out of About, the question every dogfooding round starts
+  // with. There it can be small and faint. Not in a title bar: one has a title
+  // to show, and in one the system draws nothing about this would be ours to
+  // make quiet.
   static QString versionLabel();
   // The application's display name followed by that. The long form: the tooltip
-  // that spells out what the small text in the bar is, and the window title of a
-  // window whose frame the system draws, where there is no bar to put it in.
+  // a drawn bar answers a settled hover with — the only place it is written out
+  // when that bar has a title in it already — and the window title of a window
+  // whose frame the system draws, where there is no bar of ours at all.
   static QString appNameWithVersion();
   static QString refreshCacheSize(const QString cache_dir);
   static bool delete_cache(const QString cache_dir);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(tst_logic
     ${S}/networkproxy.cpp ${S}/autostart.cpp ${S}/portalnotification.cpp
     ${S}/notificationreply.cpp
     ${S}/setupwizard.cpp
+    ${S}/lingertip.cpp
     ${S}/icons.qrc
 )
 target_include_directories(tst_logic PRIVATE ${S} ${CMAKE_BINARY_DIR})

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -110,6 +110,17 @@ private slots:
     const QString s = Utils::convertSectoDay(3661); // 1h 1m 1s
     QVERIFY(!s.isEmpty());
   }
+  // The version shown in the window title and beside the tabs. This binary is
+  // compiled with VERSIONSTR="test" and WITHOUT a build label, which is the case
+  // the #ifdef in versionLabel() exists for — an unguarded use of the macro would
+  // not compile here at all.
+  void versionLabelForTheTitle() {
+    QCOMPARE(Utils::versionLabel(), QStringLiteral("test"));
+    // The name leads and the version follows, so shortening a title in a narrow
+    // title bar takes the version rather than the app's name.
+    QVERIFY(Utils::appNameWithVersion().endsWith(QStringLiteral(" test")));
+    QVERIFY(!Utils::appNameWithVersion().startsWith(QStringLiteral("test")));
+  }
   void xmlRoundTrip() {
     const QString raw = QStringLiteral("a<b>&\"'c");
     const QString enc = Utils::encodeXML(raw);


### PR DESCRIPTION
Which build is running is the question every bug report and every test round opens with, and answering it currently means opening About and reading a dialog. It should be readable off the app — but it is also a question a handful of people ask a few times a year, so it must not be in front of everyone else all day.

Two places, one for each way the question gets asked:

- **Under the Settings window's title**, in writing, small and faint, with the app's own icon and name already beside it. That is where someone who wants it goes looking, and it is out of sight of everyone who does not.
- **On the account strip's tooltip**, for a pointer that has come to rest on the run of strip past the last tab. The strip is the one piece of chrome that is ours in every window: the title bar above it may be the system's, and then nothing on it could carry an answer at all — which is why this does not live on the title bar Whatly draws, where it would be an answer that appears and disappears with a setting.

Nothing else in a window says it. In particular the window title is the plain application name again, whoever draws the frame.

The rest of the change follows from that:

- With "Hide the title bar" on, where the account tabs *are* the title bar, the run of strip beside them shows **the window title** — the same string a standalone bar shows, since that row is now the title bar and should say what one says. Small and faint, because the tabs are what the row is for.
- That label is `Ignored` horizontally with no minimum width, so the layout may shrink it to nothing and the text is simply clipped. It must never push the tabs.
- Nothing in either bar takes mouse events except the buttons — not the title, not the icon. That stretch of chrome is what the window is dragged by, and a label that answered a press would put a dead patch in the middle of it.
- The faintness is opacity, not a computed colour. A colour does not survive here: `updateWindowTheme()` hands the application palette back to every child of the main window, and these labels are children, so a main window's copy came back at full strength while a detached window's — which that loop never reaches — stayed quiet. A fifth of the text colour over whatever is really painted behind is the shade the calculation was after anyway, and it needs no light/dark branch.

`LingerTip` is the waiting tooltip, since two widgets want it. Qt's own appears after a fraction of a second, which is right for a control with something to explain and wrong for a run of chrome someone is only crossing on the way to a tab: five seconds of stillness, put back to the beginning by every move, and gone again the moment the pointer moves. It takes back only its own tip, never whatever else happens to be on screen, so the tab the pointer moves onto keeps its own.

`WHATLY_BUILD_LABEL` is included when a build sets one — that is what makes a test build identifiable on sight rather than by asking the tester to check About. The macro is `#ifdef`-guarded because the test binaries compile `utils.cpp` without it; an unguarded use does not build there.

Asked for during Linux dogfooding, and shaped by four rounds of it — the version has been in the title bar, at the end of the tab strip and in the window title on the way to this. Windows after that; draft until both.
