### PR TITLE
fix(settings): the wheel guard missed the double spin boxes, so a scroll could halve the whole interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **A wheel scrolling the Settings page can no longer set the interface scale or the page zoom.** The guard that keeps the wheel from changing a control it merely passes over was installed on `QSpinBox`, and the interface scale and the two zoom factors are `QDoubleSpinBox` — a sibling of `QSpinBox`, not a subclass — so those three were never covered. The interface scale is the one that does damage: it is only read at launch, so the setting is changed silently and the app comes back at half size, with nothing left to connect the tiny window to the scroll that caused it. The guard now covers every `QAbstractSpinBox`, and the wheel regression test checks the interface scale by name.
+
 ## 7.2.2 (2026-08-13)
 
 - **The "update available" notification is clickable again on KDE/Linux (#74).**

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -18,6 +18,7 @@
 #include <QStandardItem>
 #include <QAbstractItemView>
 #include <QAbstractScrollArea>
+#include <QAbstractSpinBox>
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QCheckBox>
@@ -373,7 +374,13 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
   foreach (QComboBox *box, this->findChildren<QComboBox *>()) {
     box->installEventFilter(this);
   }
-  foreach (QSpinBox *spinBox, this->findChildren<QSpinBox *>()) {
+  // QAbstractSpinBox, not QSpinBox: the interface scale and the two zoom factors
+  // are QDoubleSpinBox, which is a sibling of QSpinBox and not a subclass of it —
+  // so those three were left out of this guard and a wheel scrolling the page went
+  // on changing them under the pointer. The interface scale is the one that hurts:
+  // it only takes effect at the next launch, so the app comes back at half size
+  // with nothing to connect it to.
+  foreach (QAbstractSpinBox *spinBox, this->findChildren<QAbstractSpinBox *>()) {
     spinBox->installEventFilter(this);
   }
   // The lists inside the page scroll themselves and keep the wheel that starts

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -292,7 +292,12 @@ private slots:
     auto *combo =
         sw.findChild<QComboBox *>(QStringLiteral("spellCheckLanguageComboBox"));
     auto *control = sw.findChildren<QSpinBox *>().value(0);
-    QVERIFY(page && list && combo && combo->view() && control);
+    // The interface scale is a QDoubleSpinBox — a sibling of QSpinBox, not a
+    // subclass — which is exactly how it slipped through the guard and let a wheel
+    // scrolling the page set the whole interface to half size at the next launch.
+    auto *scale =
+        sw.findChild<QDoubleSpinBox *>(QStringLiteral("interfaceScaleSpinBox"));
+    QVERIFY(page && list && combo && combo->view() && control && scale);
 
     // Give both scrollbars somewhere to go, since this window is never shown and
     // so was never laid out against real content.
@@ -318,6 +323,16 @@ private slots:
     turn(control, -1);
     QVERIFY(pageBar->value() > 100);
     QCOMPARE(control->value(), before);
+
+    // The same on a double spin box, and on this one in particular: a stored 0.5
+    // interface scale is not visible until the app is restarted, so a wheel that
+    // could set it left no way to connect the half-size window to what caused it.
+    letGo();
+    const double scaleBefore = scale->value();
+    pageBar->setValue(100);
+    turn(scale, -1);
+    QVERIFY(pageBar->value() > 100);
+    QCOMPARE(scale->value(), scaleBefore);
 
     // On the open language list: the page stays exactly where it was. It is a
     // window of its own, so scrolling the page leaves it floating in mid-air over


### PR DESCRIPTION
The filter that stops a mouse wheel changing a control the pointer merely passed over — the one added in #72 — is installed on every `QSlider`, `QComboBox` and `QSpinBox` in Settings. `QDoubleSpinBox` is a *sibling* of `QSpinBox` rather than a subclass of it, so the three controls that use it were never covered:

- **Interface scale** (Window & zoom)
- **Zoom factor** and **Zoom factor when maximised**

A wheel scrolling the page went on changing all three under the pointer, and worse, the page did not scroll while it happened — the notch went into the spin box instead.

**The interface scale is the one that does real damage.** It is read once, at launch, to fill `QT_SCALE_FACTOR`, so nothing visible happens when it is changed: the value is stored, the session carries on as normal, and the app comes back **at half size** at the next start — text, buttons, window controls and all — with nothing left to connect the tiny window to a scroll that happened hours earlier.

That is exactly how it was found: a dogfooding profile came back half-size overnight, with `interfaceScaleFactor=0.5` in its store and no memory of ever having set it.

## The change

One line: guard every `QAbstractSpinBox`, which covers both spin box classes (and the date/time edits with them) instead of only one of them.

## Test

`tst_settings::wheelStaysWithWhatItStartedOn` now checks the interface scale by name as well as the plain spin box: the page must scroll and the value must not change. Without this fix it fails on the page-not-scrolling assertion, because the notch went into the spin box.

Both suites green: `tst_logic` and `tst_settings`, zero failures.
