### PR TITLE
build(msvc): split the two injected scripts that outgrew a string literal

### DIFF
--- a/src/chatliststrip.cpp
+++ b/src/chatliststrip.cpp
@@ -403,6 +403,11 @@ R"JS(
       } catch (e) { /* never break the page */ }
     }, 1000);
 
+)JS"
+// MSVC caps a single string literal at 16380 bytes and this half of the script
+// has grown past it again. Adjacent literals are concatenated by the compiler,
+// so this split is a build constraint only — it changes nothing about the script.
+R"JS(
     var panel = function () {
       var t = document.getElementById(TIP);
       if (!t) {

--- a/src/webtweaks.cpp
+++ b/src/webtweaks.cpp
@@ -235,6 +235,11 @@ static const char kScriptTemplate[] = R"JS(
     },
   ];
 
+)JS"
+// MSVC caps a single string literal at 16380 bytes and this script is past it.
+// Adjacent literals are concatenated by the compiler, so this split is a build
+// constraint only — it changes nothing about the script.
+R"JS(
   // Idempotent, and that is not an optimisation but a correctness requirement:
   // writing innerHTML is a DOM mutation, and this used to be called from a
   // MutationObserver watching the DOM. Every repaint retriggered the observer,


### PR DESCRIPTION
**Merge this one first.** Four of the open PRs do not compile on Windows without it.

MSVC caps a **single string literal at 16380 bytes** and rejects anything past it outright (C2026) — it takes down `whatly.vcxproj`, `tst_logic` and `tst_settings` together. GCC and Clang have no such limit, which is why nothing on Linux can see it.

Both injected scripts were already within a kilobyte of the ceiling on `main`, and four of the pending branches cross it on their own — measured per branch, largest raw literal in the file:

| file | on `main` | branches that cross it alone |
|---|---|---|
| `src/chatliststrip.cpp` | 15954 | #50 → 16385, #54 → 16866 |
| `src/webtweaks.cpp` | 15598 | #57 → 16391, #60 → 17670 |

**Adjacent string literals are concatenated by the compiler**, so splitting each script in two at a statement boundary changes nothing about the JavaScript — not one character of it, and no behaviour. `chatliststrip.cpp` already carried exactly such a split with a comment explaining this same limit; its second half had simply outgrown the limit again.

It lands here rather than on any one of the four because no one of them owns it, and each would otherwise carry a copy that conflicts with the next.

Both files are back to 6–10 KB. **This is a standing hazard rather than a one-off** — the next few hundred lines of injected JS will meet the ceiling again, and a Windows CI job would catch it the day it happens rather than at packaging time. Worth adding if you would like it.

Found while dogfooding #49–#63 on Windows; the whole set passes there with this in place.
