### PR TITLE
fix(settings): the wheel scrolls what the pointer is on, not always the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+**The wheel in Settings scrolls what the pointer is on.** Opening the
+spell-check language picker and turning the wheel over its list scrolled the
+Settings page instead, leaving the list floating in mid-air over settings it had
+nothing to do with. A wheel over a list now belongs to that list, the page
+scrolls when the pointer is on the page, and whichever of the two the gesture
+started on keeps it — so a scroll down the page no longer stops dead the moment
+the pointer crosses a list.
+
 **Windows: the installer and portable zip now run on a clean machine (#68).**
 `whatly.exe` imports the MSVC runtime (`MSVCP140.dll`, `VCRUNTIME140*.dll`), but
 neither Windows artifact shipped it, so a PC without the "VC++ 2015–2022

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -15,6 +15,7 @@
 #include <QStandardItemModel>
 #include <QStandardItem>
 #include <QAbstractItemView>
+#include <QAbstractScrollArea>
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QCheckBox>
@@ -372,6 +373,14 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
   }
   foreach (QSpinBox *spinBox, this->findChildren<QSpinBox *>()) {
     spinBox->installEventFilter(this);
+  }
+  // The lists inside the page scroll themselves and keep the wheel that starts
+  // on them, but a page scroll passing over one must not stop dead there — which
+  // is what happens when Qt hands them the event directly.
+  foreach (QAbstractScrollArea *area,
+           this->findChildren<QAbstractScrollArea *>()) {
+    if (area != ui->scrollArea)
+      area->viewport()->installEventFilter(this);
   }
 
   ui->scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -840,6 +849,27 @@ bool SettingsWidget::eventFilter(QObject *obj, QEvent *event) {
   // also a child of this widget, so forwarding would come straight back here.
   if (event->type() == QEvent::Wheel && isChildOf(this, obj)) {
     auto *wheel = static_cast<QWheelEvent *>(event);
+    auto *target = qobject_cast<QWidget *>(obj);
+
+    // An open drop-down list is a window of its own, floating above the page.
+    // Scrolling the page under it left the list hanging in mid-air over settings
+    // it has nothing to do with — the wheel over a list belongs to the list. The
+    // spell-check picker reached this because its viewport carries this filter
+    // for the multi-select clicks above.
+    if (target && target->window() != this->window())
+      return QWidget::eventFilter(obj, event);
+
+    // A mouse wheel has no begin/end phase, so a gesture is however many notches
+    // arrive without a pause, and whatever the first one chose keeps the rest of
+    // them: a page scroll must not park itself the moment the pointer crosses a
+    // list, and a list being scrolled must not hand the page a stray notch when
+    // it reaches its end.
+    if (!m_wheelIdle.isValid() || m_wheelIdle.hasExpired(400))
+      m_wheelScrollsPage = !hasScrollOfItsOwn(target, wheel->angleDelta().y());
+    m_wheelIdle.restart();
+    if (!m_wheelScrollsPage)
+      return QWidget::eventFilter(obj, event);
+
     QScrollBar *bar = ui->scrollArea ? ui->scrollArea->verticalScrollBar()
                                      : nullptr;
     const int dy = wheel->angleDelta().y();
@@ -897,6 +927,24 @@ void SettingsWidget::closeEvent(QCloseEvent *event) {
   SettingsManager::instance().settings().setValue("settingsGeo",
                                                   this->saveGeometry());
   QWidget::closeEvent(event);
+}
+
+bool SettingsWidget::hasScrollOfItsOwn(QWidget *target, int angleDeltaY) const {
+  for (QWidget *w = target; w && w != ui->scrollArea; w = w->parentWidget()) {
+    auto *area = qobject_cast<QAbstractScrollArea *>(w);
+    if (!area)
+      continue;
+    const QScrollBar *bar = area->verticalScrollBar();
+    if (angleDeltaY > 0 && bar->value() > bar->minimum())
+      return true;
+    if (angleDeltaY < 0 && bar->value() < bar->maximum())
+      return true;
+    // Already at that end, so it has nothing left to give: the page takes the
+    // gesture instead of the notch being lost. Only for a gesture that starts
+    // here — one that scrolls a list down to its end keeps the list until the
+    // hand stops, rather than running on into the page.
+  }
+  return false;
 }
 
 bool SettingsWidget::isChildOf(QObject *Of, QObject *self) {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -1,6 +1,7 @@
 #ifndef SETTINGSWIDGET_H
 #define SETTINGSWIDGET_H
 
+#include <QElapsedTimer>
 #include <QWidget>
 
 class QListWidgetItem;
@@ -250,8 +251,17 @@ private:
   // Fills the language picker from the .qm files compiled into the binary, so
   // adding a translation needs no code change.
   void populateLanguages();
+  // Whether a wheel over this widget has content of its own to scroll in that
+  // direction. The page's own scroll area does not count — scrolling the page is
+  // what the caller falls back to.
+  bool hasScrollOfItsOwn(QWidget *target, int angleDeltaY) const;
 
   Ui::SettingsWidget *ui;
+  // The wheel gesture in progress: what the first notch chose to scroll, and how
+  // long since the last one. A mouse wheel has no phase to separate one gesture
+  // from the next, so a pause is what ends it.
+  QElapsedTimer m_wheelIdle;
+  bool m_wheelScrollsPage = true;
   QString engineCachePath, enginePersistentStoragePath;
   QTimer *themeSwitchTimer;
   class OllamaManager *m_ollama = nullptr; // lazy; local-model detect/download

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -12,8 +12,12 @@
 #include <QDoubleSpinBox>
 #include <QGroupBox>
 #include <QRegularExpression>
+#include <QAbstractItemView>
 #include <QLineEdit>
+#include <QListWidget>
 #include <QPointer>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QSignalSpy>
 #include <QPushButton>
 #include <QSlider>
@@ -271,6 +275,68 @@ private slots:
     QCOMPARE(spy.count(), 1);
     QCOMPARE(spy.first().at(0).toString(), QStringLiteral("Alice"));
     QCOMPARE(spy.first().at(1).toString(), QStringLiteral("hola"));
+  }
+
+  // The wheel in Settings: the page scrolls when the pointer is on the page, the
+  // thing under the pointer scrolls when it has content of its own, and whichever
+  // of the two the gesture started on keeps the rest of it.
+  void wheelStaysWithWhatItStartedOn() {
+    QTemporaryDir cache, storage;
+    SettingsWidget sw(nullptr, 0, cache.path(), storage.path());
+
+    auto *page = sw.findChild<QScrollArea *>(QStringLiteral("scrollArea"));
+    auto *list = sw.findChild<QListWidget *>(QStringLiteral("jsAddonsList"));
+    auto *combo =
+        sw.findChild<QComboBox *>(QStringLiteral("spellCheckLanguageComboBox"));
+    auto *control = sw.findChildren<QSpinBox *>().value(0);
+    QVERIFY(page && list && combo && combo->view() && control);
+
+    // Give both scrollbars somewhere to go, since this window is never shown and
+    // so was never laid out against real content.
+    QScrollBar *pageBar = page->verticalScrollBar();
+    pageBar->setRange(0, 1000);
+    pageBar->setSingleStep(10);
+    QScrollBar *listBar = list->verticalScrollBar();
+    listBar->setRange(0, 1000);
+
+    auto turn = [](QWidget *at, int notches) {
+      QWheelEvent ev(QPointF(2, 2), at->mapToGlobal(QPointF(2, 2)), QPoint(),
+                     QPoint(0, 120 * notches), Qt::NoButton, Qt::NoModifier,
+                     Qt::NoScrollPhase, false);
+      QApplication::sendEvent(at, &ev);
+    };
+    // Nothing separates one turn of a mouse wheel from the next but a pause.
+    auto letGo = [] { QTest::qWait(500); };
+
+    // On a spin box: the page moves, and the box keeps its value — a wheel must
+    // not change a setting the pointer merely passed over.
+    const int before = control->value();
+    pageBar->setValue(100);
+    turn(control, -1);
+    QVERIFY(pageBar->value() > 100);
+    QCOMPARE(control->value(), before);
+
+    // On the open language list: the page stays exactly where it was. It is a
+    // window of its own, so scrolling the page leaves it floating in mid-air over
+    // settings it has nothing to do with.
+    letGo();
+    pageBar->setValue(100);
+    listBar->setValue(500);
+    turn(combo->view()->viewport(), -1);
+    QCOMPARE(pageBar->value(), 100);
+
+    // On a list inside the page that has more to show: also the list's own.
+    letGo();
+    turn(list->viewport(), -1);
+    QCOMPARE(pageBar->value(), 100);
+
+    // But a page scroll that crosses that same list carries on down the page,
+    // instead of dying the moment the pointer touches it.
+    letGo();
+    turn(control, -1);
+    const int crossing = pageBar->value();
+    turn(list->viewport(), -1);
+    QVERIFY(pageBar->value() > crossing);
   }
 };
 


### PR DESCRIPTION
## What happens now

Open Settings, tick "Check spelling as I type", open the language picker, and turn
the mouse wheel over the list of languages. The list does not scroll. The Settings
page behind it does — and since the drop-down is a window of its own, it stays
exactly where it was, left floating over whatever settings scrolled under it. It
reads as the list having come loose from the combo box it belongs to.

## Why

Two fixes that are each right on their own.

The picker's viewport carries the SettingsWidget event filter, so a click can tick
a language without dismissing the popup (#46).

That filter's wheel branch exists because a wheel over a slider or a spin box used
to change its value under a merely passing pointer. Swallowing the event fixed
that and stopped the page dead, so reaching the bottom of Settings meant steering
around every control on the way; the branch therefore scrolls the page by hand
instead (#56).

The popup's viewport is a child of SettingsWidget, so it matched, and the branch
treated a list of languages as one more control to scroll the page for.

## The change

`SettingsWidget::eventFilter`, in its wheel branch:

- anything that is not part of the Settings window is left to Qt, which is what
  makes the drop-down list scroll itself;
- so is any list inside the page that still has content of its own to show;
- and the gesture is kept. A mouse wheel has no begin or end phase, so notches
  arriving without a pause count as one gesture, and whatever the first notch
  chose gets the rest of them.

That last part is what keeps #56 working: a scroll down the page carries on
across the two lists on the way rather than dying on one of them. It cuts the
other way too — a list scrolled to its end keeps the gesture until the hand stops,
instead of the surplus notches running on into the page.

## Testing

`tst_settings::wheelStaysWithWhatItStartedOn` sends real wheel events at a spin
box, at the open picker's viewport, and at a list inside the page, and checks the
page scrollbar each time. It fails on `main` (the page moves 100 → 130 with the
wheel over the picker) and passes with this change.

Full suite green locally: Qt 6.12.0, `ctest` 3/3.