### PR TITLE
feat(accounts): let the user say what the unread badge counts

### DIFF
--- a/src/chatnav.cpp
+++ b/src/chatnav.cpp
@@ -189,9 +189,10 @@ QString focusSearchScript() {
 )JS");
 }
 
-QString unreadSummaryScript() {
+QString unreadSummaryScript(bool includeMuted, bool includeArchived) {
   return QStringLiteral(R"JS(
 (function(){
+  var INCLUDE_MUTED = %1, INCLUDE_ARCHIVED = %2;
   // Counting the drawn rows, for when the database cannot be read. Same badge
   // detection as unreadChatsScript: a leaf span whose whole text is a number.
   function fromList(){
@@ -247,6 +248,15 @@ QString unreadSummaryScript() {
         var cur = req.result;
         if (!cur) { walked = true; resolve(); return; }
         var c = cur.value || {};
+        // Archived is the pile deliberately put away, and muted is the chat
+        // that was told not to interrupt — both still carry a pill in their
+        // list, so whether they belong in the total is a matter of how someone
+        // uses WhatsApp rather than of fact, and both are settings.
+        if ((!INCLUDE_ARCHIVED && c.archive) ||
+            (!INCLUDE_MUTED && (c.muteExpiration || c.isAutoMuted))) {
+          cur.continue();
+          return;
+        }
         var n = c.unreadCount | 0;
         // A chat marked unread by hand has no messages to count, and WhatsApp
         // records it as a negative count or as a flag depending on the build.
@@ -254,7 +264,7 @@ QString unreadSummaryScript() {
         // it appears under the list's own "unread" filter, which is the set this
         // number is meant to be the size of.
         var marked = n < 0 || !!c.markedUnread;
-        if ((n > 0 || marked) && !c.archive) {
+        if (n > 0 || marked) {
           chats++;
           messages += (n > 0 ? n : 0);
         }
@@ -267,12 +277,16 @@ QString unreadSummaryScript() {
     return walked ? { chats: chats, messages: messages, source: 'db' } : null;
   }
 
+  // The cache is per set of filters: change a setting and the number worked out
+  // under the old one is not an answer to the new question, so it is dropped
+  // rather than shown for one more beat.
+  var key = (INCLUDE_MUTED ? 'm' : '-') + (INCLUDE_ARCHIVED ? 'a' : '-');
   var W = window.__whatlyUnread ||
-          (window.__whatlyUnread = { known: null, busy: false, at: 0 });
-  // Asked often — a title change is not the only way an unread count moves, and
-  // marking a chat read or unread by hand moves it without one — so the read
-  // itself is throttled here rather than at the call site. Calls in between are
-  // free: they hand back the number already worked out.
+          (window.__whatlyUnread = { known: null, busy: false, at: 0, key: key });
+  if (W.key !== key) { W.known = null; W.at = 0; W.key = key; }
+  // Asked often — a title change is not the only way an unread count moves — so
+  // the read itself is throttled here rather than at the call site. A changed
+  // setting resets the clock above, because that answer is wanted at once.
   if (!W.busy && Date.now() - (W.at || 0) > 2500) {
     W.busy = true;
     W.at = Date.now();
@@ -284,7 +298,9 @@ QString unreadSummaryScript() {
   return JSON.stringify(W.known || fromList() ||
                         { chats: 0, messages: 0, source: 'none' });
 })()
-)JS");
+)JS")
+      .arg(includeMuted ? QStringLiteral("true") : QStringLiteral("false"),
+           includeArchived ? QStringLiteral("true") : QStringLiteral("false"));
 }
 
 } // namespace ChatNav

--- a/src/chatnav.h
+++ b/src/chatnav.h
@@ -29,7 +29,10 @@ QString unreadChatsScript(int limit);
 //
 // Falls back to counting the drawn rows if the database is not readable, which
 // is the honest degradation: WhatsApp's schema is theirs to change.
-QString unreadSummaryScript();
+// `includeMuted` and `includeArchived` are the user's answers to what the badge
+// should count; the list fallback cannot honour either, since a drawn row says
+// nothing about muting and the archived pile is not in that list at all.
+QString unreadSummaryScript(bool includeMuted, bool includeArchived);
 
 // JS that opens the chat whose row title matches `name` exactly, by dispatching
 // the pointer/mouse sequence WhatsApp Web's list rows react to (a plain click is

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -121,6 +121,22 @@ public slots:
   // on Ctrl+K, the command palette and the Add-account action.
   static bool alwaysShowAccountTabs();
   static void setAlwaysShowAccountTabs(bool enabled);
+  // What the unread badge counts. Three answers, because the right one is a
+  // matter of how someone uses WhatsApp rather than of fact: muted chats still
+  // show a pill in the list (so they are counted by default), archived ones are
+  // the pile deliberately put away (so they are not), and the badge counts
+  // conversations rather than messages unless asked otherwise — a sum is
+  // dominated by whichever group is busiest, and every chat already shows its
+  // own number.
+  static bool unreadCountIncludesMuted();
+  static void setUnreadCountIncludesMuted(bool enabled);
+  static bool unreadCountIncludesArchived();
+  static void setUnreadCountIncludesArchived(bool enabled);
+  static bool unreadCountCountsMessages();
+  static void setUnreadCountCountsMessages(bool enabled);
+  // Count again everywhere, now — for when one of those three changes and the
+  // number on screen means something different from the moment it is ticked.
+  void countUnreadEverywhere();
   int accountCount() const { return m_accounts.size(); }
   // Re-run the strip's visibility and labels after that setting changes.
   void refreshAccountStrip();
@@ -297,7 +313,6 @@ private:
   // Ask one account's page how much is unread and put it on the badges. The
   // page throttles the reading; this can be called as often as is useful.
   void countUnread(int idx);
-  void countUnreadEverywhere();
   QTimer *m_unreadTimer = nullptr;
   int accountIndexForView(const QObject *view) const;
   void refreshAccountTabs();

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -77,6 +77,42 @@ void MainWindow::setAlwaysShowAccountTabs(bool enabled) {
       QStringLiteral("alwaysShowAccountTabs"), enabled);
 }
 
+bool MainWindow::unreadCountIncludesMuted() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QStringLiteral("unreadCountIncludesMuted"), true)
+      .toBool();
+}
+
+void MainWindow::setUnreadCountIncludesMuted(bool enabled) {
+  SettingsManager::instance().settings().setValue(
+      QStringLiteral("unreadCountIncludesMuted"), enabled);
+}
+
+bool MainWindow::unreadCountIncludesArchived() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QStringLiteral("unreadCountIncludesArchived"), false)
+      .toBool();
+}
+
+void MainWindow::setUnreadCountIncludesArchived(bool enabled) {
+  SettingsManager::instance().settings().setValue(
+      QStringLiteral("unreadCountIncludesArchived"), enabled);
+}
+
+bool MainWindow::unreadCountCountsMessages() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QStringLiteral("unreadCountCountsMessages"), false)
+      .toBool();
+}
+
+void MainWindow::setUnreadCountCountsMessages(bool enabled) {
+  SettingsManager::instance().settings().setValue(
+      QStringLiteral("unreadCountCountsMessages"), enabled);
+}
+
 void MainWindow::countUnread(int idx) {
   if (idx < 0 || idx >= m_accounts.size())
     return;
@@ -85,7 +121,9 @@ void MainWindow::countUnread(int idx) {
     return; // dormant: it has nothing to count with
   const QString id = m_accounts[idx].id;
   page->runJavaScript(
-      ChatNav::unreadSummaryScript(), [this, id](const QVariant &result) {
+      ChatNav::unreadSummaryScript(unreadCountIncludesMuted(),
+                                   unreadCountIncludesArchived()),
+      [this, id](const QVariant &result) {
         const int i = accountIndexForId(id);
         if (i < 0)
           return;
@@ -106,9 +144,11 @@ void MainWindow::countUnread(int idx) {
             !counted.isDouble() || counted.toInt() < 0)
           return;
         const int chats = counted.toInt();
-        if (m_accounts[i].unread == chats)
+        const int messages = o.value(QStringLiteral("messages")).toInt();
+        const int shown = unreadCountCountsMessages() ? messages : chats;
+        if (m_accounts[i].unread == shown)
           return; // nothing to redraw
-        m_accounts[i].unread = chats;
+        m_accounts[i].unread = shown;
         refreshAccountTabs();
         updateTrayUnread();
       });

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -182,6 +182,32 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
           .settings()
           .value("rememberWindowLayout", false)
           .toBool());
+  ui->unreadCountMutedCheckBox->setChecked(MainWindow::unreadCountIncludesMuted());
+  ui->unreadCountArchivedCheckBox->setChecked(
+      MainWindow::unreadCountIncludesArchived());
+  ui->unreadCountMessagesCheckBox->setChecked(
+      MainWindow::unreadCountCountsMessages());
+  // Each one changes what a number on screen means, so the number is worked out
+  // again at once rather than at the next message to arrive anywhere.
+  const auto recount = [this]() {
+    if (auto *w = qobject_cast<MainWindow *>(this->parent()))
+      w->countUnreadEverywhere();
+  };
+  connect(ui->unreadCountMutedCheckBox, &QCheckBox::toggled, this,
+          [recount](bool on) {
+            MainWindow::setUnreadCountIncludesMuted(on);
+            recount();
+          });
+  connect(ui->unreadCountArchivedCheckBox, &QCheckBox::toggled, this,
+          [recount](bool on) {
+            MainWindow::setUnreadCountIncludesArchived(on);
+            recount();
+          });
+  connect(ui->unreadCountMessagesCheckBox, &QCheckBox::toggled, this,
+          [recount](bool on) {
+            MainWindow::setUnreadCountCountsMessages(on);
+            recount();
+          });
   ui->dismissEmojiPanelCheckBox->setChecked(
       SettingsManager::instance()
           .settings()
@@ -513,6 +539,9 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
     moveWidget(body(chatting), ui->muteAudioCheckBox, G);
     moveWidget(body(chatting), ui->autoPlayMediaCheckBox, G);
     moveWidget(body(chatting), ui->dismissEmojiPanelCheckBox, G);
+    moveWidget(body(chatting), ui->unreadCountMutedCheckBox, G);
+    moveWidget(body(chatting), ui->unreadCountArchivedCheckBox, G);
+    moveWidget(body(chatting), ui->unreadCountMessagesCheckBox, G);
     moveWidget(body(chatting), ui->hideMutedStatusCheckBox, G);
     // Two everyday messaging preferences that were filed under "Performance &
     // Privacy", where nobody would think to look for them: how photos are sent,

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -557,6 +557,36 @@ background:transparent;
               </property>
              </widget>
             </item>
+            <item row="40" column="1">
+             <widget class="QCheckBox" name="unreadCountMutedCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A muted chat still shows its own count in the list. Off, it stops adding to the badge on the account tab and to the tray.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Count muted chats as unread</string>
+              </property>
+             </widget>
+            </item>
+            <item row="41" column="1">
+             <widget class="QCheckBox" name="unreadCountArchivedCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Archived chats are kept out of the main list. On, unread messages in them add to the badge as well.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Count archived chats as unread</string>
+              </property>
+             </widget>
+            </item>
+            <item row="42" column="1">
+             <widget class="QCheckBox" name="unreadCountMessagesCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Off, the badge is the number of conversations waiting. On, it is the number of messages in them &amp;mdash; and the collapsed chat list&amp;apos;s unread filter then carries the number of conversations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Count unread messages instead of chats</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="1">
              <widget class="QCheckBox" name="dismissEmojiPanelCheckBox">
               <property name="toolTip">

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -2245,14 +2245,17 @@ private slots:
     QVERIFY(!ChatNav::unreadChatsScript(0).isEmpty()); // clamped, still valid
   }
   void unreadSummaryReadsTheDatabaseAndFallsBackToTheList() {
-    const QString js = ChatNav::unreadSummaryScript();
+    const QString js = ChatNav::unreadSummaryScript(true, false);
     // WhatsApp's own store, which is what makes the count independent of how
     // much of the virtualised list happens to be drawn.
     QVERIFY(js.contains(QLatin1String("model-storage")));
     QVERIFY(js.contains(QLatin1String("unreadCount")));
-    // Archived chats are not counted; muted ones are.
-    QVERIFY(js.contains(QLatin1String("!c.archive")));
-    QVERIFY(!js.contains(QLatin1String("muteExpiration")));
+    // Both archived and muted are the user's call, so both are read from the
+    // record and both are gated on a flag rather than hard-coded.
+    QVERIFY(js.contains(QLatin1String("c.archive")));
+    QVERIFY(js.contains(QLatin1String("muteExpiration")));
+    // A chat marked unread by hand carries no message count and still counts.
+    QVERIFY(js.contains(QLatin1String("markedUnread")));
     // And the list is still there to answer while the first read is in flight,
     // since runJavaScript cannot await a promise.
     QVERIFY(js.contains(QLatin1String("#pane-side")));
@@ -2262,6 +2265,17 @@ private slots:
     QVERIFY(js.contains(QLatin1String("walked = true")));
     QVERIFY(js.contains(QLatin1String("return walked ?")));
     QVERIFY(js.contains(QLatin1String("JSON.stringify")));
+  }
+  void unreadSummaryCarriesTheUsersFilters() {
+    const QString both = ChatNav::unreadSummaryScript(true, true);
+    QVERIFY(both.contains(QLatin1String("INCLUDE_MUTED = true")));
+    QVERIFY(both.contains(QLatin1String("INCLUDE_ARCHIVED = true")));
+    const QString neither = ChatNav::unreadSummaryScript(false, false);
+    QVERIFY(neither.contains(QLatin1String("INCLUDE_MUTED = false")));
+    QVERIFY(neither.contains(QLatin1String("INCLUDE_ARCHIVED = false")));
+    // The page keeps the last answer, so it has to know which question it was
+    // an answer to — otherwise a changed setting shows the old number.
+    QVERIFY(both.contains(QLatin1String("W.key !== key")));
   }
   void openScriptEscapesName() {
     const QString js =


### PR DESCRIPTION
Three settings for what the unread badge counts, in **Settings → Chats**. Built on #65, which is where the counting itself moved from WhatsApp's page title to its own store — merge that first.

The right answer here is a matter of how someone uses WhatsApp rather than of fact, which is why it is a setting rather than a decision:

| | default | why |
|---|---|---|
| **Count muted chats as unread** | on | A muted chat still shows its own count in the list, so leaving it out makes the badge disagree with what is on screen. But muting was a decision, and someone who made it may want the badge to respect it. For the reporter it is the difference between ten and three. |
| **Count archived chats as unread** | off | Archived is the pile deliberately put away, and WhatsApp keeps it out of the main list. |
| **Count unread messages instead of chats** | off | Conversations is the better default — every chat already shows its own number, and a sum is dominated by whichever group chat is busiest — but the volume is what some people want to see. |

**Each one recounts every account the moment it is ticked**, rather than leaving the badge to correct itself when the next message happens to arrive: a setting that changes what a number means has to change the number. The page's cached answer is keyed to the filters too, or the number worked out under the old ones would stand for one more beat.

Dogfooded on Linux across two rounds. The first found that ticking took effect only after a restart; the cause was in #65 — the count ran on WhatsApp's title changes alone, and a setting change is not one — and is fixed there. The second confirmed all three take effect at once.

**Known and deliberate:** the filters are honoured by the database read, which is the normal path. For the second before the first read lands after a page load, the count falls back to the visible rows, and that fallback cannot tell a muted chat from an unmuted one, nor see the archived pile at all.
