### PR TITLE
fix(settings): name the application before anything reads a setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **Settings are no longer lost on every launch.** The Chromium flags are assembled before `main()` sets the application and organization names, and assembling them now reads a setting — the custom-frame check added in 7.6.0 for the frameless-window scroll fix (#104). That first read is what constructs `SettingsManager`, a function-local static that takes both names once, when it is built, so the whole run pointed at an unnamed store: every read returned its default (light window theme, "follow system theme" off, so the system was never consulted either, and no saved accounts) and every write was discarded. The names are now set before anything reads a setting. Nothing was ever written to the wrong place, so an existing configuration comes back untouched.
+
 ## 7.6.0 (2026-09-08)
 
 - **"Link with phone number" can be made to work again (#43).** WhatsApp's phone-number linking refuses to issue a pairing code unless the browser it is told about is one it recognises, and the "Identify as Whatly in linked devices" feature reported an unknown "Whatly", which silently broke that flow while QR linking kept working. The browser name is now a setting: leave it empty for the clean "Whatly" label as before, or set a recognised browser such as Chrome to make phone-number linking work (the browser prefix then reappears in the label). Thanks to Nigel1992 for the precise A/B diagnosis.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -553,6 +553,25 @@ int main(int argc, char *argv[]) {
   qputenv("QT_FORCE_STDERR_LOGGING", "1");
 #endif
 
+  // The machine name is lowercase — it is the leaf of every QStandardPaths
+  // location (~/.local/share/shakaran/whatly, ~/.config/shakaran/whatly.conf)
+  // and of the settings file. The human-facing name, shown in window titles and
+  // the About box, is set separately so those read "Whatly", not "whatly".
+  //
+  // These must come before the FIRST read of any setting. SettingsManager is a
+  // function-local static that takes the application and organization names once,
+  // when it is constructed, and setChromiumFlags() below reads a setting (the
+  // custom-frame flag). Named after that first read, the singleton spends the
+  // whole run pointing at an unnamed store: every read returns its default —
+  // light theme, no accounts, follow-system-theme off — and every write is
+  // discarded, so the app looks like a first run on every launch.
+  QApplication::setApplicationName(kAppName);
+  QApplication::setApplicationDisplayName(kAppDisplayName);
+  QApplication::setDesktopFileName(kAppId);
+  QApplication::setOrganizationDomain(kOrgDomain);
+  QApplication::setOrganizationName(kOrgName);
+  QApplication::setApplicationVersion(VERSIONSTR);
+
   // Detect a previous launch that crashed before WhatsApp Web loaded, so the
   // Chromium flags built next can escalate to safer rendering (issue #3).
   Performance::evaluateStartup();
@@ -591,16 +610,6 @@ int main(int argc, char *argv[]) {
   }
 #endif
   instance.setWindowIcon(appWindowIcon());
-  // The machine name is lowercase — it is the leaf of every QStandardPaths
-  // location (~/.local/share/shakaran/whatly, ~/.config/shakaran/whatly.conf)
-  // and of the settings file. The human-facing name, shown in window titles and
-  // the About box, is set separately so those read "Whatly", not "whatly".
-  QApplication::setApplicationName(kAppName);
-  QApplication::setApplicationDisplayName(kAppDisplayName);
-  QApplication::setDesktopFileName(kAppId);
-  QApplication::setOrganizationDomain(kOrgDomain);
-  QApplication::setOrganizationName(kOrgName);
-  QApplication::setApplicationVersion(VERSIONSTR);
 
   // Now that the app/org names (and thus the data path) are set, persist
   // Chromium's own fd-2 output to a file for bug reports. Must be before Qt


### PR DESCRIPTION
7.6.0 loses a user's settings on every launch. The window opens as a first run — light theme, no saved accounts, nothing remembered — and nothing changed in that session is kept either.

## Cause

`setChromiumFlags()` runs before `main()` sets the application and organization names, and since 7.6.0 it reads a setting: the `CustomTitleBar::isEnabled()` check added for the frameless-window scroll fix (#104).

That read is what constructs `SettingsManager`. It is a function-local static that takes `QCoreApplication::organizationName()` and `applicationName()` **once, when it is built** (`settingsmanager.h:24-28`). Built before either name is set, it points at an unnamed store for the rest of the process:

- every read returns its default — `windowTheme` falls back to `light` (`mainwindow.cpp:694`) and `followSystemTheme` falls back to `false` (`mainwindow.cpp:655`), so the system colour scheme is never consulted either;
- the account list comes back empty;
- every write is discarded.

`CustomTitleBar::isEnabled()` is evaluated unconditionally, whatever the setting's value, so this is not confined to users of the custom frame.

7.3.1 does not have it. The ordering was already fragile there — names at 583/587, flags at 545 — but nothing read a setting before the names were set, so it never fired. 7.6.0 armed it.

## Fix

The six identity setters move above the first read. They now run after `AppProfile::initFromArgs()` — whose suffix is folded into the settings name, so it must still come first — and before `Performance::evaluateStartup()` and `setChromiumFlags()`.

Nothing was ever written to the wrong location, so an existing configuration is simply found again. No migration is needed.

## Verification

On Windows, against a 7.6.0 install that had been opening as a first run every time:

- **before** — the launch counter sat frozen at 158 across repeated launches, and no new key appeared anywhere under `HKCU\Software`, confirming reads and writes were both going nowhere;
- **after** — the saved dark theme, the interface language and all three accounts come back with nothing reconfigured, and the launch counter advances again.

## Notes

I could not find a way to cover the ordering in the test suite without restructuring `main()`, so this comes without a test. The comment added at the call site records why the order is load-bearing, since the block reads like something safe to move back.

@coderabbitai ignore
