### PR TITLE
debug: add the scroll and update-notice probes, with their harnesses

### DIFF
--- a/debug/.gitignore
+++ b/debug/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/debug/README.md
+++ b/debug/README.md
@@ -1,0 +1,95 @@
+# Debug probes
+
+Instrumentation for questions that cannot be answered by reading the code: what a
+user is actually seeing in the embedded page, measured rather than guessed.
+
+Nothing here ships with Whatly. These are Custom JS addons and Node harnesses,
+used during an investigation and then left behind so the next one does not start
+from nothing.
+
+## Why measure at all
+
+During the 2026sep01 scroll investigation, four separate hypotheses about a
+reported jerkiness — a blocking wheel listener, an expensive `MutationObserver`,
+distance per wheel notch, and Chromium's vsync scheduling — each looked
+convincing and each was killed by a measurement. Two of the probes' own metrics
+also turned out to be measuring the wrong thing. Impressions, including the
+author's, were wrong far more often than numbers were.
+
+## `scroll-smoothness-probe.js`
+
+Turns "scrolling feels bad" into figures. Install as a Custom JS addon
+(Settings → Custom JS), restart, scroll a chat, and read
+`localStorage.__whatly_scroll_probe`.
+
+Every listener it registers is **passive**. A probe that took scrolling off the
+compositor thread would be measuring its own cost.
+
+Per burst of wheeling (a burst ends after 900 ms of quiet; fewer than five
+notches is discarded as a stray flick):
+
+| field | meaning |
+|---|---|
+| `wheels`, `seconds`, `wheelsPerSec` | how hard the wheel was actually turned |
+| `pxPerWheel` | distance the content travels per notch — 100 is stock Chromium |
+| `dyAvg`, `dyMax` | the `deltaY` the page is handed, before any scrolling happens |
+| `latAvg`, `latMax` | wheel tick → pixels actually moving, in ms |
+| `visJumpMax`, `visJump200` | biggest single **visible** step, and how many were large |
+| `wobble`, `wobbleMaxPx` | the picture reversing direction while the wheel never did |
+| `reanchor` | `scrollTop` moved far while the screen stayed still — a history load, not a defect |
+| `pctOver33`, `gapOver100`, `gapMax` | frame pacing |
+| `g33`…`g200p` | frame-gap histogram, because a run full of 60 ms gaps never trips a 100 ms counter |
+
+Two of those exist because earlier versions were wrong, and the mistakes are
+worth knowing:
+
+- **`scrollTop` is not what the eye sees.** When WhatsApp prepends older
+  messages it *must* change `scrollTop` to hold the view still, and nothing moves
+  on screen. Counting that as a jump made the probe report jumps a user could
+  not see. Visible movement is now `Δ scrollTop − Δ scrollHeight`.
+- **An element anchor is useless in a virtualised list.** The element under the
+  viewport centre is recycled almost every frame during a fast scroll, so an
+  anchor-based metric silently returns zero on exactly the long bursts that
+  matter. Arithmetic cannot be recycled; elements can.
+
+## `scroll-probe-console.js`
+
+The same probe plus a `__whatlyReport()` that prints a `console.table`. Paste it
+into DevTools on `web.whatsapp.com` in an ordinary browser to get a comparison
+against stock Chromium. Identical measurement code on purpose — a second
+implementation would let a difference in method masquerade as a difference in
+browsers.
+
+## `update-banner-probe.js`
+
+Captures the structure of WhatsApp's "Refresh to update" notice when one appears,
+so a feature can be built against the real markup instead of a guess. Records up
+to four captures as a list; a wrong match can never block the right one.
+
+It deliberately has **no `MutationObserver`**. One was tried, on
+`document.documentElement` with `subtree: true`, and it polluted the very frame
+timings another probe was reading. Whatly's own strip code refuses the same
+pattern and says why in `src/chatliststrip.cpp` — "a MutationObserver over a tree
+WhatsApp mutates continuously would measure the layout several times a second
+instead". An initial sweep plus a five-second poll costs nothing and misses
+nothing that sits on screen for minutes.
+
+## Harnesses
+
+Both probes are proved against a stand-in DOM before being trusted with a
+measurement.
+
+```bash
+cd debug
+npm install
+node scroll-harness.js                          # 14 assertions
+node banner-probe-harness.js update-banner-probe.js   # 7 assertions
+```
+
+`jsdom@24` is pinned: jsdom 25+ pulls an ESM-only dependency that Node 20's
+`require` cannot load.
+
+The scroll harness asserts, among other things, that every listener is passive,
+that a short flick records nothing, that backwards motion is caught with its
+distance, that an honest change of direction is *not* counted as a glitch, and
+that Ctrl+wheel starts no burst.

--- a/debug/banner-probe-harness.js
+++ b/debug/banner-probe-harness.js
@@ -1,0 +1,50 @@
+// Proves the probe captures the notice and NOT the filter tablist. The tablist
+// here is the real one off Gert's page: role="tablist",
+// aria-label="chat-list-filters", an svg whose only name is its <title>.
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+const PROBE = fs.readFileSync(process.argv[2], 'utf8');
+
+const HTML = `<!doctype html><html><body><div id="app">
+  <div id="side">
+    <header><span>WhatsApp</span></header>
+    <div class="searchbox"><span data-icon="search"></span><input placeholder="Search or start a new chat"></div>
+    <div class="filters" role="tablist" aria-label="chat-list-filters" tabindex="-1">
+      <button id="all-filter" role="tab" aria-selected="true">All</button>
+      <button role="tab">Unread4</button>
+      <button role="tab">Favourites</button>
+      <button role="tab">Groups2</button>
+      <button id="additional-filters"><svg><title>ic-arrow-drop-down</title></svg></button>
+    </div>
+    <div id="pane-side">
+      <div class="notice">
+        <span data-icon="refresh"><svg><title>refresh</title></svg></span>
+        <div><h2>Refresh to update</h2><div>A new version of WhatsApp is available.</div>
+        <a id="refresh" role="button">Refresh</a></div>
+      </div>
+      <div role="grid"><div role="row"><img><span>Pintura</span><span>Sonia: ola</span></div></div>
+    </div>
+  </div></div></body></html>`;
+
+const dom = new JSDOM(HTML, { runScripts: 'outside-only', pretendToBeVisual: true, url: 'https://web.whatsapp.com/' });
+const { window } = dom; const doc = window.document;
+const warns = []; window.console.warn = (m) => warns.push(String(m));
+
+window.eval(PROBE);
+
+setTimeout(() => {
+  let ok = 0, bad = 0;
+  const check = (n, c, x) => { if (c) { ok++; console.log('  PASS  ' + n); } else { bad++; console.log('  FAIL  ' + n + (x ? '  -> ' + x : '')); } };
+  const raw = window.localStorage.getItem('__whatly_banner_probe');
+  check('the probe captured something', !!raw);
+  let arr = []; try { arr = JSON.parse(raw || '[]'); } catch (e) {}
+  check('it stores a list', Array.isArray(arr), typeof arr);
+  const texts = arr.map(a => a.text);
+  check('it captured the NOTICE', texts.some(t => t.includes('A new version of WhatsApp is available')), JSON.stringify(texts));
+  check('it did NOT capture the filter tablist', !texts.some(t => t.includes('AllUnread')), JSON.stringify(texts));
+  check('it did NOT capture the search box', !texts.some(t => (t || '').includes('Search or start')), JSON.stringify(texts));
+  check('the capture is marked as coming from the list', arr.some(a => a.where === 'pane-side'), JSON.stringify(arr.map(a => a.where)));
+  check('it recorded the clickable', arr.some(a => (a.clickables || []).some(c => c.text === 'Refresh')));
+  console.log('\n' + ok + ' passed, ' + bad + ' failed');
+  process.exit(bad ? 1 : 0);
+}, 400);

--- a/debug/package.json
+++ b/debug/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "whatly-debug-probes",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Harnesses that prove the debug probes before they are trusted with a measurement",
+  "scripts": {
+    "test": "node scroll-harness.js && node banner-probe-harness.js update-banner-probe.js"
+  },
+  "devDependencies": {
+    "jsdom": "24.1.3"
+  }
+}

--- a/debug/scroll-harness.js
+++ b/debug/scroll-harness.js
@@ -1,0 +1,101 @@
+// Proves the scroll-smoothness probe before it is trusted with a measurement.
+// Run: node scroll-harness.js   (from probes/)
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const SRC = path.join(__dirname, 'scroll-smoothness-probe.js');
+const code = fs.readFileSync(SRC, 'utf8');
+
+let pass = 0, fail = 0;
+const ok = (name, cond, extra) => {
+  if (cond) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${extra ? '  -> ' + extra : ''}`); }
+};
+
+const dom = new JSDOM('<!doctype html><body></body>', {
+  url: 'https://web.whatsapp.com/',
+  runScripts: 'outside-only',
+  pretendToBeVisual: true,
+});
+const { window } = dom;
+
+// Watch how the probe registers its listeners: a probe that blocks the
+// compositor would be measuring its own cost.
+const seen = [];
+for (const t of [window, window.document]) {
+  const orig = t.addEventListener.bind(t);
+  t.addEventListener = (type, fn, opts) => { seen.push({ type, opts }); return orig(type, fn, opts); };
+}
+
+const KEY = '__whatly_scroll_probe';
+const read = () => JSON.parse(window.localStorage.getItem(KEY) || 'null');
+
+const wheel = (dy, ctrl = false) =>
+  window.dispatchEvent(new window.WheelEvent('wheel', { deltaY: dy, ctrlKey: ctrl, bubbles: true }));
+
+const pane = window.document.createElement('div');
+window.document.body.appendChild(pane);
+let top = 0;
+Object.defineProperty(pane, 'scrollTop', { get: () => top, configurable: true });
+const scrollTo = (v) => { top = v; pane.dispatchEvent(new window.Event('scroll')); };
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+(async () => {
+  window.eval(code);
+
+  console.log('probe shape');
+  ok('every listener is passive', seen.length > 0 && seen.every((s) => s.opts && s.opts.passive === true),
+     JSON.stringify(seen));
+  ok('listens for wheel and scroll',
+     seen.some((s) => s.type === 'wheel') && seen.some((s) => s.type === 'scroll'));
+  ok('writes an armed timestamp at install', !!(read() || {}).armed);
+  ok('starts with no bursts', Array.isArray(read().bursts) && read().bursts.length === 0);
+
+  console.log('a short flick is not a measurement');
+  wheel(50); wheel(50); scrollTo(40);
+  await sleep(1100);
+  ok('fewer than five wheels records nothing', read().bursts.length === 0);
+
+  console.log('a real burst, scrolling down cleanly');
+  for (let i = 0; i < 6; i++) { wheel(100); scrollTo(100 + i * 100); }
+  await sleep(1100);
+  let b = read().bursts;
+  ok('one burst recorded', b.length === 1, `got ${b.length}`);
+  ok('wheels counted', b[0] && b[0].wheels === 6, b[0] && String(b[0].wheels));
+  ok('latency measured', b[0] && typeof b[0].latAvg === 'number' && b[0].latAvg >= 0);
+  ok('no backwards motion on a clean run', b[0] && b[0].backwards === 0);
+
+  console.log('content sliding back while the wheel kept going down');
+  for (let i = 0; i < 5; i++) wheel(100);
+  scrollTo(1000); scrollTo(1100); scrollTo(1040);   // 60px back, wheel still down
+  await sleep(1100);
+  b = read().bursts;
+  ok('backwards motion caught', b[1] && b[1].backwards === 1, b[1] && String(b[1].backwards));
+  ok('distance recorded', b[1] && b[1].backMaxPx === 60, b[1] && String(b[1].backMaxPx));
+
+  console.log('an honest change of direction is not a glitch');
+  for (let i = 0; i < 5; i++) wheel(100);
+  scrollTo(2000); scrollTo(2100);
+  for (let i = 0; i < 3; i++) wheel(-100);          // user now scrolls up
+  scrollTo(1900);
+  await sleep(1100);
+  b = read().bursts;
+  ok('scrolling up counts no backwards', b[2] && b[2].backwards === 0, b[2] && String(b[2].backwards));
+
+  console.log('zoom is not scrolling');
+  for (let i = 0; i < 6; i++) wheel(100, true);
+  await sleep(1100);
+  ok('ctrl+wheel starts no burst', read().bursts.length === 3, String(read().bursts.length));
+
+  console.log('the log stays bounded');
+  for (let n = 0; n < 8; n++) {
+    for (let i = 0; i < 5; i++) { wheel(100); scrollTo(3000 + n * 500 + i * 50); }
+    await sleep(1000);
+  }
+  ok('kept to the last eight bursts', read().bursts.length === 8, String(read().bursts.length));
+
+  console.log(`\n${pass}/${pass + fail} passed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/debug/scroll-probe-console.js
+++ b/debug/scroll-probe-console.js
@@ -1,0 +1,250 @@
+// Whatly scroll-smoothness probe.
+//
+// Measures what "not smooth" actually is, so a fix can be judged by numbers
+// instead of by impression. Install as a Custom JS addon, restart, scroll a
+// busy chat with the wheel for a few seconds, and read the result back off
+// disk from the profile's Local Storage.
+//
+// Every listener here is PASSIVE. A probe that took scrolling off the
+// compositor thread would be measuring itself.
+(function () {
+  'use strict';
+  var KEY = '__whatly_scroll_probe';
+  var IDLE_MS = 900;          // this much quiet ends a burst
+  var BACK_PX = 4;            // ignore sub-pixel/rounding wobble
+  var MAX_BURSTS = 8;
+
+  function save(obj) {
+    try { localStorage.setItem(KEY, JSON.stringify(obj)); } catch (e) {}
+  }
+  function load() {
+    try { return JSON.parse(localStorage.getItem(KEY)) || null; } catch (e) { return null; }
+  }
+
+  var store = load();
+  if (!store || !Array.isArray(store.bursts)) store = { bursts: [] };
+  store.armed = new Date().toISOString();      // liveness, readable from disk
+  store.ua = (navigator.userAgent || '').slice(0, 120);
+  store.dpr = window.devicePixelRatio;
+  save(store);
+
+  // Watching an element's position ON SCREEN, not scrollTop. When WhatsApp
+  // prepends older messages, scrollTop MUST change to keep the view still --
+  // nothing moves, and counting that as a jump is simply wrong. Only a change in
+  // where an anchor actually sits on screen is something a reader can see.
+  // An element anchor is useless here. In a virtualised list the element under
+  // the viewport centre is recycled almost every frame during a fast scroll, so
+  // isConnected fails, the anchor is re-picked, and no delta is ever computed --
+  // which is why this returned a flat zero on the long bursts. Use arithmetic
+  // that cannot be recycled instead:
+  //
+  //     visible movement = change in scrollTop - change in scrollHeight
+  //
+  // Prepending H pixels of history raises both by H, so the difference is zero,
+  // which is right because nothing moved on screen. Ordinary scrolling leaves
+  // scrollHeight alone, so the difference is the scroll itself.
+  var lastVisSign = 0, lastHeight = null;
+
+  var burst = null, idleTimer = null, rafId = null, lastFrame = 0;
+  var pendingWheels = [];     // performance.now() of wheels awaiting a scroll
+  var dirRun = 0;             // consecutive wheels in one direction (signed)
+  var lastTop = null, lastTarget = null;
+
+  function newBurst() {
+    return {
+      at: new Date().toISOString(),
+      t0: performance.now(),
+      wheels: 0, scrolls: 0,
+      latSum: 0, latN: 0, latMax: 0,   // wheel -> first scroll response, ms
+      backwards: 0, backMaxPx: 0,      // scroll moved against the wheel
+      travelPx: 0,                     // total distance the content actually moved
+      dySum: 0, dyMax: 0,              // the deltaY the page is actually handed
+      visBack: 0, visBackMaxPx: 0,     // content moved on SCREEN against the wheel
+      visJumpMax: 0, visJump200: 0,    // biggest single VISIBLE step, and how many were big
+      wobble: 0, wobbleMaxPx: 0,       // direction reversals while the wheel held ONE way
+      g33: 0, g50: 0, g100: 0, g200: 0, g200p: 0,   // frame-gap histogram
+      reanchor: 0,                     // scrollTop moved a lot but nothing moved on screen
+      visSamples: 0,
+      frames: 0, gapMax: 0, gapOver33: 0, gapOver100: 0
+    };
+  }
+
+  function tick(ts) {
+    if (!burst) { rafId = null; return; }
+    if (lastFrame) {
+      var gap = ts - lastFrame;
+      burst.frames++;
+      if (gap > burst.gapMax) burst.gapMax = gap;
+      if (gap > 33) burst.gapOver33++;      // missed a 30fps deadline
+      if (gap > 100) burst.gapOver100++;    // visibly stalled
+      // Where the gaps actually sit. A run full of 60ms gaps reads as constant
+      // stutter yet never trips the 100ms counter at all.
+      if (gap <= 33) burst.g33++;
+      else if (gap <= 50) burst.g50++;
+      else if (gap <= 100) burst.g100++;
+      else if (gap <= 200) burst.g200++;
+      else burst.g200p++;
+    }
+    lastFrame = ts;
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function endBurst() {
+    idleTimer = null;
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    lastFrame = 0;
+    if (!burst) return;
+    if (burst.wheels >= 5) {              // ignore stray single clicks
+      // Duration and wheel rate, so "does scrolling slower help?" is a question
+      // the numbers can answer instead of an impression.
+      burst.seconds = +((performance.now() - burst.t0) / 1000).toFixed(1);
+      burst.wheelsPerSec = burst.seconds ? +(burst.wheels / burst.seconds).toFixed(1) : null;
+      burst.backPer100 = +(100.0 * burst.backwards / burst.wheels).toFixed(1);
+      // How far the content moves for one notch of the wheel. This is the number
+      // that says whether one app simply scrolls further per tick than another.
+      burst.pxPerWheel = +(burst.travelPx / burst.wheels).toFixed(0);
+      burst.wobblePerSec = burst.seconds ? +(burst.wobble / burst.seconds).toFixed(1) : null;
+      burst.dyAvg = +(burst.dySum / burst.wheels).toFixed(0);
+      delete burst.dySum;
+      burst.pctOver33 = burst.frames ? +(100.0 * burst.gapOver33 / burst.frames).toFixed(1) : null;
+      delete burst.t0;
+      burst.latAvg = burst.latN ? +(burst.latSum / burst.latN).toFixed(1) : null;
+      burst.latMax = +burst.latMax.toFixed(1);
+      burst.gapMax = +burst.gapMax.toFixed(1);
+      delete burst.latSum; delete burst.latN;
+      var s = load() || { bursts: [] };
+      if (!Array.isArray(s.bursts)) s.bursts = [];
+      s.bursts.push(burst);
+      while (s.bursts.length > MAX_BURSTS) s.bursts.shift();
+      s.updated = new Date().toISOString();
+      save(s);
+    }
+    burst = null;
+    pendingWheels = [];
+    dirRun = 0;
+    lastTop = null; lastTarget = null; lastVisSign = 0; lastHeight = null;
+  }
+
+  function touch() {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(endBurst, IDLE_MS);
+  }
+
+  window.addEventListener('wheel', function (ev) {
+    if (ev.ctrlKey) return;               // zoom gesture, not a scroll
+    if (!burst) { burst = newBurst(); rafId = requestAnimationFrame(tick); }
+    burst.wheels++;
+    // What the page is handed per notch. A stock Chromium mouse notch is 100.
+    // Much more than that means the events arriving are already chunky, which is
+    // a different bug from the page scrolling too far for a normal delta.
+    var ady = Math.abs(ev.deltaY || 0);
+    burst.dySum += ady;
+    if (ady > burst.dyMax) burst.dyMax = ady;
+    pendingWheels.push(performance.now());
+    if (pendingWheels.length > 60) pendingWheels.shift();
+    var d = ev.deltaY > 0 ? 1 : (ev.deltaY < 0 ? -1 : 0);
+    if (d) dirRun = (dirRun > 0 && d > 0) || (dirRun < 0 && d < 0) ? dirRun + d : d;
+    touch();
+  }, { passive: true, capture: true });
+
+  document.addEventListener('scroll', function (ev) {
+    if (!burst) return;
+    var el = ev.target;
+    var top = (el && el.scrollTop !== undefined) ? el.scrollTop
+            : (document.scrollingElement || document.documentElement).scrollTop;
+    burst.scrolls++;
+
+    // Latency: how long the oldest unanswered wheel waited for pixels to move.
+    if (pendingWheels.length) {
+      var lat = performance.now() - pendingWheels[0];
+      pendingWheels.length = 0;
+      burst.latSum += lat; burst.latN++;
+      if (lat > burst.latMax) burst.latMax = lat;
+    }
+
+    // Backwards motion: content sliding back while the wheel kept going one
+    // way. Only counted after a settled run in that direction, so an honest
+    // change of direction by the user is not mistaken for a glitch.
+    if (el !== lastTarget) lastHeight = null;
+    if (el === lastTarget && lastTop !== null) {
+      burst.travelPx += Math.abs(top - lastTop);
+
+      // Compare what scrollTop did with what the reader could actually see.
+      var scrollDelta = top - lastTop;
+      var visDelta = null;
+      var h = el.scrollHeight;
+      if (lastHeight !== null) visDelta = scrollDelta - (h - lastHeight);
+      lastHeight = h;
+      if (visDelta === null) {
+        /* first sample for this scroller: nothing to compare against yet */
+      } else {
+        burst.visSamples++;
+        // How far the page visibly moved in ONE step. This is the lurch a
+        // reader actually sees when a stall lets go, and nothing else here
+        // measures it: travelPx is a total and gapMax is only time.
+        var av = Math.abs(visDelta);
+        if (av > burst.visJumpMax) burst.visJumpMax = Math.round(av);
+        if (av > 200) burst.visJump200++;
+
+        // The picture reversing direction while the wheel never did. A scroll
+        // animator that overshoots and springs back does this at a few pixels
+        // and a frame or two, far too small for visJump and far too quick to
+        // show up as a frame gap -- but it is what a reader calls stutter.
+        if (av >= 2 && Math.abs(dirRun) >= 3) {
+          var sign = visDelta > 0 ? 1 : -1;
+          if (lastVisSign !== 0 && sign !== lastVisSign) {
+            burst.wobble++;
+            if (av > burst.wobbleMaxPx) burst.wobbleMaxPx = Math.round(av);
+          }
+          lastVisSign = sign;
+        }
+        // Large scrollTop move, nothing moved on screen: a history prepend
+        // being correctly absorbed. Invisible, and NOT a defect.
+        if (Math.abs(scrollDelta) > 200 && Math.abs(visDelta) < 20) burst.reanchor++;
+        // Content moved on screen AGAINST the wheel: this one you can see.
+        if (Math.abs(dirRun) >= 3) {
+          var lurch = (dirRun > 0 && visDelta < -20) || (dirRun < 0 && visDelta > 20);
+          if (lurch) {
+            burst.visBack++;
+            var vpx = Math.round(Math.abs(visDelta));
+            if (vpx > burst.visBackMaxPx) burst.visBackMaxPx = vpx;
+          }
+        }
+      }
+    }
+    if (el === lastTarget && lastTop !== null && Math.abs(dirRun) >= 3) {
+      var delta = top - lastTop;
+      if ((dirRun > 0 && delta < -BACK_PX) || (dirRun < 0 && delta > BACK_PX)) {
+        burst.backwards++;
+        var px = Math.abs(delta);
+        if (px > burst.backMaxPx) burst.backMaxPx = Math.round(px);
+      }
+    }
+    lastTop = top; lastTarget = el;
+    touch();
+  }, { passive: true, capture: true });
+})();
+
+// ── Console readout ──────────────────────────────────────────────────────────
+// Paste this whole file into the DevTools console on web.whatsapp.com, scroll a
+// busy chat, then type:   __whatlyReport()
+window.__whatlyReport = function () {
+  var s;
+  try { s = JSON.parse(localStorage.getItem('__whatly_scroll_probe') || 'null'); } catch (e) { s = null; }
+  if (!s || !s.bursts || !s.bursts.length) {
+    console.log('no bursts yet - scroll a chat with the wheel for a few seconds, then try again');
+    return;
+  }
+  console.table(s.bursts.map(function (b) {
+    return {
+      at: (b.at || '').slice(11, 19), wheels: b.wheels, seconds: b.seconds,
+      'wheels/s': b.wheelsPerSec, 'px/wheel': b.pxPerWheel, 'deltaY avg': b.dyAvg,
+      'lat avg': b.latAvg, 'lat max': b.latMax,
+      wobble: b.wobble, 'visible jump max': b.visJumpMax, reanchor: b.reanchor,
+      '% >33ms': b.pctOver33, '>100ms': b.gapOver100, 'gap max': b.gapMax
+    };
+  }));
+  return JSON.stringify(s);
+};
+console.log('%c[whatly] scroll probe armed - scroll a chat, then run  __whatlyReport()',
+            'color:#25D366;font-weight:bold');

--- a/debug/scroll-smoothness-probe.js
+++ b/debug/scroll-smoothness-probe.js
@@ -1,0 +1,226 @@
+// Whatly scroll-smoothness probe.
+//
+// Measures what "not smooth" actually is, so a fix can be judged by numbers
+// instead of by impression. Install as a Custom JS addon, restart, scroll a
+// busy chat with the wheel for a few seconds, and read the result back off
+// disk from the profile's Local Storage.
+//
+// Every listener here is PASSIVE. A probe that took scrolling off the
+// compositor thread would be measuring itself.
+(function () {
+  'use strict';
+  var KEY = '__whatly_scroll_probe';
+  var IDLE_MS = 900;          // this much quiet ends a burst
+  var BACK_PX = 4;            // ignore sub-pixel/rounding wobble
+  var MAX_BURSTS = 8;
+
+  function save(obj) {
+    try { localStorage.setItem(KEY, JSON.stringify(obj)); } catch (e) {}
+  }
+  function load() {
+    try { return JSON.parse(localStorage.getItem(KEY)) || null; } catch (e) { return null; }
+  }
+
+  var store = load();
+  if (!store || !Array.isArray(store.bursts)) store = { bursts: [] };
+  store.armed = new Date().toISOString();      // liveness, readable from disk
+  store.ua = (navigator.userAgent || '').slice(0, 120);
+  store.dpr = window.devicePixelRatio;
+  save(store);
+
+  // Watching an element's position ON SCREEN, not scrollTop. When WhatsApp
+  // prepends older messages, scrollTop MUST change to keep the view still --
+  // nothing moves, and counting that as a jump is simply wrong. Only a change in
+  // where an anchor actually sits on screen is something a reader can see.
+  // An element anchor is useless here. In a virtualised list the element under
+  // the viewport centre is recycled almost every frame during a fast scroll, so
+  // isConnected fails, the anchor is re-picked, and no delta is ever computed --
+  // which is why this returned a flat zero on the long bursts. Use arithmetic
+  // that cannot be recycled instead:
+  //
+  //     visible movement = change in scrollTop - change in scrollHeight
+  //
+  // Prepending H pixels of history raises both by H, so the difference is zero,
+  // which is right because nothing moved on screen. Ordinary scrolling leaves
+  // scrollHeight alone, so the difference is the scroll itself.
+  var lastVisSign = 0, lastHeight = null;
+
+  var burst = null, idleTimer = null, rafId = null, lastFrame = 0;
+  var pendingWheels = [];     // performance.now() of wheels awaiting a scroll
+  var dirRun = 0;             // consecutive wheels in one direction (signed)
+  var lastTop = null, lastTarget = null;
+
+  function newBurst() {
+    return {
+      at: new Date().toISOString(),
+      t0: performance.now(),
+      wheels: 0, scrolls: 0,
+      latSum: 0, latN: 0, latMax: 0,   // wheel -> first scroll response, ms
+      backwards: 0, backMaxPx: 0,      // scroll moved against the wheel
+      travelPx: 0,                     // total distance the content actually moved
+      dySum: 0, dyMax: 0,              // the deltaY the page is actually handed
+      visBack: 0, visBackMaxPx: 0,     // content moved on SCREEN against the wheel
+      visJumpMax: 0, visJump200: 0,    // biggest single VISIBLE step, and how many were big
+      wobble: 0, wobbleMaxPx: 0,       // direction reversals while the wheel held ONE way
+      g33: 0, g50: 0, g100: 0, g200: 0, g200p: 0,   // frame-gap histogram
+      reanchor: 0,                     // scrollTop moved a lot but nothing moved on screen
+      visSamples: 0,
+      frames: 0, gapMax: 0, gapOver33: 0, gapOver100: 0
+    };
+  }
+
+  function tick(ts) {
+    if (!burst) { rafId = null; return; }
+    if (lastFrame) {
+      var gap = ts - lastFrame;
+      burst.frames++;
+      if (gap > burst.gapMax) burst.gapMax = gap;
+      if (gap > 33) burst.gapOver33++;      // missed a 30fps deadline
+      if (gap > 100) burst.gapOver100++;    // visibly stalled
+      // Where the gaps actually sit. A run full of 60ms gaps reads as constant
+      // stutter yet never trips the 100ms counter at all.
+      if (gap <= 33) burst.g33++;
+      else if (gap <= 50) burst.g50++;
+      else if (gap <= 100) burst.g100++;
+      else if (gap <= 200) burst.g200++;
+      else burst.g200p++;
+    }
+    lastFrame = ts;
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function endBurst() {
+    idleTimer = null;
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    lastFrame = 0;
+    if (!burst) return;
+    if (burst.wheels >= 5) {              // ignore stray single clicks
+      // Duration and wheel rate, so "does scrolling slower help?" is a question
+      // the numbers can answer instead of an impression.
+      burst.seconds = +((performance.now() - burst.t0) / 1000).toFixed(1);
+      burst.wheelsPerSec = burst.seconds ? +(burst.wheels / burst.seconds).toFixed(1) : null;
+      burst.backPer100 = +(100.0 * burst.backwards / burst.wheels).toFixed(1);
+      // How far the content moves for one notch of the wheel. This is the number
+      // that says whether one app simply scrolls further per tick than another.
+      burst.pxPerWheel = +(burst.travelPx / burst.wheels).toFixed(0);
+      burst.wobblePerSec = burst.seconds ? +(burst.wobble / burst.seconds).toFixed(1) : null;
+      burst.dyAvg = +(burst.dySum / burst.wheels).toFixed(0);
+      delete burst.dySum;
+      burst.pctOver33 = burst.frames ? +(100.0 * burst.gapOver33 / burst.frames).toFixed(1) : null;
+      delete burst.t0;
+      burst.latAvg = burst.latN ? +(burst.latSum / burst.latN).toFixed(1) : null;
+      burst.latMax = +burst.latMax.toFixed(1);
+      burst.gapMax = +burst.gapMax.toFixed(1);
+      delete burst.latSum; delete burst.latN;
+      var s = load() || { bursts: [] };
+      if (!Array.isArray(s.bursts)) s.bursts = [];
+      s.bursts.push(burst);
+      while (s.bursts.length > MAX_BURSTS) s.bursts.shift();
+      s.updated = new Date().toISOString();
+      save(s);
+    }
+    burst = null;
+    pendingWheels = [];
+    dirRun = 0;
+    lastTop = null; lastTarget = null; lastVisSign = 0; lastHeight = null;
+  }
+
+  function touch() {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(endBurst, IDLE_MS);
+  }
+
+  window.addEventListener('wheel', function (ev) {
+    if (ev.ctrlKey) return;               // zoom gesture, not a scroll
+    if (!burst) { burst = newBurst(); rafId = requestAnimationFrame(tick); }
+    burst.wheels++;
+    // What the page is handed per notch. A stock Chromium mouse notch is 100.
+    // Much more than that means the events arriving are already chunky, which is
+    // a different bug from the page scrolling too far for a normal delta.
+    var ady = Math.abs(ev.deltaY || 0);
+    burst.dySum += ady;
+    if (ady > burst.dyMax) burst.dyMax = ady;
+    pendingWheels.push(performance.now());
+    if (pendingWheels.length > 60) pendingWheels.shift();
+    var d = ev.deltaY > 0 ? 1 : (ev.deltaY < 0 ? -1 : 0);
+    if (d) dirRun = (dirRun > 0 && d > 0) || (dirRun < 0 && d < 0) ? dirRun + d : d;
+    touch();
+  }, { passive: true, capture: true });
+
+  document.addEventListener('scroll', function (ev) {
+    if (!burst) return;
+    var el = ev.target;
+    var top = (el && el.scrollTop !== undefined) ? el.scrollTop
+            : (document.scrollingElement || document.documentElement).scrollTop;
+    burst.scrolls++;
+
+    // Latency: how long the oldest unanswered wheel waited for pixels to move.
+    if (pendingWheels.length) {
+      var lat = performance.now() - pendingWheels[0];
+      pendingWheels.length = 0;
+      burst.latSum += lat; burst.latN++;
+      if (lat > burst.latMax) burst.latMax = lat;
+    }
+
+    // Backwards motion: content sliding back while the wheel kept going one
+    // way. Only counted after a settled run in that direction, so an honest
+    // change of direction by the user is not mistaken for a glitch.
+    if (el !== lastTarget) lastHeight = null;
+    if (el === lastTarget && lastTop !== null) {
+      burst.travelPx += Math.abs(top - lastTop);
+
+      // Compare what scrollTop did with what the reader could actually see.
+      var scrollDelta = top - lastTop;
+      var visDelta = null;
+      var h = el.scrollHeight;
+      if (lastHeight !== null) visDelta = scrollDelta - (h - lastHeight);
+      lastHeight = h;
+      if (visDelta === null) {
+        /* first sample for this scroller: nothing to compare against yet */
+      } else {
+        burst.visSamples++;
+        // How far the page visibly moved in ONE step. This is the lurch a
+        // reader actually sees when a stall lets go, and nothing else here
+        // measures it: travelPx is a total and gapMax is only time.
+        var av = Math.abs(visDelta);
+        if (av > burst.visJumpMax) burst.visJumpMax = Math.round(av);
+        if (av > 200) burst.visJump200++;
+
+        // The picture reversing direction while the wheel never did. A scroll
+        // animator that overshoots and springs back does this at a few pixels
+        // and a frame or two, far too small for visJump and far too quick to
+        // show up as a frame gap -- but it is what a reader calls stutter.
+        if (av >= 2 && Math.abs(dirRun) >= 3) {
+          var sign = visDelta > 0 ? 1 : -1;
+          if (lastVisSign !== 0 && sign !== lastVisSign) {
+            burst.wobble++;
+            if (av > burst.wobbleMaxPx) burst.wobbleMaxPx = Math.round(av);
+          }
+          lastVisSign = sign;
+        }
+        // Large scrollTop move, nothing moved on screen: a history prepend
+        // being correctly absorbed. Invisible, and NOT a defect.
+        if (Math.abs(scrollDelta) > 200 && Math.abs(visDelta) < 20) burst.reanchor++;
+        // Content moved on screen AGAINST the wheel: this one you can see.
+        if (Math.abs(dirRun) >= 3) {
+          var lurch = (dirRun > 0 && visDelta < -20) || (dirRun < 0 && visDelta > 20);
+          if (lurch) {
+            burst.visBack++;
+            var vpx = Math.round(Math.abs(visDelta));
+            if (vpx > burst.visBackMaxPx) burst.visBackMaxPx = vpx;
+          }
+        }
+      }
+    }
+    if (el === lastTarget && lastTop !== null && Math.abs(dirRun) >= 3) {
+      var delta = top - lastTop;
+      if ((dirRun > 0 && delta < -BACK_PX) || (dirRun < 0 && delta > BACK_PX)) {
+        burst.backwards++;
+        var px = Math.abs(delta);
+        if (px > burst.backMaxPx) burst.backMaxPx = Math.round(px);
+      }
+    }
+    lastTop = top; lastTarget = el;
+    touch();
+  }, { passive: true, capture: true });
+})();

--- a/debug/update-banner-probe.js
+++ b/debug/update-banner-probe.js
@@ -1,0 +1,156 @@
+// Whatly probe: capture WhatsApp Web's "Refresh to update" banner when it appears.
+//
+// Passive. It never clicks, never styles, never removes anything. It watches the
+// left pane and, the first time something turns up there that is not a chat row
+// but does carry an icon and a sentence, it writes that element's full shape into
+// localStorage under __whatly_banner_probe and warns it to the console.
+//
+// Why a watcher and not a one-shot read: the banner is not there at load. It
+// appears only once WhatsApp's service worker has a new version waiting, which
+// can be hours or days after the page opened. A reload dismisses it, so it has to
+// be caught in place, whenever it happens, without anyone being at the keyboard.
+(function () {
+  'use strict';
+  var KEY = '__whatly_banner_probe';
+  if (window.__whatlyBannerProbe) return;
+  window.__whatlyBannerProbe = true;
+
+  function attrs(e) {
+    var o = {};
+    for (var i = 0; i < e.attributes.length; i++) {
+      var a = e.attributes[i];
+      o[a.name] = a.value.length > 120 ? a.value.slice(0, 120) + '…' : a.value;
+    }
+    return o;
+  }
+
+  // The ancestor chain matters as much as the element: whether the banner sits
+  // inside #pane-side or beside it decides which CSS can reach it.
+  function chain(e) {
+    var out = [], n = e;
+    while (n && n !== document.body && out.length < 8) {
+      out.push({ tag: n.tagName, attrs: attrs(n) });
+      n = n.parentElement;
+    }
+    return out;
+  }
+
+  function describe(e) {
+    var icons = [], i;
+    var svgs = e.querySelectorAll('svg, [data-icon]');
+    for (i = 0; i < svgs.length && i < 8; i++) {
+      var t = svgs[i].querySelector ? svgs[i].querySelector('title') : null;
+      icons.push({
+        tag: svgs[i].tagName,
+        dataIcon: svgs[i].getAttribute && svgs[i].getAttribute('data-icon'),
+        testid: svgs[i].getAttribute && svgs[i].getAttribute('data-testid'),
+        title: t && t.textContent,
+        attrs: attrs(svgs[i])
+      });
+    }
+    var acts = [];
+    var cs = e.querySelectorAll('button, [role="button"], a, [tabindex]');
+    for (i = 0; i < cs.length && i < 8; i++) {
+      acts.push({
+        tag: cs[i].tagName,
+        text: (cs[i].textContent || '').trim().slice(0, 60),
+        attrs: attrs(cs[i])
+      });
+    }
+    return {
+      when: new Date().toISOString(),
+      tag: e.tagName,
+      text: (e.textContent || '').trim().slice(0, 300),
+      attrs: attrs(e),
+      icons: icons,
+      clickables: acts,
+      chain: chain(e),
+      // Capped deliberately: this is WhatsApp's own banner, and the cap keeps
+      // anything from a neighbouring chat row out of the capture.
+      outerHTML: (e.outerHTML || '').slice(0, 6000)
+    };
+  }
+
+  // A candidate is: NOT a chat row and not inside one, not holding any (which
+  // rules out the list container and every wrapper above it), carrying an icon,
+  // carrying a sentence rather than a word, and carrying something to click.
+  //
+  // The exclusions below are not guesses. The first version of this probe was
+  // scoped to #side and captured the FILTER TABLIST on Gert's own page —
+  // role="tablist", aria-label="chat-list-filters", text "AllUnread4Favourites
+  // Groups2…" — and because sweep() stopped at its first find it would have
+  // recorded that for ever and never seen the banner it was written for. The
+  // instrument was hiding the answer.
+  function excluded(e) {
+    if (e.getAttribute('role') === 'tablist') return true;
+    if (e.querySelector('[role="tablist"]')) return true;
+    if (e.querySelector('#all-filter, #additional-filters')) return true;
+    if (e.querySelector('input, [contenteditable="true"], [role="textbox"]')) return true;
+    if (e.querySelector('[role="row"]')) return true;    // the list itself
+    if (e.querySelector('[role="grid"]')) return true;
+    return false;
+  }
+
+  function candidate(e) {
+    if (!e || e.nodeType !== 1) return null;
+    if (e.closest('[role="row"]')) return null;
+    if (e.closest('header')) return null;
+    if (!e.querySelector('svg, [data-icon]')) return null;
+    if (!e.querySelector('button, [role="button"], a')) return null;
+    var txt = (e.textContent || '').trim();
+    if (txt.length < 12 || txt.length > 400) return null;
+    if (excluded(e)) return null;
+    return e;
+  }
+
+  // A LIST, not a single value: if this ever matches something unintended
+  // again, the wrong capture must not stop the right one being recorded.
+  function record(e, where) {
+    try {
+      var d = describe(e);
+      d.where = where;
+      var all;
+      try { all = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (x) { all = []; }
+      if (!all || all.constructor !== Array) all = [];
+      for (var i = 0; i < all.length; i++)
+        if (all[i] && all[i].text === d.text) return;    // already have this one
+      all.push(d);
+      while (all.length > 4) all.shift();
+      localStorage.setItem(KEY, JSON.stringify(all));
+      console.warn('[whatly-banner-probe] CAPTURED (' + where + ') ' + JSON.stringify(d));
+    } catch (err) {
+      try { console.warn('[whatly-banner-probe] failed: ' + err); } catch (e2) {}
+    }
+  }
+
+  function sweep() {
+    // #pane-side first, because that is where a notice sits and where the strip
+    // acts on it. Only if nothing matches there is the rest of #side tried, so a
+    // notice WhatsApp puts somewhere unexpected is still recorded rather than
+    // silently missed — but it can never mask one in the list.
+    var roots = [document.querySelector('#pane-side'),
+                 document.querySelector('#side')];
+    for (var r = 0; r < roots.length; r++) {
+      if (!roots[r]) continue;
+      var all = roots[r].querySelectorAll('div, section, aside');
+      for (var i = 0; i < all.length; i++) {
+        var c = candidate(all[i]);
+        if (c) { record(c, r === 0 ? 'pane-side' : 'side'); return; }
+      }
+    }
+  }
+
+  // A sweep now, then a slow poll. There was a MutationObserver here as well,
+  // on document.documentElement with subtree:true, and it was a mistake: it
+  // fired on WhatsApp's constant DOM churn and ran a querySelectorAll over the
+  // whole side pane each time. Whatly's own strip code refuses to do this and
+  // says why -- "a MutationObserver over a tree WhatsApp mutates continuously
+  // would measure the layout several times a second instead - that cost 40% of
+  // a core once already". Measured here on 2026sep01 it was polluting the very
+  // frame timings the scroll probe was trying to read. The initial sweep covers
+  // a notice already on the page; the poll catches one that appears later,
+  // within five seconds, which is nothing next to how long a notice sits there.
+  setInterval(sweep, 5000);
+  sweep();
+  console.warn('[whatly-banner-probe] armed');
+})();


### PR DESCRIPTION
Instrumentation for questions the code cannot answer: what is actually happening in the embedded page, measured rather than guessed. **Nothing here ships with Whatly** — they are Custom JS addons and Node harnesses, in a new `debug/` folder.

## Why

During a scroll investigation, four separate hypotheses about a reported jerkiness — a blocking wheel listener, an expensive `MutationObserver`, distance per wheel notch, and Chromium's vsync scheduling — each looked convincing and each was killed by a measurement. Impressions, including mine, were wrong far more often than numbers were. The probes are left behind so the next investigation does not start from nothing.

## `scroll-smoothness-probe.js`

Turns "scrolling feels bad" into figures: wheel-to-pixel latency, distance per notch, the `deltaY` the page is handed, visible step size, direction reversals, re-anchoring, and a frame-gap histogram.

Every listener it registers is **passive** — a probe that took scrolling off the compositor thread would be measuring its own cost, and the harness asserts this.

Two of its metrics exist because earlier ones were wrong, and the README records why:

- **`scrollTop` is not what the eye sees.** Prepending older messages *must* change `scrollTop` to hold the view still, so counting that as a jump reported jumps a user could not see. Visible movement is now `Δ scrollTop − Δ scrollHeight`.
- **An element anchor is useless in a virtualised list.** The element under the viewport centre is recycled almost every frame during a fast scroll, so an anchor-based metric silently returns zero on exactly the long bursts that matter.

`scroll-probe-console.js` is the same code plus a `console.table` readout, for pasting into an ordinary browser to compare against stock Chromium. Identical measurement code on purpose — a second implementation would let a difference in method masquerade as a difference in browsers.

## `update-banner-probe.js`

Captures the real markup of WhatsApp's "Refresh to update" notice, so a feature can be built against it rather than a guess. Stores up to four captures as a list, so a wrong match can never block the right one.

It deliberately has **no `MutationObserver`**. One was tried, over `document.documentElement` with `subtree: true`, and it polluted the frame timings another probe was reading — the same trap `src/chatliststrip.cpp` already documents ("would measure the layout several times a second instead").

## Harnesses

Both probes are proved against a stand-in DOM before being trusted with a measurement.

```bash
cd debug && npm install && npm test
```

14 assertions for the scroll probe, 7 for the notice probe. `jsdom@24` is pinned because 25+ pulls an ESM-only dependency that Node 20's `require` cannot load.

## Notes

- No changes to any shipped source file; this is additive only.
- `debug/.gitignore` keeps `node_modules/` and the lockfile out.
