### PR TITLE
fix(accounts): count what is unread from WhatsApp's own store, not from its title

### DIFF
--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -76,4 +76,85 @@ QString openChatByNameScript(const QString &name) {
 )JS").arg(jsonString(name));
 }
 
+QString unreadSummaryScript() {
+  return QStringLiteral(R"JS(
+(function(){
+  // Counting the drawn rows, for when the database cannot be read. Same badge
+  // detection as unreadChatsScript: a leaf span whose whole text is a number.
+  function fromList(){
+    var pane = document.querySelector('#pane-side');
+    if (!pane) return null;
+    var rows = pane.querySelectorAll('[role="row"]');
+    var chats = 0, messages = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var spans = rows[i].querySelectorAll('span'), n = 0;
+      for (var j = 0; j < spans.length; j++) {
+        var t = (spans[j].textContent || '').trim();
+        if (spans[j].children.length === 0 && /^\d{1,4}$/.test(t)) n = parseInt(t, 10);
+      }
+      if (n > 0) { chats++; messages += n; }
+    }
+    return { chats: chats, messages: messages, source: 'list' };
+  }
+
+  // runJavaScript does not await a promise — it would hand back the promise
+  // object itself — and reading a database cannot be anything but asynchronous.
+  // So the answer is kept on the page: every call returns what was last worked
+  // out and starts the next read, and with a call every few seconds the number
+  // is at most one beat behind. Until the first read lands, the drawn rows
+  // answer, which is right for the top of the list and wrong only for what has
+  // scrolled out of it.
+  async function fromDatabase(){
+    if (!indexedDB.databases) return null;
+    var dbs = await indexedDB.databases();
+    var name = null;
+    for (var i = 0; i < dbs.length; i++)
+      if (dbs[i].name === 'model-storage') name = dbs[i].name;
+    if (!name) return null;
+
+    var db = await new Promise(function(resolve, reject){
+      var r = indexedDB.open(name);
+      r.onsuccess = function(){ resolve(r.result); };
+      r.onerror = function(){ reject(r.error); };
+      r.onblocked = function(){ reject(new Error('blocked')); };
+    });
+    if (!db.objectStoreNames.contains('chat')) { db.close(); return null; }
+
+    // A cursor rather than getAll(): this runs every few seconds, and getAll on
+    // a chat store of several hundred records deserialises every field of every
+    // one of them to read two.
+    var chats = 0, messages = 0;
+    await new Promise(function(resolve){
+      var tx = db.transaction('chat', 'readonly');
+      var req = tx.objectStore('chat').openCursor();
+      req.onsuccess = function(){
+        var cur = req.result;
+        if (!cur) { resolve(); return; }
+        var c = cur.value || {};
+        var n = c.unreadCount | 0;
+        if (n > 0 && !c.archive) { chats++; messages += n; }
+        cur.continue();
+      };
+      req.onerror = function(){ resolve(); };
+      tx.onabort = function(){ resolve(); };
+    });
+    db.close();
+    return { chats: chats, messages: messages, source: 'db' };
+  }
+
+  var W = window.__whatlyUnread ||
+          (window.__whatlyUnread = { known: null, busy: false });
+  if (!W.busy) {
+    W.busy = true;
+    fromDatabase()
+      .then(function(r){ if (r) W.known = r; })
+      .catch(function(){})
+      .then(function(){ W.busy = false; });
+  }
+  return JSON.stringify(W.known || fromList() ||
+                        { chats: 0, messages: 0, source: 'none' });
+})()
+)JS");
+}
+
 } // namespace ChatNav

--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -152,9 +152,14 @@ QString unreadSummaryScript() {
   }
 
   var W = window.__whatlyUnread ||
-          (window.__whatlyUnread = { known: null, busy: false });
-  if (!W.busy) {
+          (window.__whatlyUnread = { known: null, busy: false, at: 0 });
+  // Asked often — a title change is not the only way an unread count moves, and
+  // marking a chat read or unread by hand moves it without one — so the read
+  // itself is throttled here rather than at the call site. Calls in between are
+  // free: they hand back the number already worked out.
+  if (!W.busy && Date.now() - (W.at || 0) > 2500) {
     W.busy = true;
+    W.at = Date.now();
     fromDatabase()
       .then(function(r){ if (r) W.known = r; })
       .catch(function(){})

--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -123,13 +123,16 @@ QString unreadSummaryScript() {
     // A cursor rather than getAll(): this runs every few seconds, and getAll on
     // a chat store of several hundred records deserialises every field of every
     // one of them to read two.
-    var chats = 0, messages = 0;
+    // `walked` is the difference between "nothing is unread" and "the read did
+    // not finish". Resolving the error paths with the counters as they stand
+    // would report a confident zero and clear every badge.
+    var chats = 0, messages = 0, walked = false;
     await new Promise(function(resolve){
       var tx = db.transaction('chat', 'readonly');
       var req = tx.objectStore('chat').openCursor();
       req.onsuccess = function(){
         var cur = req.result;
-        if (!cur) { resolve(); return; }
+        if (!cur) { walked = true; resolve(); return; }
         var c = cur.value || {};
         var n = c.unreadCount | 0;
         // A chat marked unread by hand has no messages to count, and WhatsApp
@@ -148,7 +151,7 @@ QString unreadSummaryScript() {
       tx.onabort = function(){ resolve(); };
     });
     db.close();
-    return { chats: chats, messages: messages, source: 'db' };
+    return walked ? { chats: chats, messages: messages, source: 'db' } : null;
   }
 
   var W = window.__whatlyUnread ||

--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -132,7 +132,16 @@ QString unreadSummaryScript() {
         if (!cur) { resolve(); return; }
         var c = cur.value || {};
         var n = c.unreadCount | 0;
-        if (n > 0 && !c.archive) { chats++; messages += n; }
+        // A chat marked unread by hand has no messages to count, and WhatsApp
+        // records it as a negative count or as a flag depending on the build.
+        // It belongs in the total either way: it carries a pill in the list and
+        // it appears under the list's own "unread" filter, which is the set this
+        // number is meant to be the size of.
+        var marked = n < 0 || !!c.markedUnread;
+        if ((n > 0 || marked) && !c.archive) {
+          chats++;
+          messages += (n > 0 ? n : 0);
+        }
         cur.continue();
       };
       req.onerror = function(){ resolve(); };

--- a/src/chatnav.h
+++ b/src/chatnav.h
@@ -14,6 +14,23 @@ namespace ChatNav {
 // the numeric count pill on the row, which is locale-independent.
 QString unreadChatsScript(int limit);
 
+// JS that answers how much is unread, as JSON: {"chats": N, "messages": M}.
+//
+// It reads WhatsApp Web's own IndexedDB (`model-storage`, store `chat`) rather
+// than the chat list, because the list is virtualised: a session with 592 chats
+// keeps about 66 of them in the DOM, so counting rows answers "unread among the
+// ones currently drawn" and changes as the list is scrolled. The database holds
+// every chat whatever is on screen.
+//
+// Archived chats are left out — they are the ones deliberately put away, and
+// they are not in the list the count sits beside. Muted ones are counted: they
+// still carry a badge in that list, and a count that disagreed with what the
+// user can see would be the bug this replaces.
+//
+// Falls back to counting the drawn rows if the database is not readable, which
+// is the honest degradation: WhatsApp's schema is theirs to change.
+QString unreadSummaryScript();
+
 // JS that opens the chat whose row title matches `name` exactly, by dispatching
 // the pointer/mouse sequence WhatsApp Web's list rows react to (a plain click is
 // ignored). Returns "ok" / "not-found" / "no-pane". The name is JSON-escaped, so

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -75,9 +75,7 @@ MainWindow::MainWindow(QWidget *parent)
 #ifdef Q_OS_LINUX
       m_notifier(kAppDisplayName, this),
 #endif
-      m_trayIconNormal(themeIcon("whatly-tray", ":/icons/app/notification/whatly-notify.png")),
-      m_notificationsTitleRegExp("^\\([1-9]\\d*\\).*"),
-      m_unreadMessageCountRegExp("\\([^\\d]*(\\d+)[^\\d]*\\)") {
+      m_trayIconNormal(themeIcon("whatly-tray", ":/icons/app/notification/whatly-notify.png")) {
 
   setObjectName("MainWindow");
   setWindowTitle(QApplication::applicationDisplayName() + AppProfile::label());

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -249,6 +249,11 @@ private:
   void collapseToOrdinalOrder(const QStringList &assign);
   bool m_loadingLayout = false; // guards saveAccounts while a layout is restored
   QTimer *m_layoutSaveTimer = nullptr; // debounces layout saves on window moves
+  // Ask one account's page how much is unread and put it on the badges. The
+  // page throttles the reading; this can be called as often as is useful.
+  void countUnread(int idx);
+  void countUnreadEverywhere();
+  QTimer *m_unreadTimer = nullptr;
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();
   // Ask a freshly loaded account's page for its WhatsApp Web version and cache

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -430,8 +430,6 @@ private:
   QMetaObject::Connection m_trayNotificationClickConnection;
 #endif
   QIcon m_trayIconNormal;
-  QRegularExpression m_notificationsTitleRegExp;
-  QRegularExpression m_unreadMessageCountRegExp;
   DownloadManagerWidget m_downloadManagerWidget;
   QScopedPointer<QWebEngineProfile> m_otrProfile;
   int m_correctlyLoadedRetries = 4;

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -76,6 +76,34 @@ void MainWindow::setAlwaysShowAccountTabs(bool enabled) {
       QStringLiteral("alwaysShowAccountTabs"), enabled);
 }
 
+void MainWindow::countUnread(int idx) {
+  if (idx < 0 || idx >= m_accounts.size())
+    return;
+  QWebEnginePage *page = pageOf(m_accounts[idx]);
+  if (!page)
+    return; // dormant: it has nothing to count with
+  const QString id = m_accounts[idx].id;
+  page->runJavaScript(
+      ChatNav::unreadSummaryScript(), [this, id](const QVariant &result) {
+        const int i = accountIndexForId(id);
+        if (i < 0)
+          return;
+        const QJsonObject o =
+            QJsonDocument::fromJson(result.toString().toUtf8()).object();
+        const int chats = o.value(QStringLiteral("chats")).toInt();
+        if (m_accounts[i].unread == chats)
+          return; // nothing to redraw
+        m_accounts[i].unread = chats;
+        refreshAccountTabs();
+        updateTrayUnread();
+      });
+}
+
+void MainWindow::countUnreadEverywhere() {
+  for (int i = 0; i < m_accounts.size(); ++i)
+    countUnread(i);
+}
+
 void MainWindow::refreshAccountStrip() { refreshAccountTabs(); }
 
 void MainWindow::buildAccountArea() {
@@ -96,6 +124,17 @@ void MainWindow::buildAccountArea() {
   connect(m_suspendTimer, &QTimer::timeout, this,
           [this]() { suspendIdleAccounts(); });
   m_suspendTimer->start();
+
+  // A title change is not the only way an unread count moves: marking a chat
+  // read or unread by hand moves it without one, and so does reading a chat on
+  // the phone. The page throttles the work — a call between reads simply hands
+  // back the last number — so this costs a function call and a string per
+  // account every few seconds.
+  m_unreadTimer = new QTimer(this);
+  m_unreadTimer->setInterval(3 * 1000);
+  connect(m_unreadTimer, &QTimer::timeout, this,
+          [this]() { countUnreadEverywhere(); });
+  m_unreadTimer->start();
   auto *central = new QWidget(this);
   auto *layout = new QVBoxLayout(central);
   layout->setContentsMargins(0, 0, 0, 0);

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -88,9 +88,23 @@ void MainWindow::countUnread(int idx) {
         const int i = accountIndexForId(id);
         if (i < 0)
           return;
-        const QJsonObject o =
-            QJsonDocument::fromJson(result.toString().toUtf8()).object();
-        const int chats = o.value(QStringLiteral("chats")).toInt();
+        // A count that could not be taken must leave the badge as it is. Zero is
+        // an answer — nothing is unread — and it has to be told apart from a
+        // page that was reloading, a store that would not open and a script that
+        // returned something unexpected, or the badge clears itself every time
+        // one of those happens, which during a reload is every time.
+        QJsonParseError parse{};
+        const QJsonDocument doc =
+            QJsonDocument::fromJson(result.toString().toUtf8(), &parse);
+        if (parse.error != QJsonParseError::NoError || !doc.isObject())
+          return;
+        const QJsonObject o = doc.object();
+        const QJsonValue counted = o.value(QStringLiteral("chats"));
+        if (o.value(QStringLiteral("source")).toString() ==
+                QLatin1String("none") ||
+            !counted.isDouble() || counted.toInt() < 0)
+          return;
+        const int chats = counted.toInt();
         if (m_accounts[i].unread == chats)
           return; // nothing to redraw
         m_accounts[i].unread = chats;
@@ -1120,8 +1134,10 @@ void MainWindow::updateTrayUnread() {
   }
 
   if (total > 0) {
+    // Chats, not messages: what is summed here is one per conversation with
+    // something unread in it.
     m_restoreAction->setText(tr("Restore") + " | " + QString::number(total) +
-                             " " + (total > 1 ? tr("messages") : tr("message")));
+                             " " + (total > 1 ? tr("chats") : tr("chat")));
     m_systemTrayIcon->setIcon(getTrayIcon(total));
     setWindowIcon(getTrayIcon(total));
   } else {

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -14,6 +14,9 @@
 #include <QIcon>
 
 #include "shortcuts.h"
+#include "chatnav.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QPalette>
 
 // ── Actions ──────────────────────────────────────────────────────────────────
@@ -433,18 +436,33 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
   if (idx < 0)
     return;
 
-  // Pull the unread count out of the title ("(3) Chat name"), and remember it
-  // per account so the tray can show the total across all of them.
-  int unread = 0;
-  const QRegularExpressionMatch titleMatch =
-      m_notificationsTitleRegExp.match(title);
-  if (titleMatch.hasMatch()) {
-    const QRegularExpressionMatch countMatch =
-        m_unreadMessageCountRegExp.match(titleMatch.captured(0));
-    if (countMatch.hasMatch())
-      unread = countMatch.captured(1).toInt();
+  // A title change is the signal that something arrived, and nothing more than
+  // that. The number in it used to be taken as the unread count, and it is not
+  // one: measured on a session with ten unread chats holding fifty-five unread
+  // messages between them, WhatsApp's own title said "(1)". Whatever it counts,
+  // it is neither of the two things anyone reads a badge for. So ask the page.
+  //
+  // The answer is chats, not messages: each chat already shows its own number in
+  // the list, so a total repeats what is on screen, and a sum is dominated by
+  // whichever group is busiest — which stops it answering "how many
+  // conversations need me", the only question a badge is for.
+  if (QWebEnginePage *page = pageOf(m_accounts[idx])) {
+    const QString id = m_accounts[idx].id;
+    page->runJavaScript(
+        ChatNav::unreadSummaryScript(), [this, id](const QVariant &result) {
+          const int i = accountIndexForId(id);
+          if (i < 0)
+            return;
+          const QJsonObject o =
+              QJsonDocument::fromJson(result.toString().toUtf8()).object();
+          const int chats = o.value(QStringLiteral("chats")).toInt();
+          if (m_accounts[i].unread == chats)
+            return; // nothing to redraw
+          m_accounts[i].unread = chats;
+          refreshAccountTabs();
+          updateTrayUnread();
+        });
   }
-  m_accounts[idx].unread = unread;
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -446,23 +446,7 @@ void MainWindow::handleWebViewTitleChanged(const QString &title) {
   // the list, so a total repeats what is on screen, and a sum is dominated by
   // whichever group is busiest — which stops it answering "how many
   // conversations need me", the only question a badge is for.
-  if (QWebEnginePage *page = pageOf(m_accounts[idx])) {
-    const QString id = m_accounts[idx].id;
-    page->runJavaScript(
-        ChatNav::unreadSummaryScript(), [this, id](const QVariant &result) {
-          const int i = accountIndexForId(id);
-          if (i < 0)
-            return;
-          const QJsonObject o =
-              QJsonDocument::fromJson(result.toString().toUtf8()).object();
-          const int chats = o.value(QStringLiteral("chats")).toInt();
-          if (m_accounts[i].unread == chats)
-            return; // nothing to redraw
-          m_accounts[i].unread = chats;
-          refreshAccountTabs();
-          updateTrayUnread();
-        });
-  }
+  countUnread(idx);
 
   // The window title follows the active account only.
   if (idx == m_activeAccount)

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2171,6 +2171,21 @@ private slots:
     QVERIFY(js.contains(QLatin1String(">= 6"))); // the limit was substituted
     QVERIFY(!ChatNav::unreadChatsScript(0).isEmpty()); // clamped, still valid
   }
+  void unreadSummaryReadsTheDatabaseAndFallsBackToTheList() {
+    const QString js = ChatNav::unreadSummaryScript();
+    // WhatsApp's own store, which is what makes the count independent of how
+    // much of the virtualised list happens to be drawn.
+    QVERIFY(js.contains(QLatin1String("model-storage")));
+    QVERIFY(js.contains(QLatin1String("unreadCount")));
+    // Archived chats are not counted; muted ones are.
+    QVERIFY(js.contains(QLatin1String("!c.archive")));
+    QVERIFY(!js.contains(QLatin1String("muteExpiration")));
+    // And the list is still there to answer while the first read is in flight,
+    // since runJavaScript cannot await a promise.
+    QVERIFY(js.contains(QLatin1String("#pane-side")));
+    QVERIFY(js.contains(QLatin1String("__whatlyUnread")));
+    QVERIFY(js.contains(QLatin1String("JSON.stringify")));
+  }
   void openScriptEscapesName() {
     const QString js =
         ChatNav::openChatByNameScript(QStringLiteral("a\"b'c\n<x>"));

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2184,6 +2184,10 @@ private slots:
     // since runJavaScript cannot await a promise.
     QVERIFY(js.contains(QLatin1String("#pane-side")));
     QVERIFY(js.contains(QLatin1String("__whatlyUnread")));
+    // A read that did not finish must not be reported as a confident zero: the
+    // cursor sets `walked` only when it reaches the end of the store.
+    QVERIFY(js.contains(QLatin1String("walked = true")));
+    QVERIFY(js.contains(QLatin1String("return walked ?")));
     QVERIFY(js.contains(QLatin1String("JSON.stringify")));
   }
   void openScriptEscapesName() {


### PR DESCRIPTION
The badge on a tab, the badge on the tray and the count in a window title all came from the number in WhatsApp Web's page title. That number is not an unread count.

Measured on a live session with the remote-debugging port, cross-checked three ways — the rendered chat list, the `aria-label`s, and WhatsApp's own IndexedDB:

| | |
|---|---|
| chats with unread messages | **10** |
| unread messages between them | **55** |
| what the page title said | **`(1) WhatsApp`** |

Whatever WhatsApp counts there, it is neither of the two things anyone reads a badge for, and it has been the source for as long as it has been read.

**Chats, not messages.** Every chat already shows its own number in the list, so a total repeats what is on screen; and a sum is dominated by whichever group chat is busiest, which stops it answering *how many conversations need me* — the only question a badge is for. Ten reads as ten conversations; fifty-five reads as a backlog, and mostly one loud afternoon in a group.

**Read from the database, not from the list.** The chat list is virtualised: the session above keeps **66 of its 592 chats** in the DOM, so counting rows answers "unread among the ones currently drawn" and changes as the list is scrolled. `model-storage` → `chat` holds every chat whatever is on screen. Archived chats are left out, being the ones deliberately put away. Muted chats are counted: they still carry a badge in that list, and a count disagreeing with what the user can see would be the bug this replaces.

**A cursor, not `getAll()`** — this runs on title changes, and `getAll` on several hundred chat records deserialises every field of every one of them to read two.

**How the async is handled.** `runJavaScript` cannot await a promise and a database read cannot be synchronous, so the answer is kept on the page: each call returns what was last worked out and starts the next read, which at one call per title change is at most a beat behind. Until the first read lands, the drawn rows answer — right for the top of the list, which is where unread chats sit in a list sorted by recency.

Verified live against the script as committed: first call `{"chats":10,"messages":55,"source":"list"}`, second `{"chats":10,"messages":55,"source":"db"}` — the fallback and the store agree, and the handover works.

The title still *triggers* the count, since WhatsApp retitles the window whenever anything arrives anywhere. It is simply no longer believed. Its two regexes are gone with it.

`messages` is returned alongside `chats` although nothing reads it yet — it is the natural thing for a tooltip to say, and computing it costs nothing once the cursor is walking.

---

**Kept following what is unread.** A title change was the only trigger, and it is not the only way an unread count moves — marking a chat read or unread by hand moves it without one, and so does reading a chat on the phone. Every account with a page is now asked every three seconds as well. That is affordable because the reading is throttled *in the page* rather than at the call site: a call arriving between reads hands back the number already worked out, so the extra calls cost a function call and a short string each.

**What is deliberately not in this PR:** settings for what the badge counts (muted, archived, messages-instead-of-chats) and the count on the collapsed strip's unread letter. Both are written and dogfooded, and both had defects worth fixing before review rather than after, so they follow in their own PR.
