### PR TITLE
fix(app): keep the log running across a restart

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,6 +52,7 @@
 #include <QProcess>
 #include <QVarLengthArray>
 #ifdef Q_OS_UNIX
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
@@ -1355,8 +1356,9 @@ void MainWindow::restartApp() {
   // session and process group, and does not survive it here: the new process got
   // as far as printing its start-up line and was then taken down with the old
   // one. It has to leave that session (setsid) and be orphaned onto init (the
-  // second fork) to outlive the instance that started it. Descriptors survive
-  // both forks untouched, which is the whole point of doing this at all.
+  // second fork) to outlive the instance that started it. stdout and stderr
+  // survive both forks untouched, which is the whole point of doing this at all;
+  // every other descriptor is closed just before exec, below.
   const pid_t child = ::fork();
   if (child < 0) {
     failed();
@@ -1369,6 +1371,23 @@ void MainWindow::restartApp() {
     if (grandchild < 0)
       ::_exit(127);
     if (grandchild == 0) {
+      // Keep 0, 1 and 2 — they are the log, and the reason for all of this —
+      // and close everything above them. QProcess::startDetached used to do
+      // that for us, and dropping it cost the remote-debugging port: the old
+      // process's listening socket came through exec, so the new process could
+      // not bind it ("bind() failed: Address already in use", in the log of the
+      // session that found this) and the inherited socket sat there listening
+      // with nobody left to accept on it. Any other descriptor the old process
+      // held — profile locks among them — would travel the same way.
+      bool closed = false;
+#ifdef SYS_close_range
+      closed = ::syscall(SYS_close_range, 3, ~0U, 0) == 0;
+#endif
+      if (!closed) {
+        const long maxFd = ::sysconf(_SC_OPEN_MAX);
+        for (int fd = 3; fd < int(maxFd > 0 ? maxFd : 4096); ++fd)
+          ::close(fd);
+      }
       ::execv(argStore.first().constData(), argv.data());
       // Only reachable if exec failed. Nobody is left to tell by now — the
       // executable was checked before the first fork for exactly that reason.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -50,6 +50,10 @@
 #include <QDesktopServices>
 #include <QMessageBox>
 #include <QProcess>
+#include <QVarLengthArray>
+#ifdef Q_OS_UNIX
+#include <unistd.h>
+#endif
 #include "chatliststrip.h"
 #include "privacyblur.h"
 #include "localapi.h"
@@ -1310,14 +1314,59 @@ void MainWindow::restartApp() {
   saveWindowLayout();
   SettingsManager::instance().settings().sync(); // the new process reads these
 
-  if (!QProcess::startDetached(QCoreApplication::applicationFilePath(), args)) {
+  const QString exePath = QCoreApplication::applicationFilePath();
+  const auto failed = [this]() {
     // Nothing has been closed yet, so a failure here costs the user nothing
     // beyond the message.
     QMessageBox::warning(this, tr("Restart"),
                          tr("Whatly could not start a new instance, so it has "
                             "not closed this one. Please quit and reopen it."));
+  };
+
+#ifdef Q_OS_UNIX
+  // Hand the new process the SAME stdout and stderr this one has.
+  // QProcess::startDetached deliberately does not — the child ends up on the
+  // controlling terminal — so a launch whose output was being piped into a log
+  // file stopped being logged the instant anything called this. "Restart now" is
+  // a button we put in Settings, and one press of it silently ended the log
+  // people are asked to attach to bug reports. Losing the log at the exact moment
+  // someone is reproducing a problem is the worst possible time to lose it.
+  //
+  // fork+exec keeps the descriptors, and that is the whole difference: the
+  // --restart-wait handshake, the arguments and the ordering are unchanged.
+  if (!QFileInfo(exePath).isExecutable()) {
+    failed();
     return;
   }
+  // Everything the child needs is built HERE, before the fork: between fork and
+  // exec only async-signal-safe calls are allowed, and allocating is not one.
+  QList<QByteArray> argStore;
+  argStore << exePath.toLocal8Bit();
+  for (const QString &a : args)
+    argStore << a.toLocal8Bit();
+  QVarLengthArray<char *, 16> argv;
+  for (QByteArray &a : argStore)
+    argv.append(a.data());
+  argv.append(nullptr);
+
+  const pid_t child = ::fork();
+  if (child < 0) {
+    failed();
+    return;
+  }
+  if (child == 0) {
+    ::execv(argStore.first().constData(), argv.data());
+    // Only reachable if exec failed. The parent is already committed by now, so
+    // there is nobody left to tell; dying quietly at least leaves no half-started
+    // process behind, and the executable was checked above.
+    ::_exit(127);
+  }
+#else
+  if (!QProcess::startDetached(exePath, args)) {
+    failed();
+    return;
+  }
+#endif
   quitApp();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,6 +52,7 @@
 #include <QProcess>
 #include <QVarLengthArray>
 #ifdef Q_OS_UNIX
+#include <sys/wait.h>
 #include <unistd.h>
 #endif
 #include "chatliststrip.h"
@@ -1349,18 +1350,37 @@ void MainWindow::restartApp() {
     argv.append(a.data());
   argv.append(nullptr);
 
+  // fork, setsid, fork again — the dance startDetached does, and the part of it
+  // that a bare fork was missing. A plain child stays in the dying parent's
+  // session and process group, and does not survive it here: the new process got
+  // as far as printing its start-up line and was then taken down with the old
+  // one. It has to leave that session (setsid) and be orphaned onto init (the
+  // second fork) to outlive the instance that started it. Descriptors survive
+  // both forks untouched, which is the whole point of doing this at all.
   const pid_t child = ::fork();
   if (child < 0) {
     failed();
     return;
   }
   if (child == 0) {
-    ::execv(argStore.first().constData(), argv.data());
-    // Only reachable if exec failed. The parent is already committed by now, so
-    // there is nobody left to tell; dying quietly at least leaves no half-started
-    // process behind, and the executable was checked above.
-    ::_exit(127);
+    if (::setsid() < 0)
+      ::_exit(127);
+    const pid_t grandchild = ::fork();
+    if (grandchild < 0)
+      ::_exit(127);
+    if (grandchild == 0) {
+      ::execv(argStore.first().constData(), argv.data());
+      // Only reachable if exec failed. Nobody is left to tell by now — the
+      // executable was checked before the first fork for exactly that reason.
+      ::_exit(127);
+    }
+    ::_exit(0); // the middle process has done its job; init adopts the grandchild
   }
+  // Reap the middle process, which exits immediately. Without this it lingers as
+  // a zombie for as long as this instance takes to quit, and --restart-wait
+  // watches for a pid to disappear.
+  int status = 0;
+  ::waitpid(child, &status, 0);
 #else
   if (!QProcess::startDetached(exePath, args)) {
     failed();


### PR DESCRIPTION
"Restart now" silently ended logging.

Run Whatly with its output piped into a file — which is exactly what a bug report asks for — and the log stopped at the moment the user pressed a button we put in Settings. Everything after it went to the controlling terminal instead, and nothing said so: the file simply stopped growing. It also switches off the app's own `whatly-webengine.log` capture, which no-ops when stderr is a TTY, so both records end at once.

`QProcess::startDetached` is documented not to pass the parent's channels on, and that is the whole cause. Measured on a running instance before changing anything: the process had been started by `restartApp()` (`--restart-wait=<pid>`), and its `/proc/<pid>/fd/1` and `fd/2` pointed at `/dev/pts/1` while the original pipeline still held the pipe.

On Unix the restart is a `fork`+`execv` now, which keeps the descriptors exactly as they are. The `--restart-wait` handshake, the argument list and the ordering are untouched, and Windows keeps `startDetached`.

Two details that are the difference between this working and being a trap:

- **Everything the child needs is built before the fork.** Between `fork` and `exec` only async-signal-safe calls are permitted, and allocating is not one — so the argv array is assembled while there is still only one process.
- **The executable is checked before forking**, because after the fork the parent is committed: an `exec` that fails there has nobody left to report to. `startDetached` returned a bool the caller could act on, and that is what had to be replaced with something.

Worth noting the effect is not only on logs — a Whatly launched from a terminal keeps its terminal across a restart now, which is what anyone would expect it to do.

Found while trying to read a log that turned out to be empty, on a run that had restarted itself hours earlier. Dogfooding on Linux next, Windows after; draft until both.
