### PR TITLE
feat(spelling): switch between the chosen languages while typing (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Settings like every other shortcut — now switches between the languages you
 chose, checking against one at a time, and comes back round to all of them at
 once for a message that mixes two. The switch takes effect on the page you are
 typing on, with no reload, and says which language it landed on; what you ticked
-in Settings is left alone, since that is the set being switched between.
+in Settings is left alone, since that is the set being switched between. Two
+things about the language box itself came out of dogfooding it: it now opens its
+list when clicked anywhere on the box rather than only on the arrow, and an open
+Settings page keeps up with a language switched from the tray or the keyboard
+instead of going on claiming "3 languages" while one of them does the work.
 
 **The update notice now says the right thing for the way you installed Whatly.**
 It told everyone alike to click through to the download page, which is wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ in Settings is left alone, since that is the set being switched between. Two
 things about the language box itself came out of dogfooding it: it now opens its
 list when clicked anywhere on the box rather than only on the arrow, and an open
 Settings page keeps up with a language switched from the tray or the keyboard
-instead of going on claiming "3 languages" while one of them does the work.
+instead of going on claiming "3 languages" while one of them does the work. The
+languages are also named correctly at last: every English dictionary read
+"American English", and pt_PT was indistinguishable from pt_BR, because the name
+was built from the language with its territory thrown away — en_GB now reads
+"British English", en_AU "Australian English", pt_PT "português europeu".
 
 **The update notice now says the right thing for the way you installed Whatly.**
 It told everyone alike to click through to the download page, which is wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ things about the language box itself came out of dogfooding it: it now opens its
 list when clicked anywhere on the box rather than only on the arrow, and an open
 Settings page keeps up with a language switched from the tray or the keyboard
 instead of going on claiming "3 languages" while one of them does the work. The
-languages are also named correctly at last: every English dictionary read
-"American English", and pt_PT was indistinguishable from pt_BR, because the name
-was built from the language with its territory thrown away — en_GB now reads
-"British English", en_AU "Australian English", pt_PT "português europeu".
+languages are also named properly at last, and named alike: every English
+dictionary read "American English" and pt_PT was indistinguishable from pt_BR,
+because the name was built from the language with its territory thrown away. Each
+entry now reads as its own language plus the place it belongs to — "British English
+(United Kingdom)", "português (Brasil)", "español (España)", "español (Argentina)" —
+one shape for the whole list.
 
 **The update notice now says the right thing for the way you installed Whatly.**
 It told everyone alike to click through to the download page, which is wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+**Switch spell-check language mid-sentence (request #41).** Ticking three
+languages in Settings means Chromium accepts any word that any of the three
+knows, so most typos in the language you are actually writing go unmarked. A new
+**Spelling** submenu in the tray icon — and **Ctrl+Alt+S**, rebindable in
+Settings like every other shortcut — now switches between the languages you
+chose, checking against one at a time, and comes back round to all of them at
+once for a message that mixes two. The switch takes effect on the page you are
+typing on, with no reload, and says which language it landed on; what you ticked
+in Settings is left alone, since that is the set being switched between.
+
 **The update notice now says the right thing for the way you installed Whatly.**
 It told everyone alike to click through to the download page, which is wrong
 advice for most installations: a Flatpak cannot replace itself from inside its

--- a/src/dictionaries.cpp
+++ b/src/dictionaries.cpp
@@ -194,4 +194,41 @@ QStringList selectedDictionaries() {
   return chosen;
 }
 
+QString focusedDictionary() {
+  const QString stored = SettingsManager::instance()
+                             .settings()
+                             .value(QStringLiteral("spellCheckFocus"))
+                             .toString();
+  // A language dropped from the picker (or uninstalled) leaves no focus behind,
+  // rather than silently checking against nothing.
+  return selectedDictionaries().contains(stored) ? stored : QString();
+}
+
+void setFocusedDictionary(const QString &code) {
+  SettingsManager::instance().settings().setValue(
+      QStringLiteral("spellCheckFocus"), code);
+}
+
+QStringList activeDictionaries() {
+  const QString focus = focusedDictionary();
+  return focus.isEmpty() ? selectedDictionaries() : QStringList{focus};
+}
+
+QString languageLabel(const QString &code) {
+  const QLocale locale(code);
+  if (locale.language() == QLocale::C)
+    return code;
+  return QLocale(locale.language()).nativeLanguageName() +
+         QStringLiteral(" (") + code + QStringLiteral(")");
+}
+
+QString nextFocus(const QStringList &chosen, const QString &current) {
+  if (chosen.size() < 2)
+    return QString(); // nothing to switch between: all of them is the only stop
+  const int at = chosen.indexOf(current);
+  if (at < 0)
+    return chosen.first(); // came from all of them, or from one since removed
+  return at + 1 < chosen.size() ? chosen.at(at + 1) : QString();
+}
+
 } // namespace Dictionaries

--- a/src/dictionaries.cpp
+++ b/src/dictionaries.cpp
@@ -216,10 +216,19 @@ QStringList activeDictionaries() {
 
 QString languageLabel(const QString &code) {
   const QLocale locale(code);
-  if (locale.language() == QLocale::C)
+  // An unrecognised code maps to the C locale (or to no language at all): show it
+  // as it stands rather than inventing a name for it.
+  if (locale.language() == QLocale::C || locale.language() == QLocale::AnyLanguage)
     return code;
-  return QLocale(locale.language()).nativeLanguageName() +
-         QStringLiteral(" (") + code + QStringLiteral(")");
+  // Ask the dictionary's own locale, not QLocale(its language). The language-only
+  // form throws the territory away and Qt fills in the likeliest one, which for
+  // English is the United States — so en_GB and en_AU both came out as "American
+  // English", and pt_PT was indistinguishable from pt_BR. Asking en_GB itself gives
+  // "British English", and pt_PT "português europeu".
+  const QString name = locale.nativeLanguageName();
+  return name.isEmpty()
+             ? code
+             : name + QStringLiteral(" (") + code + QStringLiteral(")");
 }
 
 QString nextFocus(const QStringList &chosen, const QString &current) {

--- a/src/dictionaries.cpp
+++ b/src/dictionaries.cpp
@@ -237,17 +237,28 @@ QString languageLabel(const QString &code) {
   if (locale.name() != code)
     return name + QStringLiteral(" (") + code + QStringLiteral(")");
 
-  {
-    // CLDR qualifies only the variants that are not its default, so plain
-    // "português" IS Brazilian and plain "español" IS Argentinian, while pt_PT and
-    // es_ES carry theirs. Naming the territory is what makes every entry say which
-    // one it is — skipped where the name already says it, or es_ES would read
-    // "español de España (España)".
-    const QString territory = locale.nativeTerritoryName();
-    if (!territory.isEmpty() && !name.contains(territory, Qt::CaseInsensitive))
-      name += QStringLiteral(" (") + territory + QStringLiteral(")");
+  // Every entry gets the same shape, "language (territory)", because a list where
+  // some rows carry a territory and others do not reads as an accident. CLDR
+  // qualifies only the variants that are not its default, so plain "português" IS
+  // Brazilian and plain "español" IS Argentinian while es_ES and pt_PT carry theirs
+  // — naming the territory is what makes each row say which one it is.
+  const QString territory = locale.nativeTerritoryName();
+  if (territory.isEmpty())
+    return name;
+
+  // Where the name already ends in the territory, take it out before adding it
+  // back as the qualifier: "español de España" would otherwise become "español de
+  // España (España)", which is the row that stood out in the first place. The
+  // connector left behind ("de", "do", "of") is one short word, so drop it too.
+  const int at = name.lastIndexOf(territory, -1, Qt::CaseInsensitive);
+  if (at > 0) {
+    name.truncate(at);
+    name = name.trimmed();
+    const int space = name.lastIndexOf(QLatin1Char(' '));
+    if (space > 0 && name.length() - space - 1 <= 3)
+      name.truncate(space);
   }
-  return name;
+  return name + QStringLiteral(" (") + territory + QStringLiteral(")");
 }
 
 QString nextFocus(const QStringList &chosen, const QString &current) {

--- a/src/dictionaries.cpp
+++ b/src/dictionaries.cpp
@@ -223,12 +223,31 @@ QString languageLabel(const QString &code) {
   // Ask the dictionary's own locale, not QLocale(its language). The language-only
   // form throws the territory away and Qt fills in the likeliest one, which for
   // English is the United States — so en_GB and en_AU both came out as "American
-  // English", and pt_PT was indistinguishable from pt_BR. Asking en_GB itself gives
-  // "British English", and pt_PT "português europeu".
-  const QString name = locale.nativeLanguageName();
-  return name.isEmpty()
-             ? code
-             : name + QStringLiteral(" (") + code + QStringLiteral(")");
+  // English". Asking en_GB itself gives "British English".
+  QString name = locale.nativeLanguageName();
+  if (name.isEmpty())
+    return code;
+
+  // Two cases where the code itself is the only honest thing to add. A code Qt does
+  // not model exactly: the bundle ships de_DE beside de_DE_neu (the reformed
+  // spelling) and en_US beside en-US, and Qt reads each pair as one and the same
+  // locale, so naming them by locale alone would put two entries with identical
+  // names in the picker. And a bare language like "eo", where Qt would otherwise
+  // supply whichever territory it considers likeliest — for Esperanto, "mondo".
+  if (locale.name() != code)
+    return name + QStringLiteral(" (") + code + QStringLiteral(")");
+
+  {
+    // CLDR qualifies only the variants that are not its default, so plain
+    // "português" IS Brazilian and plain "español" IS Argentinian, while pt_PT and
+    // es_ES carry theirs. Naming the territory is what makes every entry say which
+    // one it is — skipped where the name already says it, or es_ES would read
+    // "español de España (España)".
+    const QString territory = locale.nativeTerritoryName();
+    if (!territory.isEmpty() && !name.contains(territory, Qt::CaseInsensitive))
+      name += QStringLiteral(" (") + territory + QStringLiteral(")");
+  }
+  return name;
 }
 
 QString nextFocus(const QStringList &chosen, const QString &current) {

--- a/src/dictionaries.h
+++ b/src/dictionaries.h
@@ -53,6 +53,29 @@ QString preferredDictionary();
 // stored, so an upgrade from the single-language setting keeps working.
 QStringList selectedDictionaries();
 
+// The one chosen language being checked right now, or empty for all of them at
+// once. Chromium accepts a word any of its languages knows, so three languages
+// at once means three vocabularies' worth of typos going unmarked; narrowing to
+// the language actually being written is what makes the underline mean something.
+// The chosen set above is untouched by this — it stays the set to switch between.
+QString focusedDictionary();
+void setFocusedDictionary(const QString &code);
+
+// What QWebEngineProfile::setSpellCheckLanguages() is given: the focused language
+// alone while one is focused and still chosen, otherwise every chosen one.
+QStringList activeDictionaries();
+
+// The next language to focus after `current`, for a key pressed mid-sentence:
+// each of `chosen` in turn and then all of them together (an empty string) once
+// per lap. An unknown `current` starts the lap over. Pure and unit tested.
+QString nextFocus(const QStringList &chosen, const QString &current);
+
+// A language code as something to read: "Esperanto (eo)", "Español (es_ES)".
+// Built from the language alone, so es_ES reads "Español" rather than "Español de
+// España" — the code in brackets already says which territory it is. A code no
+// QLocale recognises is handed back as it stands.
+QString languageLabel(const QString &code);
+
 } // namespace Dictionaries
 
 #endif // DICTIONARIES_H

--- a/src/dictionaries.h
+++ b/src/dictionaries.h
@@ -70,10 +70,10 @@ QStringList activeDictionaries();
 // per lap. An unknown `current` starts the lap over. Pure and unit tested.
 QString nextFocus(const QStringList &chosen, const QString &current);
 
-// A language code as something to read: "Esperanto (eo)", "Español (es_ES)".
-// Built from the language alone, so es_ES reads "Español" rather than "Español de
-// España" — the code in brackets already says which territory it is. A code no
-// QLocale recognises is handed back as it stands.
+// A language code as something to read: "Esperanto (eo)", "British English
+// (en_GB)". Named by the code's own locale, so the territory is not lost — the
+// language alone would have every English dictionary reading "American English".
+// A code no QLocale recognises is handed back as it stands.
 QString languageLabel(const QString &code);
 
 } // namespace Dictionaries

--- a/src/i18n/eo.ts
+++ b/src/i18n/eo.ts
@@ -593,6 +593,34 @@ Do you wish to override the security check and continue ?   </source>
 <context>
     <name>MainWindow</name>
     <message>
+        <source>Spelling</source>
+        <translation>Literumado</translation>
+    </message>
+    <message>
+        <source>Spelling: next language</source>
+        <translation>Literumado: sekva lingvo</translation>
+    </message>
+    <message>
+        <source>All of them</source>
+        <translation>Ĉiuj elektitaj</translation>
+    </message>
+    <message>
+        <source>Spelling: %1</source>
+        <translation>Literumado: %1</translation>
+    </message>
+    <message>
+        <source>Spelling: every chosen language</source>
+        <translation>Literumado: ĉiuj elektitaj lingvoj</translation>
+    </message>
+    <message>
+        <source>No spell-check language is installed.</source>
+        <translation>Neniu literuma lingvo estas instalita.</translation>
+    </message>
+    <message>
+        <source>Only one spell-check language is chosen. Pick more in Settings to switch between them.</source>
+        <translation>Nur unu literuma lingvo estas elektita. Elektu pliajn en Agordoj por ŝalti inter ili.</translation>
+    </message>
+    <message>
         <location filename="../mainwindow_tray.cpp" line="411"/>
         <source>Recent unread</source>
         <translation>Lastaj nelegitaj</translation>
@@ -2262,6 +2290,10 @@ Bonvolu unue agordi la pasvorton en la Agordoj.</translation>
 </context>
 <context>
     <name>SettingsWidget</name>
+    <message>
+        <source>%1 of %2 chosen</source>
+        <translation>%1 el %2 elektitaj</translation>
+    </message>
     <message>
         <location filename="../settingswidget.ui" line="435"/>
         <source>VIP contacts</source>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -370,6 +370,16 @@ private:
   QList<QPointer<QWidget>> m_windowsMenuTargets;
   void refreshWindowsMenu();
   QString windowLabel(const QWidget *w) const;
+  // Which language spelling is checked against, in the tray menu: one entry per
+  // language chosen in Settings, plus all of them at once. Rebuilt each time it
+  // opens, since one can be added or downloaded while the app runs.
+  QMenu *m_spellingMenu = nullptr;
+  void rebuildSpellingMenu();
+  // Move to the next chosen language and say which it is, so the key can be
+  // pressed mid-sentence and trusted without a look at Settings.
+  void cycleSpellCheckLanguage();
+  // Check against this language alone, or against all of them when it is empty.
+  void applySpellCheckFocus(const QString &code);
   // A chat asked for before its account had a page: run it once that page
   // reports itself loaded. The name is the presence flag — the account id cannot
   // be, since the default account's id is the empty string.
@@ -623,6 +633,7 @@ private:
   QAction *m_zoomResetAction = nullptr;
   QAction *m_chatListStripAction = nullptr;
   QAction *m_findChatAction = nullptr;
+  QAction *m_spellNextAction = nullptr;
   QAction *m_translateSelectionAction = nullptr;
   QAction *m_translateComposerAction = nullptr;
 

--- a/src/mainwindow_accounts.cpp
+++ b/src/mainwindow_accounts.cpp
@@ -383,7 +383,8 @@ void MainWindow::showCommandPalette() {
       m_dndAction,         m_dnd1hAction,     m_dnd2hAction,
       m_dndMorningAction,
       m_remind1hAction,    m_remind3hAction,  m_remindTomorrowAction,
-      m_viewTabsAction,    m_viewGridAction,  m_quitAction};
+      m_viewTabsAction,    m_viewGridAction,  m_spellNextAction,
+      m_quitAction};
   for (QAction *a : actions) {
     if (!a)
       continue;

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -664,6 +664,12 @@ void MainWindow::applySpellCheckFocus(const QString &code) {
   // Live: the profiles keep their pages, and Chromium picks the new language list
   // up without a reload.
   WebEngineProfileManager::instance().applyUserSettings();
+  // A Settings page left open is looking at the language box this just changed the
+  // meaning of, and it has no way to know: it only re-reads that line when the
+  // picker itself is used. Without this it goes on claiming "3 languages" while
+  // one of the three is doing the checking.
+  if (m_settingsWidget)
+    m_settingsWidget->updateSpellCheckSummary();
   // A key pressed in the middle of a sentence has to answer for itself; the tray
   // submenu is not where someone typing is looking.
   showNotification(QApplication::applicationDisplayName(),

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -16,6 +16,8 @@
 
 #include "shortcuts.h"
 #include "chatnav.h"
+#include "dictionaries.h"
+#include "webengineprofilemanager.h"
 #include "aiassistant.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -139,6 +141,18 @@ void MainWindow::createActions() {
   connect(m_findChatAction, &QAction::triggered, this,
           &MainWindow::focusChatSearch);
   addAction(m_findChatAction);
+
+  // Which language spelling is checked against, switched from the keyboard while
+  // writing (#41). Ctrl+Alt+S because WhatsApp Web binds nothing with Alt in the
+  // message box, which is exactly where this key is pressed — and an application
+  // shortcut so it answers from a detached account window too.
+  m_spellNextAction = new QAction(tr("Spelling: next language"), this);
+  m_spellNextAction->setShortcut(
+      QKeySequence(Qt::Modifier::CTRL | Qt::Modifier::ALT | Qt::Key_S));
+  m_spellNextAction->setShortcutContext(Qt::ApplicationShortcut);
+  connect(m_spellNextAction, &QAction::triggered, this,
+          &MainWindow::cycleSpellCheckLanguage);
+  addAction(m_spellNextAction);
 
   m_settingsAction = new QAction(tr("&Settings"), this);
   m_settingsAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_P));
@@ -355,6 +369,7 @@ void MainWindow::createActions() {
       // be bound to whatever the user likes.
       {m_chatListStripAction, "chatListStrip", tr("Collapse the chat list")},
       {m_findChatAction, "findChat", tr("Find in chats")},
+      {m_spellNextAction, "spellNext", tr("Spelling: next language")},
       {m_translateSelectionAction, "translateSelection",
        tr("Translate selection")},
       {m_translateComposerAction, "translateComposer",
@@ -422,6 +437,10 @@ void MainWindow::createTrayIcon() {
   m_trayIconMenu->addAction(m_viewGridAction);
   m_trayIconMenu->addAction(m_addAccountAction);
   m_trayIconMenu->addSeparator();
+  // Which language spelling is checked against. Built each time it opens, and
+  // hidden while there is only one language to check against — a list of one is
+  // not a switch. The keyboard reaches the same thing (m_spellNextAction).
+  m_spellingMenu = m_trayIconMenu->addMenu(tr("Spelling"));
   m_trayIconMenu->addAction(m_toggleThemeAction);
   m_trayIconMenu->addAction(m_settingsAction);
   m_trayIconMenu->addAction(m_aboutAction);
@@ -459,6 +478,10 @@ void MainWindow::createTrayIcon() {
   m_systemTrayIcon->setContextMenu(m_trayIconMenu);
   connect(m_trayIconMenu, &QMenu::aboutToShow, this,
           &MainWindow::checkWindowState);
+  // On the whole menu opening, not on the submenu: whether "Spelling" is there at
+  // all has to be settled before the pointer reaches it.
+  connect(m_trayIconMenu, &QMenu::aboutToShow, this,
+          &MainWindow::rebuildSpellingMenu);
   connect(m_systemTrayIcon, &QSystemTrayIcon::activated, this,
           &MainWindow::iconActivated);
 
@@ -581,6 +604,73 @@ void MainWindow::refreshWindowsMenu() {
     m_windowsMenuTargets << QPointer<QWidget>(order[i]);
   }
   m_windowsMenu->menuAction()->setVisible(order.size() > 1);
+}
+
+// ── Spell-check language (#41) ─────────────────────────────────────────────────
+
+void MainWindow::rebuildSpellingMenu() {
+  if (!m_spellingMenu)
+    return;
+  const QStringList chosen = Dictionaries::selectedDictionaries();
+  // One language is not something to switch between, and none at all means there
+  // is no checker running to switch anything on.
+  m_spellingMenu->menuAction()->setVisible(chosen.size() > 1);
+  if (chosen.size() < 2)
+    return;
+
+  m_spellingMenu->clear();
+  // clear() takes the entries and leaves the group they were in behind, so a
+  // session's worth of menu openings would pile them up.
+  qDeleteAll(m_spellingMenu->findChildren<QActionGroup *>());
+  auto *group = new QActionGroup(m_spellingMenu); // radio marks, not tick boxes
+  const QString focus = Dictionaries::focusedDictionary();
+  for (const QString &code : chosen) {
+    QAction *entry = m_spellingMenu->addAction(Dictionaries::languageLabel(code));
+    entry->setCheckable(true);
+    entry->setChecked(code == focus);
+    entry->setActionGroup(group);
+    connect(entry, &QAction::triggered, this,
+            [this, code]() { applySpellCheckFocus(code); });
+  }
+  m_spellingMenu->addSeparator();
+  // All of them at once is Chromium's own behaviour and the state to come back
+  // to, not a fourth language: a message written in two of them wants both.
+  QAction *all = m_spellingMenu->addAction(tr("All of them"));
+  all->setCheckable(true);
+  all->setChecked(focus.isEmpty());
+  all->setActionGroup(group);
+  connect(all, &QAction::triggered, this,
+          [this]() { applySpellCheckFocus(QString()); });
+}
+
+void MainWindow::cycleSpellCheckLanguage() {
+  const QStringList chosen = Dictionaries::selectedDictionaries();
+  if (chosen.size() < 2) {
+    // Pressed with nothing to switch to. Say why rather than doing nothing at
+    // all, since the key gave no sign either way.
+    showNotification(QApplication::applicationDisplayName(),
+                     chosen.isEmpty()
+                         ? tr("No spell-check language is installed.")
+                         : tr("Only one spell-check language is chosen. Pick "
+                              "more in Settings to switch between them."));
+    return;
+  }
+  applySpellCheckFocus(
+      Dictionaries::nextFocus(chosen, Dictionaries::focusedDictionary()));
+}
+
+void MainWindow::applySpellCheckFocus(const QString &code) {
+  Dictionaries::setFocusedDictionary(code);
+  // Live: the profiles keep their pages, and Chromium picks the new language list
+  // up without a reload.
+  WebEngineProfileManager::instance().applyUserSettings();
+  // A key pressed in the middle of a sentence has to answer for itself; the tray
+  // submenu is not where someone typing is looking.
+  showNotification(QApplication::applicationDisplayName(),
+                   code.isEmpty()
+                       ? tr("Spelling: every chosen language")
+                       : tr("Spelling: %1")
+                             .arg(Dictionaries::languageLabel(code)));
 }
 
 void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -819,6 +819,22 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
 
 bool SettingsWidget::eventFilter(QObject *obj, QEvent *event) {
 
+  // The spell-check combo has to be editable to show a summary of what is ticked
+  // rather than one entry's text — and an editable combo opens its list only when
+  // the arrow is clicked, so clicking the box itself did nothing whatsoever. Open
+  // it from anywhere on the box, the way every other combo on this page behaves.
+  if (event->type() == QEvent::MouseButtonPress &&
+      ui->spellCheckLanguageComboBox->lineEdit() &&
+      obj == ui->spellCheckLanguageComboBox->lineEdit()) {
+    QAbstractItemView *view = ui->spellCheckLanguageComboBox->view();
+    // A second click closes it again, since that is what clicking a combo does.
+    if (view && view->isVisible())
+      ui->spellCheckLanguageComboBox->hidePopup();
+    else
+      ui->spellCheckLanguageComboBox->showPopup();
+    return true;
+  }
+
   // The spell-check language combo is a multi-select: a click on the drop-down
   // list toggles that language's checkbox and keeps the list open, instead of
   // picking one entry and closing (which is what a plain combo does).
@@ -2288,6 +2304,10 @@ void SettingsWidget::populateSpellCheck() {
     combo->setEditable(true);
     combo->lineEdit()->setReadOnly(true);
     combo->lineEdit()->setFocusPolicy(Qt::NoFocus);
+    // Being editable is what lets it show a summary instead of one entry's text,
+    // and it is also why clicking the box did nothing: an editable combo opens its
+    // list from the arrow alone. See eventFilter().
+    combo->lineEdit()->installEventFilter(this);
   }
   auto *model = new QStandardItemModel(combo);
   for (const QString &dictionary : available) {

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -827,11 +827,18 @@ bool SettingsWidget::eventFilter(QObject *obj, QEvent *event) {
       ui->spellCheckLanguageComboBox->lineEdit() &&
       obj == ui->spellCheckLanguageComboBox->lineEdit()) {
     QAbstractItemView *view = ui->spellCheckLanguageComboBox->view();
-    // A second click closes it again, since that is what clicking a combo does.
-    if (view && view->isVisible())
-      ui->spellCheckLanguageComboBox->hidePopup();
-    else
-      ui->spellCheckLanguageComboBox->showPopup();
+    // Opening it from inside the press made it flash and vanish: the list appears
+    // under the pointer, the release that follows lands on it, and a release on a
+    // freshly shown popup reads as a click outside the list, which closes it. Qt's
+    // own arrow path blocks that one release with an internal timer this cannot
+    // reach — so open the list once this click has finished being delivered.
+    //
+    // Nothing to do when it is already open: the list has the mouse then, so the
+    // press never arrives here and Qt closes it as a click outside, which is the
+    // behaviour wanted anyway.
+    if (!view || !view->isVisible())
+      QTimer::singleShot(0, ui->spellCheckLanguageComboBox,
+                         &QComboBox::showPopup);
     return true;
   }
 

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -2291,15 +2291,7 @@ void SettingsWidget::populateSpellCheck() {
   }
   auto *model = new QStandardItemModel(combo);
   for (const QString &dictionary : available) {
-    // Build from the language alone so "es_ES" reads "Español", not "Español
-    // de España" — the code in parentheses already disambiguates the territory.
-    const QLocale locale(dictionary);
-    const QString name = locale.language() == QLocale::C
-                             ? dictionary
-                             : QLocale(locale.language()).nativeLanguageName() +
-                                   QStringLiteral(" (") + dictionary +
-                                   QStringLiteral(")");
-    auto *item = new QStandardItem(name);
+    auto *item = new QStandardItem(Dictionaries::languageLabel(dictionary));
     item->setData(dictionary, Qt::UserRole);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
     item->setCheckState(selected.contains(dictionary) ? Qt::Checked
@@ -2311,14 +2303,9 @@ void SettingsWidget::populateSpellCheck() {
   for (const DictionaryEntry &entry : m_dictCatalog) {
     if (available.contains(entry.code))
       continue;
-    const QLocale locale(entry.code);
-    const QString name =
-        locale.language() == QLocale::C
-            ? entry.code
-            : QLocale(locale.language()).nativeLanguageName() +
-                  QStringLiteral(" (") + entry.code + QStringLiteral(")");
-    auto *item = new QStandardItem(name + QStringLiteral("  \u2014 ") +
-                                   tr("download"));
+    auto *item =
+        new QStandardItem(Dictionaries::languageLabel(entry.code) +
+                          QStringLiteral("  \u2014 ") + tr("download"));
     item->setData(entry.code, Qt::UserRole);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
     item->setCheckState(selected.contains(entry.code) ? Qt::Checked
@@ -2359,10 +2346,15 @@ void SettingsWidget::populateSpellCheck() {
 void SettingsWidget::updateSpellCheckSummary() {
   const QStringList selected = Dictionaries::selectedDictionaries();
   QString text;
+  const QString focus = Dictionaries::focusedDictionary();
   if (selected.isEmpty())
     text = tr("Choose languages\u2026"); // hints the picker takes several
   else if (selected.size() == 1)
     text = selected.first();
+  else if (!focus.isEmpty())
+    // Ticked three and checking against one of them: saying "3 languages" here
+    // would be a half-truth, and the checker's behaviour the puzzling half.
+    text = tr("%1 of %2 chosen").arg(focus).arg(selected.size());
   else
     text = tr("%1 languages").arg(selected.size());
   ui->spellCheckLanguageComboBox->setCurrentText(text);

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -77,6 +77,11 @@ public slots:
   void updateAppLockPasswordViewer();
   void appAutoLockingSetChecked(bool checked);
   void toggleTheme();
+  // What the language box says about the spell checker. Public because the focused
+  // language can be changed from outside this window — the tray menu and the
+  // keyboard both do it — and an open Settings page went on showing the count it
+  // had ("3 languages") while one of those three was doing the work.
+  void updateSpellCheckSummary();
 protected slots:
   bool eventFilter(QObject *obj, QEvent *event);
   void closeEvent(QCloseEvent *event);
@@ -246,7 +251,6 @@ private:
   void populateChatListPreviewSize();
   void populateFontFamilies();
   void populateSpellCheck();
-  void updateSpellCheckSummary();
   void saveSpellCheckLanguages();
   // Fills the language picker from the .qm files compiled into the binary, so
   // adding a translation needs no code change.

--- a/src/webengineprofilemanager.cpp
+++ b/src/webengineprofilemanager.cpp
@@ -251,8 +251,9 @@ void WebEngineProfileManager::applyUserSettingsTo(QWebEngineProfile *profile,
     // Chromium's spell checker underlines nothing unless it is given a language
     // whose .bdic it can actually find, so an empty list is the same as off. It
     // checks against every language in the list at once, which is the point of
-    // letting more than one be selected.
-    const QStringList dictionaries = Dictionaries::selectedDictionaries();
+    // letting more than one be selected — and the reason a single one of them can
+    // be focused while writing in that language (see activeDictionaries()).
+    const QStringList dictionaries = Dictionaries::activeDictionaries();
     const bool spellCheck =
         s.value(QStringLiteral("spellCheckEnabled"), true).toBool() &&
         !dictionaries.isEmpty();

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -322,6 +322,76 @@ private slots:
         QStringLiteral("spellCheckLanguages"));
     qunsetenv("QTWEBENGINE_DICTIONARIES_PATH");
   }
+  // Focusing one of the chosen languages (#41): what Chromium is given, and the
+  // order a key mid-sentence walks through.
+  void focusOneChosenLanguage() {
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    for (const QString &n : {"en_US", "es_ES", "eo"}) {
+      QFile f(dir.filePath(n + QStringLiteral(".bdic")));
+      QVERIFY(f.open(QIODevice::WriteOnly));
+      f.write("BDIC-stub");
+      f.close();
+    }
+    qputenv("QTWEBENGINE_DICTIONARIES_PATH", dir.path().toLocal8Bit());
+    const QStringList three{QStringLiteral("en_US"), QStringLiteral("eo"),
+                            QStringLiteral("es_ES")};
+    SettingsManager::instance().settings().setValue(
+        QStringLiteral("spellCheckLanguages"), three);
+    QCOMPARE(Dictionaries::selectedDictionaries(), three);
+
+    // Nothing focused: every chosen language at once, as before.
+    Dictionaries::setFocusedDictionary(QString());
+    QVERIFY(Dictionaries::focusedDictionary().isEmpty());
+    QCOMPARE(Dictionaries::activeDictionaries(), three);
+
+    // Focused: that one alone, however many are ticked.
+    Dictionaries::setFocusedDictionary(QStringLiteral("eo"));
+    QCOMPARE(Dictionaries::focusedDictionary(), QStringLiteral("eo"));
+    QCOMPARE(Dictionaries::activeDictionaries(),
+             QStringList{QStringLiteral("eo")});
+
+    // Focused on one that is no longer ticked: back to all of them, rather than
+    // checking against a language that is not in the picker any more.
+    SettingsManager::instance().settings().setValue(
+        QStringLiteral("spellCheckLanguages"),
+        QStringList{QStringLiteral("en_US"), QStringLiteral("es_ES")});
+    QVERIFY(Dictionaries::focusedDictionary().isEmpty());
+    QCOMPARE(Dictionaries::activeDictionaries().size(), 2);
+
+    // One lap: each language in turn, then all of them, then round again.
+    QCOMPARE(Dictionaries::nextFocus(three, QString()), QStringLiteral("en_US"));
+    QCOMPARE(Dictionaries::nextFocus(three, QStringLiteral("en_US")),
+             QStringLiteral("eo"));
+    QCOMPARE(Dictionaries::nextFocus(three, QStringLiteral("eo")),
+             QStringLiteral("es_ES"));
+    QVERIFY(Dictionaries::nextFocus(three, QStringLiteral("es_ES")).isEmpty());
+    // A language dropped from the picker since it was focused starts the lap over.
+    QCOMPARE(Dictionaries::nextFocus(three, QStringLiteral("zz_ZZ")),
+             QStringLiteral("en_US"));
+    // Nothing to switch between: all of them is the only stop there is.
+    QVERIFY(Dictionaries::nextFocus({QStringLiteral("eo")},
+                                    QStringLiteral("eo"))
+                .isEmpty());
+    QVERIFY(Dictionaries::nextFocus({}, QString()).isEmpty());
+
+    // Labels: the language's own name with the code to tell territories apart,
+    // and an unknown code left exactly as it is.
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("es_ES"))
+                .endsWith(QStringLiteral(" (es_ES)")));
+    // ...and a name in front of it, not only the code again ("español (es_ES)" —
+    // Spanish does not capitalise its own language name).
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("es_ES")).size() >
+            QStringLiteral(" (es_ES)").size());
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("zz_ZZ")),
+             QStringLiteral("zz_ZZ"));
+
+    SettingsManager::instance().settings().remove(
+        QStringLiteral("spellCheckLanguages"));
+    SettingsManager::instance().settings().remove(
+        QStringLiteral("spellCheckFocus"));
+    qunsetenv("QTWEBENGINE_DICTIONARIES_PATH");
+  }
   // A dictionary named exactly after the system locale is the preferred one
   // (covers the exact-locale-match branch of preferredDictionary).
   void localeExactMatch() {

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -375,14 +375,16 @@ private slots:
                 .isEmpty());
     QVERIFY(Dictionaries::nextFocus({}, QString()).isEmpty());
 
-    // Labels: the language's own name with the code to tell territories apart,
-    // and an unknown code left exactly as it is.
-    QVERIFY(Dictionaries::languageLabel(QStringLiteral("es_ES"))
-                .endsWith(QStringLiteral(" (es_ES)")));
-    // ...and a name in front of it, not only the code again ("español (es_ES)" —
-    // Spanish does not capitalise its own language name).
-    QVERIFY(Dictionaries::languageLabel(QStringLiteral("es_ES")).size() >
-            QStringLiteral(" (es_ES)").size());
+    // Labels: one shape for every entry, the language in its own words and the
+    // territory that says which variant it is — so a list of them reads as a list
+    // rather than as an accident. tst_settings pins the pairs that used to collide.
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("es_ES")),
+             QStringLiteral("español (España)"));
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("eo"))
+                .startsWith(QStringLiteral("Esperanto")));
+    // An unknown code is left exactly as it is.
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("zz_ZZ")),
+             QStringLiteral("zz_ZZ"));
     QCOMPARE(Dictionaries::languageLabel(QStringLiteral("zz_ZZ")),
              QStringLiteral("zz_ZZ"));
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -378,6 +378,23 @@ private slots:
     // Three ticked, none focused: the count.
     QCOMPARE(combo->lineEdit()->text(), QStringLiteral("3 languages"));
 
+    // Every English dictionary used to read "American English": the label was built
+    // from the language alone, and Qt fills the dropped territory back in with the
+    // likeliest one. Two English variants must not share a name.
+    const QString us = Dictionaries::languageLabel(QStringLiteral("en_US"));
+    const QString gb = Dictionaries::languageLabel(QStringLiteral("en_GB"));
+    QVERIFY(us != gb);
+    QVERIFY(gb.startsWith(QStringLiteral("British")));
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("en_AU"))
+                .startsWith(QStringLiteral("Australian")));
+    // ...and the same trap on the other side of pt: two Portuguese, two names.
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("pt_BR")) !=
+            Dictionaries::languageLabel(QStringLiteral("pt_PT")));
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("eo")),
+             QStringLiteral("Esperanto (eo)"));
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("zz_ZZ")),
+             QStringLiteral("zz_ZZ"));
+
     // What the tray menu and Ctrl+Alt+S do, followed by the call MainWindow makes.
     Dictionaries::setFocusedDictionary(QStringLiteral("eo"));
     sw.updateSpellCheckSummary();
@@ -388,13 +405,23 @@ private slots:
     sw.updateSpellCheckSummary();
     QCOMPARE(combo->lineEdit()->text(), QStringLiteral("3 languages"));
 
-    // A click anywhere on the box opens the list, and a second one closes it.
+    // A click anywhere on the box opens the list — deferred to the next turn of
+    // the event loop, so the release that follows the press cannot be mistaken for
+    // a click outside a list that has only just appeared (which made it flash and
+    // vanish). Closing again is Qt's own doing: with the list open it holds the
+    // mouse, and a synthesised press cannot reproduce that grab, so this checks
+    // only the half that is ours.
     QVERIFY(combo->view());
     QVERIFY(!combo->view()->isVisible());
     QTest::mousePress(combo->lineEdit(), Qt::LeftButton);
-    QVERIFY(combo->view()->isVisible());
-    QTest::mousePress(combo->lineEdit(), Qt::LeftButton);
+    QTest::mouseRelease(combo->lineEdit(), Qt::LeftButton);
+    // Not yet — that is the whole point of the fix, and the assertion that fails if
+    // anyone opens it straight from the press again. The flash-and-vanish itself
+    // needs a real mouse grab and cannot be reproduced here, so this pins the
+    // mechanism instead of the symptom.
     QVERIFY(!combo->view()->isVisible());
+    QTRY_VERIFY(combo->view()->isVisible());
+    combo->hidePopup();
 
     s.remove(QStringLiteral("spellCheckLanguages"));
     s.remove(QStringLiteral("spellCheckFocus"));

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -396,9 +396,13 @@ private slots:
                 .contains(QStringLiteral("Argentina")));
     QVERIFY(Dictionaries::languageLabel(QStringLiteral("pt_BR")) !=
             Dictionaries::languageLabel(QStringLiteral("pt_PT")));
-    // ...but not twice, or es_ES reads "español de España (España)".
+    // ...and exactly once: "español de España" has its territory taken out of the
+    // name before it goes back in as the qualifier, so the whole list keeps one
+    // shape and the Spanish entries read alike.
     QCOMPARE(Dictionaries::languageLabel(QStringLiteral("es_ES")),
-             QStringLiteral("español de España"));
+             QStringLiteral("español (España)"));
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("es_MX")),
+             QStringLiteral("español (México)"));
     // The bundle ships both of these and Qt reads them as one locale, so the label
     // has to keep them apart.
     QVERIFY(Dictionaries::languageLabel(QStringLiteral("de_DE")) !=

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -6,13 +6,14 @@
 // dialog that still appears so nothing can block the run.
 #include <QtTest>
 #include <QApplication>
+#include <QAbstractItemView>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
+#include <QFile>
 #include <QDoubleSpinBox>
 #include <QGroupBox>
 #include <QRegularExpression>
-#include <QAbstractItemView>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPointer>
@@ -28,7 +29,9 @@
 #include <QToolButton>
 
 #include "customtitlebar.h"
+#include "dictionaries.h"
 #include "quickcompose.h"
+#include "settingsmanager.h"
 #include "settingswidget.h"
 
 class TstSettings : public QObject {
@@ -337,6 +340,65 @@ private slots:
     const int crossing = pageBar->value();
     turn(list->viewport(), -1);
     QVERIFY(pageBar->value() > crossing);
+  }
+
+  // Dogfood round 18, two findings against the spell-check picker.
+  //
+  // One: the language box shows a summary of what is ticked, but which language is
+  // being checked can be changed from the tray menu or the keyboard — and an open
+  // Settings page went on showing "3 languages" while one of the three was doing
+  // the work, because it only re-read that line when the picker itself was used.
+  //
+  // Two: the box is editable so it can show that summary, which is exactly why a
+  // click on it did nothing — an editable combo opens its list from the arrow alone.
+  void languageBoxFollowsTheFocusAndOpensOnClick() {
+    QTemporaryDir dicts;
+    QVERIFY(dicts.isValid());
+    for (const QString &n : {"eo", "en_US", "es_ES"}) {
+      QFile f(dicts.filePath(n + QStringLiteral(".bdic")));
+      QVERIFY(f.open(QIODevice::WriteOnly));
+      f.write("BDIC-stub");
+      f.close();
+    }
+    // Set before constructing: the picker is filled during construction.
+    qputenv("QTWEBENGINE_DICTIONARIES_PATH", dicts.path().toLocal8Bit());
+    auto &s = SettingsManager::instance().settings();
+    s.setValue(QStringLiteral("spellCheckEnabled"), true);
+    s.setValue(QStringLiteral("spellCheckLanguages"),
+               QStringList{QStringLiteral("en_US"), QStringLiteral("eo"),
+                           QStringLiteral("es_ES")});
+    s.remove(QStringLiteral("spellCheckFocus"));
+
+    QTemporaryDir cache, storage;
+    SettingsWidget sw(nullptr, 0, cache.path(), storage.path());
+    auto *combo =
+        sw.findChild<QComboBox *>(QStringLiteral("spellCheckLanguageComboBox"));
+    QVERIFY(combo && combo->lineEdit());
+
+    // Three ticked, none focused: the count.
+    QCOMPARE(combo->lineEdit()->text(), QStringLiteral("3 languages"));
+
+    // What the tray menu and Ctrl+Alt+S do, followed by the call MainWindow makes.
+    Dictionaries::setFocusedDictionary(QStringLiteral("eo"));
+    sw.updateSpellCheckSummary();
+    QCOMPARE(combo->lineEdit()->text(), QStringLiteral("eo of 3 chosen"));
+
+    // ...and back again, so the line is not one-way.
+    Dictionaries::setFocusedDictionary(QString());
+    sw.updateSpellCheckSummary();
+    QCOMPARE(combo->lineEdit()->text(), QStringLiteral("3 languages"));
+
+    // A click anywhere on the box opens the list, and a second one closes it.
+    QVERIFY(combo->view());
+    QVERIFY(!combo->view()->isVisible());
+    QTest::mousePress(combo->lineEdit(), Qt::LeftButton);
+    QVERIFY(combo->view()->isVisible());
+    QTest::mousePress(combo->lineEdit(), Qt::LeftButton);
+    QVERIFY(!combo->view()->isVisible());
+
+    s.remove(QStringLiteral("spellCheckLanguages"));
+    s.remove(QStringLiteral("spellCheckFocus"));
+    qunsetenv("QTWEBENGINE_DICTIONARIES_PATH");
   }
 };
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -387,9 +387,22 @@ private slots:
     QVERIFY(gb.startsWith(QStringLiteral("British")));
     QVERIFY(Dictionaries::languageLabel(QStringLiteral("en_AU"))
                 .startsWith(QStringLiteral("Australian")));
-    // ...and the same trap on the other side of pt: two Portuguese, two names.
+    // The other half of it: CLDR gives its *default* variant the bare name, so
+    // "português" is the Brazilian one and "español" the Argentinian one, and
+    // neither said so. The territory has to be named for those.
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("pt_BR"))
+                .contains(QStringLiteral("Brasil")));
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("es_AR"))
+                .contains(QStringLiteral("Argentina")));
     QVERIFY(Dictionaries::languageLabel(QStringLiteral("pt_BR")) !=
             Dictionaries::languageLabel(QStringLiteral("pt_PT")));
+    // ...but not twice, or es_ES reads "español de España (España)".
+    QCOMPARE(Dictionaries::languageLabel(QStringLiteral("es_ES")),
+             QStringLiteral("español de España"));
+    // The bundle ships both of these and Qt reads them as one locale, so the label
+    // has to keep them apart.
+    QVERIFY(Dictionaries::languageLabel(QStringLiteral("de_DE")) !=
+            Dictionaries::languageLabel(QStringLiteral("de_DE_neu")));
     QCOMPARE(Dictionaries::languageLabel(QStringLiteral("eo")),
              QStringLiteral("Esperanto (eo)"));
     QCOMPARE(Dictionaries::languageLabel(QStringLiteral("zz_ZZ")),


### PR DESCRIPTION
## The problem with checking against three languages at once

`QWebEngineProfile::setSpellCheckLanguages()` hands Chromium a list, and Chromium
accepts a word that **any** language on the list knows. Tick Esperanto, English and
Spanish — which the multi-select picker from #46 invites — and you have three
vocabularies' worth of typos going unmarked in whichever language you are actually
writing. `son`, `mia`, `pero`, `dona`, `late`, `come` are all real words in one of
the three. The underline stops meaning much.

The picker is the right way to say *which languages I use*. It is the wrong way to
say *which one I am writing in right now*: that changes between messages, and it
is two clicks and a Settings window away.

## The change

A **Spelling** submenu in the tray icon, and **Ctrl+Alt+S**, move between the
chosen languages — narrowing the checker to one at a time, with **all of them at
once** as one more stop on the lap, for a message that mixes two.

- The ticked set is untouched. It is the set being switched between, so a quick
  switch that rewrote it would be eating its own input. The focused language lives
  in its own setting (`spellCheckFocus`).
- Reading that setting back checks the language is still one of the chosen ones,
  so unticking the focused one — or uninstalling its dictionary — means all of
  them again, never a checker pointed at a language that is no longer there.
- It takes effect on the page being typed on: `applyUserSettings()` re-applies the
  language list to every profile, no reload.
- It says which language it landed on, because a key pressed mid-sentence has to
  answer for itself, and the tray submenu is not where someone typing is looking.
- The submenu hides itself while fewer than two languages are chosen: a list of one
  is not a switch. Pressing the key in that state says why rather than doing
  nothing at all.
- Settings agrees with it: with a language focused the picker reads `eo of 3
  chosen` instead of claiming `3 languages` while one of them is doing the work.

**Ctrl+Alt+S**: this key is pressed with the cursor in the message box, and
WhatsApp Web binds nothing with Alt there — the reason `m_chatListStripAction` has
no default key is that Ctrl+B is Bold in that box. It goes through the shortcut
registry, so it can be rebound or cleared in Settings, and it is an application
shortcut, so a detached account window answers it too. It is in the Ctrl+K palette
as well.

## Also in here

`populateSpellCheck()` had two copies of the code that turns `es_ES` into
`español (es_ES)`; the tray menu wanted a third. They are now one
`Dictionaries::languageLabel()`.

## Testing

`tst_logic::focusOneChosenLanguage` covers what Chromium is given in each state,
the focus being dropped when its language is unticked, the order of a lap
(each language, then all of them, then round again), an unknown focus starting the
lap over, and the label format.

Full suite green locally: Qt 6.12.0, `ctest` 3/3.

Esperanto translations included; the other locales have the new strings untranslated.
