### PR TITLE
fix(windows): ship the MSVC runtime the executable imports (#68)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -76,8 +76,38 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
 
+      # windeployqt only copies the MSVC runtime when asked, and it finds the
+      # redistributable through VCINSTALLDIR — which the Visual Studio generator
+      # never sets, unlike a vcvars shell. Without both halves, whatly.exe ships
+      # importing MSVCP140.dll / VCRUNTIME140.dll from a machine that may not
+      # have them, and dies before main() with a missing-DLL box (issue #68).
+      # Everything downstream is packaged from build\Release, so this one step
+      # fixes the .msi and the portable .zip together.
       - name: Deploy Qt runtime
-        run: '& "$env:QT_ROOT_DIR\bin\windeployqt.exe" build\Release\whatly.exe'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if ($vs) { $env:VCINSTALLDIR = (Join-Path $vs 'VC\') }
+          & "$env:QT_ROOT_DIR\bin\windeployqt.exe" --compiler-runtime build\Release\whatly.exe
+
+      # A silent no-op here is the whole failure mode, so check rather than hope:
+      # windeployqt only warns when it cannot find the redistributable.
+      - name: Verify the MSVC runtime was deployed
+        shell: pwsh
+        run: |
+          $missing = @()
+          foreach ($dll in 'msvcp140.dll', 'vcruntime140.dll', 'vcruntime140_1.dll') {
+            if (-not (Test-Path "build\Release\$dll")) { $missing += $dll }
+          }
+          if ($missing.Count -gt 0) {
+            throw "windeployqt did not deploy the MSVC runtime: $($missing -join ', '). " +
+                  "Without it the .msi and the .zip cannot start on a machine that " +
+                  "lacks the VC++ redistributable."
+          }
+          Get-ChildItem build\Release\*140*.dll | Select-Object Name, Length
 
       # ── Optional: code-sign the built .exe via SignPath (issue #325) ──────────
       # Skipped entirely unless SIGNPATH_API_TOKEN is configured. When it is, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+**The Windows packages carry the MSVC runtime they need (#68).** `whatly.exe`
+imports `MSVCP140.dll`, `VCRUNTIME140.dll` and `VCRUNTIME140_1.dll`, and neither
+the installer nor the portable archive contained them, so on a machine without
+the Visual C++ redistributable both died before starting — a bare "the code
+execution cannot proceed" box, with nothing the application could do about it,
+because the loader fails before its first line runs. The runtime is now deployed
+beside the executable, which fixes the installer and the archive together, and
+the release build fails loudly if it is ever missing again.
+
 **A warning before a full disk corrupts your session.** When the data folder's
 disk drops below 1 GB free, Whatly now warns at startup that WhatsApp Web's
 local database can be corrupted by a truncated write (which forces you to link


### PR DESCRIPTION
Closes #68.

`whatly.exe` imports `MSVCP140.dll`, `VCRUNTIME140.dll` and `VCRUNTIME140_1.dll`, and neither the `.msi` nor the portable `.zip` from v7.1.0 contained any of them. On a machine without the Visual C++ 2015–2022 redistributable, both fail at load time with a bare "the code execution cannot proceed because MSVCP140.dll was not found".

**Nothing in the application can catch that**, which is the reason this belongs in the package rather than in a runtime check: those are static imports in the PE import table, so the loader gives up before the entry point is reached. There is no moment at which Whatly could show a dialog, a link or an instruction — any check written for this failure only ever runs on machines that do not have it.

## What was wrong

`windeployqt` needs two things before it will deploy the runtime, and the workflow had neither:

1. It only copies the compiler runtime when asked, with `--compiler-runtime`.
2. It locates the redistributable through `VCINSTALLDIR`, which the Visual Studio generator never sets — unlike a `vcvars` shell. So adding the flag alone could still have copied nothing.

Both halves are in place now, with `VCINSTALLDIR` resolved through the `vswhere` that ships on the runner, so no new action or dependency is involved.

**One step fixes both artifacts.** Everything downstream is packaged from `build\Release` — WiX harvests it for the installer, `Compress-Archive` zips it — so the deploy step is the single place where this could be missing.

## Why there is a verification step

A silent no-op is the entire failure mode: `windeployqt` only *warns* when it cannot find the redistributable, and the release would have gone out looking healthy. So the build now fails if the three DLLs are not next to the executable afterwards, in the same spirit as the existing guard on the `.msi` size and the one on the completeness of the bundled WebEngine runtime — both of which exist for exactly this reason.

## Testing

**I cannot exercise this from here, and I would rather say so than imply otherwise.** The change is a Windows CI step; the YAML parses and the step order is right (Deploy → Verify → sign → MSI → Package), but whether `vswhere` resolves and `windeployqt` copies has to be seen on the runner. The verification step is what makes that safe: if it does not work, the build stops instead of publishing packages that cannot start.

Worth noting for the same reason: **this bug cannot be reproduced on any machine that builds Whatly.** Installing the MSVC toolchain necessarily installs the runtime, so every developer machine passes and only users fail — which is presumably how it reached a release. If a live check is ever wanted, Windows Sandbox boots a clean, disposable Windows with no redistributable.

App-local deployment of these DLLs is permitted by their redistributable licence, and for the portable `.zip` it is the only thing that can work at all, since an archive cannot install a prerequisite.

## Not in this PR

A WiX `LaunchCondition`, so the installer would refuse with a sentence if the runtime were somehow still absent. With the DLLs now shipped it has nothing to catch, and it is a change to `packaging/windows/whatly.wxs` rather than to the deployment — a separate decision, mentioned in #68.
