### PR TITLE
fix(spelling): open the language list through the arrow, not through showPopup()

### DIFF
--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -10,8 +10,10 @@
 #include <QDir>
 #include <QLocale>
 #include <QMessageBox>
+#include <QApplication>
 #include <QStyle>
 #include <QStyleFactory>
+#include <QStyleOptionComboBox>
 #include <QStandardItemModel>
 #include <QStandardItem>
 #include <QAbstractItemView>
@@ -826,19 +828,29 @@ bool SettingsWidget::eventFilter(QObject *obj, QEvent *event) {
   if (event->type() == QEvent::MouseButtonPress &&
       ui->spellCheckLanguageComboBox->lineEdit() &&
       obj == ui->spellCheckLanguageComboBox->lineEdit()) {
-    QAbstractItemView *view = ui->spellCheckLanguageComboBox->view();
-    // Opening it from inside the press made it flash and vanish: the list appears
-    // under the pointer, the release that follows lands on it, and a release on a
-    // freshly shown popup reads as a click outside the list, which closes it. Qt's
-    // own arrow path blocks that one release with an internal timer this cannot
-    // reach — so open the list once this click has finished being delivered.
+    auto *combo = ui->spellCheckLanguageComboBox;
+    // Hand the click to the arrow rather than calling showPopup() ourselves.
     //
-    // Nothing to do when it is already open: the list has the mouse then, so the
-    // press never arrives here and Qt closes it as a click outside, which is the
-    // behaviour wanted anyway.
-    if (!view || !view->isVisible())
-      QTimer::singleShot(0, ui->spellCheckLanguageComboBox,
-                         &QComboBox::showPopup);
+    // showPopup() alone made the list flash and vanish: it appears under the
+    // pointer and the release that follows lands on it, which a popup shown this
+    // instant reads as a click outside itself. Qt's own arrow path is the only one
+    // that swallows that release — QComboBox::mousePressEvent starts the container's
+    // block-release timer, and nothing public starts it — and deferring the call
+    // past the release did not help either, because the list is then shown with the
+    // combo still unfocused and closes on the activation change instead. Which is
+    // why clicking the arrow once cured it for the rest of the session, and why the
+    // fix is to take that same path every time.
+    QStyleOptionComboBox opt;
+    opt.initFrom(combo);
+    const QPoint arrow =
+        combo->style()
+            ->subControlRect(QStyle::CC_ComboBox, &opt,
+                             QStyle::SC_ComboBoxArrow, combo)
+            .center();
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(arrow),
+                      QPointF(combo->mapToGlobal(arrow)), Qt::LeftButton,
+                      Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(combo, &press);
     return true;
   }
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -432,13 +432,16 @@ private slots:
     QVERIFY(!combo->view()->isVisible());
     QTest::mousePress(combo->lineEdit(), Qt::LeftButton);
     QTest::mouseRelease(combo->lineEdit(), Qt::LeftButton);
-    // Not yet — that is the whole point of the fix, and the assertion that fails if
-    // anyone opens it straight from the press again. The flash-and-vanish itself
-    // needs a real mouse grab and cannot be reproduced here, so this pins the
-    // mechanism instead of the symptom.
-    QVERIFY(!combo->view()->isVisible());
-    QTRY_VERIFY(combo->view()->isVisible());
+    QVERIFY2(combo->view()->isVisible(),
+             "a click on the box must open the list and it must survive the "
+             "release that follows");
     combo->hidePopup();
+    // What this cannot check: the list flashing up and vanishing again, which is
+    // what the click used to do. That needs the mouse grab a shown popup takes, and
+    // a synthesised release goes to the line edit rather than to the list, so it
+    // stays open here either way. The fix for it — handing the click to the arrow so
+    // Qt's own path swallows the release — is verified by hand; this pins the part
+    // that can be: that clicking the box opens the list at all.
 
     s.remove(QStringLiteral("spellCheckLanguages"));
     s.remove(QStringLiteral("spellCheckFocus"));


### PR DESCRIPTION
## What happens now

In Settings, click the spell-check language box anywhere except the little arrow.
The list flashes up and vanishes again. It keeps doing that — until you click the
arrow once, after which the box works for the rest of the session.

Shipped in v7.2.0. It is the tail of #73: the box became worth clicking when the
picker gained the quick switch, and #73's own fix for "clicking the box did nothing"
turned "nothing" into "flashes and closes".

## Why

The box has to be editable to show a summary of what is ticked ("3 languages")
instead of one entry's text, and an editable `QComboBox` does not open its popup
when the line edit is clicked. #73 answered that by calling `showPopup()` from an
event filter — which is not what the arrow does.

`QComboBox::mousePressEvent` starts the popup container's block-release timer, and
that timer is the only thing that swallows the mouse release arriving immediately
after the click. Nothing public starts it. So a popup shown from inside the press
appears under the pointer, the release lands on it, and a release on a popup shown
this instant reads as a click outside the list — which closes it.

Deferring the call past the release (`QTimer::singleShot(0, …)`) does not fix it
either: the list then opens with the combo still unfocused and goes away on the
activation change instead. That is exactly why one click on the arrow cured it for
the session, and it is the reason this cannot be fixed by choosing a better moment
to call `showPopup()`.

## The change

Hand the click to the arrow. Work out the arrow's rectangle from the style and send
the press there, so Qt takes its own path — timer, focus and all. There is no longer
a second way to open the list that can behave differently from the first.

```cpp
QStyleOptionComboBox opt;
opt.initFrom(combo);
const QPoint arrow = combo->style()->subControlRect(
    QStyle::CC_ComboBox, &opt, QStyle::SC_ComboBoxArrow, combo).center();
QMouseEvent press(QEvent::MouseButtonPress, QPointF(arrow),
                  QPointF(combo->mapToGlobal(arrow)), Qt::LeftButton,
                  Qt::LeftButton, Qt::NoModifier);
QApplication::sendEvent(combo, &press);
```

Closing on a second click needs no code: while the list is open it holds the mouse,
so the press never reaches the filter and Qt dismisses it as a click outside.

## Testing

Confirmed by hand on Linux/X11 (Cinnamon, Qt 6.12.0), on a fresh start and without
touching the arrow first: the list opens, stays open, closes on a second click,
opens again on a third, and the arrow still works.

`tst_settings::languageBoxFollowsTheFocusAndOpensOnClick` checks that clicking the
box opens the list. It **cannot** catch the flash, and the test says so in a comment:
that needs the mouse grab a shown popup takes, and a synthesised release goes to the
line edit rather than to the list, so the list stays open in the test whichever way
the code is written. That is how the `showPopup()` version passed its suite while
failing in front of a user. Worth knowing before trusting the test here.

Both suites green: `tst_settings` and `tst_logic`, zero failures, Qt 6.12.0.
